### PR TITLE
feat: add --paths mode to /cleanup-worktrees for concurrency-safe cleanup

### DIFF
--- a/skills/cleanup-worktrees/SKILL.md
+++ b/skills/cleanup-worktrees/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cleanup-worktrees
-description: Use when the user wants to remove stale agent worktrees under .claude/worktrees/ in the current repo, or invokes /cleanup-worktrees. Safely skips worktrees with uncommitted changes unless --force is passed.
+description: Use when the user wants to remove stale agent worktrees under .claude/worktrees/ in the current repo, or invokes /cleanup-worktrees. Safely skips worktrees with uncommitted changes unless --force is passed. Orchestrators should pass --paths with the exact worktree paths they own to avoid racing peer sessions.
 ---
 
 # Cleanup Agent Worktrees
@@ -18,15 +18,30 @@ handlers, so if an orchestrator is interrupted (Ctrl+C, crash) before its final 
 runs, re-invoke `/cleanup-worktrees` manually to reclaim disk space.
 
 ```
-/cleanup-worktrees [--force] [--dry-run]
+/cleanup-worktrees [--paths=<csv>] [--force] [--dry-run]
 ```
 
 ## Arguments
 
 | Arg | Default | Effect |
 |-----|---------|--------|
+| `--paths=<csv>` | unset (glob mode) | Comma-separated list of exact worktree paths to clean. Skips the `agent-*/` glob; only the listed paths are considered. Use this from orchestrators to avoid racing other parallel sessions. |
 | `--force` | off | Remove worktrees even if they contain uncommitted changes or untracked files (destructive; opt-in) |
 | `--dry-run` | off | Print what would be removed, make no changes |
+
+## Mode Selection
+
+Two modes, chosen by the presence of `--paths`:
+
+- **Glob mode (default, manual recovery):** enumerates `$WORKTREES_DIR/agent-*/` and
+  applies the uncommitted-changes safety guard to each candidate. Use when running the
+  skill manually after an interrupt or periodically as housekeeping.
+- **Paths mode (orchestrator-driven):** cleans only the explicitly listed paths. Use
+  from an orchestrator that captured each worktree path from the Agent tool's return
+  value (the harness returns `worktreePath` when the isolated agent made changes). Same
+  safety guard applies. Exact paths avoid the race in glob mode where a peer session's
+  active worktree could show momentarily "clean" under `git status` and be wrongly
+  removed.
 
 ## Execution
 
@@ -41,15 +56,31 @@ If `$WORKTREES_DIR` does not exist, print `nothing to clean` and exit 0.
 
 ### 2. Enumerate candidates
 
-Match only `$WORKTREES_DIR/agent-*/` — do not touch sibling subdirectories the user may
-have created for other purposes.
+**Paths mode** (if `--paths=<csv>` is set): split on commas and use each entry directly.
+Validate each path is under `$WORKTREES_DIR/` — reject any path that resolves outside
+(guards against misuse or malicious orchestrator input). Non-existent paths are a no-op
+(report as skipped with reason `not found`, exit 0 for that entry).
+
+```bash
+IFS=',' read -ra candidates <<< "$PATHS_CSV"
+for dir in "${candidates[@]}"; do
+  # Reject if $dir is not under $WORKTREES_DIR
+  case "$(cd "$dir" 2>/dev/null && pwd -P)" in
+    "$WORKTREES_DIR"/*) : ;;  # OK
+    *) echo "refusing: $dir is not under $WORKTREES_DIR"; continue ;;
+  esac
+done
+```
+
+**Glob mode** (default): match only `$WORKTREES_DIR/agent-*/` — do not touch sibling
+subdirectories the user may have created for other purposes.
 
 ```bash
 shopt -s nullglob
 candidates=("$WORKTREES_DIR"/agent-*/)
 ```
 
-If the list is empty, print `nothing to clean` and exit 0.
+If the candidate list is empty (either mode), print `nothing to clean` and exit 0.
 
 ### 3. Safety guard
 
@@ -106,9 +137,11 @@ Include the per-entry paths so the user can audit.
 ## When to Invoke
 
 - **As a final step of an orchestrator pipeline** (`implement-orchestrator`,
-  `implement-till-merge`) — mandatory, runs even on the error path.
-- **Manually after an interrupt** — Ctrl+C'd a long-running pipeline? Run this to reclaim
-  the disk space the harness left behind.
+  `implement-till-merge`) — mandatory, runs even on the error path. Orchestrators that
+  dispatched isolated agents should pass `--paths=<csv>` with the paths returned by the
+  Agent tool so peer sessions' worktrees are never touched.
+- **Manually after an interrupt** — Ctrl+C'd a long-running pipeline? Run this (glob
+  mode, no `--paths`) to reclaim the disk space the harness left behind.
 - **Periodically** — if you regularly use skills that launch isolated agents, run it as
   housekeeping.
 
@@ -120,3 +153,5 @@ Include the per-entry paths so the user can audit.
 | Targeting the user-global `~/.claude/skills/cleanup/` | That skill is for sibling worktrees in `~/dev/<repo>-<branch>/`. This skill is for per-agent worktrees *inside* a single repo. Different scope, both needed. |
 | Removing `$WORKTREES_DIR` itself | Only remove `agent-*/` children. The parent dir is harmless and may be recreated by future agents. |
 | Skipping `worktree prune` | Git keeps dangling registrations in `.git/worktrees/` even after the directory is gone. Always prune. |
