### PR TITLE
feat(make-pr): add --no-reviewers flag

### DIFF
--- a/skills/implement-till-merge/SKILL.md
+++ b/skills/implement-till-merge/SKILL.md
@@ -24,7 +24,7 @@ Wait for `/implement-orchestrator` to complete. All steps should be committed.
 
 ### Step 2: PR and Babysit
 
-Use the Skill tool to invoke `pr-make-till-merge` with any PR-related and babysit-related arguments the user provided.
+Use the Skill tool to invoke `pr-make-till-merge` with any PR-related and babysit-related arguments the user provided (`--issue`, `--reviewers`, `--no-reviewers`, `--title`, `--base`, `--draft`, `--no-agent-review`, `--interval`, `--max-rounds`).
 
 ### Step 3: Cleanup agent worktrees
 

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -41,6 +41,7 @@ Parse arguments from the user's message. All are optional:
 |-----|---------|---------|
 | `--issue=N` | Auto-detect or auto-create | `--issue=42` |
 | `--reviewers=user1,user2` | Inferred from recent commit authors | `--reviewers=alice,bob` |
+| `--no-reviewers` | Reviewers are added | `--no-reviewers` |
 | `--title="..."` | Generated from commits | `--title="Add user auth"` |
 | `--base=branch` | Repository default branch | `--base=develop` |
 | `--draft` | Not draft | `--draft` |
@@ -78,6 +79,8 @@ If a PR exists, store its number for Phase 3 (update instead of create).
 Issue detection and creation is handled by `/issue-make`. Pass `--issue=N` if the user provided one; otherwise `/issue-make` will auto-detect from the branch name or commit messages, or create a new issue.
 
 ### 0d. Reviewer Detection
+
+If `--no-reviewers` is passed, skip this step entirely — create the PR without any reviewers.
 
 If `--reviewers` is provided, use those. Otherwise, infer from recent commit history:
 
@@ -346,9 +349,11 @@ gh pr create \
   --base "$BASE_BRANCH" \
   --title "$PR_TITLE" \
   --body "$PR_BODY" \
-  --reviewer "$REVIEWERS" \
+  ${REVIEWERS:+--reviewer "$REVIEWERS"} \
   ${DRAFT:+--draft}
 ```
+
+When `--no-reviewers` is passed, `$REVIEWERS` is empty and the `--reviewer` flag is omitted entirely.
 
 **If PR already exists:**
 

--- a/skills/plan-till-merge/SKILL.md
+++ b/skills/plan-till-merge/SKILL.md
@@ -25,6 +25,7 @@ All optional. Parsed from the user's message:
 |-----|-------|---------|---------|
 | `--issue=N` | 3, 4 | Auto-detect | `--issue=42` |
 | `--reviewers=u1,u2` | 4 | Auto-detect | `--reviewers=alice` |
+| `--no-reviewers` | 4 | Reviewers added | `--no-reviewers` |
 | `--title="..."` | 3, 4 | From plan | `--title="Add auth"` |
 | `--base=branch` | 4 | Default branch | `--base=develop` |
 | `--draft` | 4 | Not draft | `--draft` |
@@ -77,7 +78,7 @@ This creates/updates the GitHub issue and attaches planning `.md` files as a gis
 
 Use the Skill tool to invoke `make-pr` with:
 - `--issue=N` from Phase 3 result
-- `--reviewers`, `--title`, `--base`, `--draft` if the user provided them
+- `--reviewers`, `--no-reviewers`, `--title`, `--base`, `--draft`, `--no-agent-review` if the user provided them
 
 This runs gates, quick review, `/review-and-fix`, pushes, and creates the PR. (`/make-pr` invokes `/review-and-fix` internally as Phase 2.5.)
 

--- a/skills/pr-make-till-merge/SKILL.md
+++ b/skills/pr-make-till-merge/SKILL.md
@@ -18,7 +18,7 @@ Create a PR and babysit it through the review/CI cycle until it's ready to merge
 
 ### Step 1: Create/Update PR
 
-Use the Skill tool to invoke `make-pr` with all arguments the user provided that match `/make-pr` arguments (`--issue`, `--reviewers`, `--title`, `--base`, `--draft`).
+Use the Skill tool to invoke `make-pr` with all arguments the user provided that match `/make-pr` arguments (`--issue`, `--reviewers`, `--no-reviewers`, `--title`, `--base`, `--draft`, `--no-agent-review`).
 
 Wait for `/make-pr` to complete. If it fails (e.g., no commits, on base branch), stop and report the error.
 


### PR DESCRIPTION
## Summary

- Add `--no-reviewers` flag to `/make-pr` to skip reviewer auto-detection
- When passed, `--reviewer` is omitted from `gh pr create`
- Forwarded through `/pr-make-till-merge` and `/plan-till-merge` argument tables

## Usage

- `/pr-make --no-reviewers` — create PR without reviewers
- `/pr-make-till-merge --no-reviewers` — same, then babysit
- `/plan-till-merge --no-reviewers` — same in full pipeline

## Test plan

- [x] `./validate.sh` passes (78/78)
- [x] Installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)