+| Orchestrator uses glob mode in a multi-session repo | Orchestrators MUST pass `--paths=<csv>` with the paths captured from the Agent tool's return value. Glob mode can falsely match a peer session's active worktree during a quiescent moment. |
+| Passing paths outside `$WORKTREES_DIR` | The skill rejects paths whose realpath is not under `.claude/worktrees/`. Orchestrators should only ever pass paths returned by the Agent tool. |

--- a/skills/implement-orchestrator/SKILL.md
+++ b/skills/implement-orchestrator/SKILL.md
@@ -34,8 +34,20 @@ checkout, often gigabytes) for the caller to clean up. A prior incident accumula
 of stale worktrees across 18 runs and filled the user's disk.
 
 If a future change introduces `isolation: "worktree"` to any Agent call dispatched from
-this pipeline, that change **must** invoke `/cleanup-worktrees` as its final step (even
-on the error path) to remove the spawned worktree. See the final "Cleanup" section below.
+this pipeline, that change **must** follow the explicit-paths cleanup contract:
+
+1. **Capture the returned path.** The Agent tool returns `worktreePath` (and `worktreeBranch`)
+   in its result when an isolated agent makes file changes. Record each returned path in
+   a session-scoped file, e.g. `$IMPL_TMP/agent-worktrees.txt` (one path per line).
+2. **Clean by exact path, not by glob.** At pipeline end — and on every error path —
+   invoke `/cleanup-worktrees --paths="$(paste -sd, $IMPL_TMP/agent-worktrees.txt)"`.
+   Do **not** rely on the default glob mode for orchestrator-driven cleanup: two
+   concurrent sessions in the same repo would race on each other's worktrees, and the
+   `git status --porcelain` safety guard can false-negative during quiescent moments.
+3. **Glob mode remains the manual-recovery path.** Users invoke bare `/cleanup-worktrees`
+   (no `--paths`) after an interrupt to sweep truly orphaned worktrees from crashed runs.
+
+See the final "Cleanup" section below for the mechanics.
 
 ## Temporary Directory Setup
 
@@ -175,16 +187,26 @@ relevant phase.
 
 ### Cleanup 2: Remove any agent worktrees
 
-Invoke the `cleanup-worktrees` skill to remove stale `.claude/worktrees/agent-*/` entries
+Invoke the `cleanup-worktrees` skill to remove `.claude/worktrees/agent-*/` entries
 created by isolation-worktree subagents (see "Worktree Isolation Policy" above). With the
 current design this is a no-op, but it is load-bearing once any step here adopts
-`isolation: "worktree"`, and it also catches worktrees left behind by previous interrupted
-runs.
+`isolation: "worktree"`.
 
 **REQUIRED SKILL:** cleanup-worktrees
 
-Do not pass `--force` — the skill's uncommitted-changes guard preserves in-flight work
-from other active sessions.
+Two call patterns, pick the one that matches what the pipeline actually did:
+
+- **Nothing in this pipeline passed `isolation: "worktree"`** (current state): skip this
+  step. There is nothing for the pipeline to clean up. Users can invoke bare
+  `/cleanup-worktrees` manually to sweep orphans from prior crashed runs.
+- **One or more steps passed `isolation: "worktree"`** and captured returned paths to
+  `$IMPL_TMP/agent-worktrees.txt`: invoke
+  `/cleanup-worktrees --paths="$(paste -sd, $IMPL_TMP/agent-worktrees.txt)"`. Exact paths
+  only — no globbing — to avoid racing concurrent sessions in the same repo.
+
+Do not pass `--force` in either case — the skill's uncommitted-changes guard preserves
+in-flight work. If the guard blocks removal of a path this pipeline owns, that's a
+signal the agent's changes were not merged back; report rather than force-delete.
 
 ## Error Recovery
 


### PR DESCRIPTION
## Summary

- Add `--paths=<csv>` mode to `/cleanup-worktrees` for exact-match cleanup, skipping the `agent-*/` glob enumeration
- Validate each supplied path resolves under `.claude/worktrees/` before touching it
- Update `implement-orchestrator`'s "Worktree Isolation Policy" and "Cleanup" sections to describe the explicit-paths contract any future isolation-adopter must follow

## Why

Glob-based cleanup (shipped in #51) has a race window when two Claude sessions run in the same repo and any skill uses `isolation: "worktree"`:

1. Session A dispatches an isolated agent → harness creates `.claude/worktrees/agent-<hash-A>/`
2. Session B finishes and invokes `/cleanup-worktrees`
3. B's enumeration matches A's worktree. A's agent happens to be in a quiescent moment (before its first write, or between edits after a commit)
4. `git status --porcelain` returns empty — the safety guard false-negatives
5. B removes A's active worktree mid-run

Fix: orchestrators capture the `worktreePath` the Agent tool returns, record it per-session in `$IMPL_TMP`, and pass the list to `/cleanup-worktrees --paths=<csv>` at pipeline end. Exact paths → no peer-session collisions possible. Glob mode stays as the manual-recovery path for orphans from crashed runs (the Ctrl+C case noted in #50).

This is currently latent — no skill in the repo passes `isolation: "worktree"`. The contract is ready for the first adopter.

Closes #52

## Test plan

- [x] `./at validate --skills` passes (75/75)
- [x] `./at validate` full suite passes (99/99)
- [ ] Once a skill actually uses `isolation: "worktree"`: run two orchestrators in parallel in the same repo, confirm neither removes the other's active worktree
- [ ] `/cleanup-worktrees --paths=/tmp/not-under-worktrees` refuses with clear message
- [ ] `/cleanup-worktrees --paths=<valid>,<invalid>` cleans the valid entries and reports the invalid ones
- [ ] Bare `/cleanup-worktrees` (no `--paths`) still works in glob mode for manual recovery