### PR TITLE
docs: onboarding Getting Started section + full Skills Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,15 +104,49 @@ Each plan step produces one focused commit, independently reviewed for quality v
 
 ### Skills Reference
 
+Organized by who invokes the skill. Skills in the first two groups are meant to be typed directly; skills in the third group are called internally by the orchestrator.
+
+#### End-to-end pipelines
+
+Top-level skills that run full workflows by composing lower-level skills.
+
 | Skill | Command | Purpose |
 |-------|---------|---------|
-| **implement-orchestrator** | `/implement-orchestrator` | Run the step-by-step pipeline from any plan source |
-| **plan-codebase** | `/plan-codebase` | Analyze codebase and produce implementation spec for a step |
-| **plan-tests** | `/plan-tests` | Discover test patterns and produce test plan for a step |
-| **implement-parallel** | `/implement-parallel` | Dispatch parallel Impl Coder and Test Coder for a step |
-| **review-parallel** | `/review-parallel` | Run parallel reviewers with severity-based consensus |
-| **clean-code-planner** | `/clean-code-planner` | Produce a code plan before any code change (any size) |
-| **python-coding-rules** | `/python-coding-rules` | Apply Python 3.12+ coding standards interactively |
+| **plan-till-merge** | `/plan-till-merge` | Plan -> implement -> PR -> babysit. Composes: clean-code-planner -> implement-orchestrator -> issue-make -> make-pr -> pr-babysit |
+| **implement-till-merge** | `/implement-till-merge` | Implement a plan -> PR -> babysit. Composes: implement-orchestrator -> make-pr -> pr-babysit |
+| **pr-make-till-merge** | `/pr-make-till-merge` | Create PR from current branch -> babysit. Composes: make-pr -> pr-babysit |
+
+#### Building blocks -- you invoke directly
+
+| Skill | Command | Purpose |
+|-------|---------|---------|
+| **plan-arch** | `/plan-arch` | Architecture design doc for a chosen approach |
+| **plan-options** | `/plan-options` | Evaluate multiple approaches with tradeoffs |
+| **clean-code-planner** | `/clean-code-planner` | Produce a code plan before any code change |
+| **implement-orchestrator** | `/implement-orchestrator` | Step-by-step agentic implementation from a plan |
+| **make-pr** | `/make-pr` | Run gates, review, push, create PR |
+| **pr-babysit** | `/pr-babysit` | Poll PR until ready to merge, fix review/CI issues |
+| **review-and-fix** | `/review-and-fix` | Review current diff, fix CRITICAL and MAJOR issues |
+| **multi-review** | `/multi-review` | Multi-model code review via external AI CLIs |
+| **issue-make** | `/issue-make` | Create or update a GitHub issue with planning artifacts |
+| **wt-create** | `/wt-create` | Create a git worktree for parallel work |
+| **cleanup-worktrees** | `/cleanup-worktrees` | Remove stale agent-generated worktrees under `.claude/worktrees/agent-*/` |
+| **latest-update** | `/latest-update` | Pull main, clean up merged branches, validate, install |
+| **latest-rebase** | `/latest-rebase` | Rebase current branch onto latest main |
+| **python-coding-rules** | `/python-coding-rules` | Apply Python 3.12+ coding standards (TypeScript / Rust / C++ rules load automatically via `rules/` when editing matching files) |
+
+#### Dispatched internally -- don't invoke directly
+
+These are called by `/implement-orchestrator`; invoking them directly is not the intended use.
+
+| Skill | Purpose |
+|-------|---------|
+| **plan-codebase** | Analyze codebase, produce implementation spec for a step |
+| **plan-tests** | Discover test patterns, produce test plan for a step |
+| **implement-parallel** | Dispatch parallel Impl Coder and Test Coder for a step |
+| **review-parallel** | Run parallel reviewers with severity-based consensus |
+
+**Aliases** (same arguments, alternate slash name): `/plan-code` -> `/clean-code-planner`, `/pr-make` -> `/make-pr`.
 
 ## Language Rules
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,54 @@ Or install everything non-interactively:
 ./install.sh --uninstall                       # Restore from backups
 ```
 
+## Getting Started
+
+### Prerequisites
+
+- `gh` CLI authenticated (`gh auth login`) with repo scope
+- `jq` installed
+- Claude Code CLI installed
+- Verify the install with `./validate.sh`
+
+### Mental model
+
+A skill is a named procedure invoked by typing `/skill-name` in a Claude Code session. Some skills are aliases that dispatch to another skill with identical arguments -- for example, `/pr-make` dispatches to `/make-pr`, and `/plan-code` dispatches to `/clean-code-planner`. The Agentic Workflow diagram below shows how `/implement-orchestrator` chains lower-level skills together.
+
+### Your first run
+
+Try the lowest-risk skill to verify everything works:
+
+```
+/wt-create scratch
+```
+
+This creates a sibling worktree at `../<repo>-scratch/`, a branch `scratch`, and prints the `cd` / `tmux` commands to enter it.
+
+Clean up when done:
+
+```bash
+git worktree remove ../<repo>-scratch
+git branch -D scratch
+```
+
+### Decision tree -- "I have X, I want Y"
+
+| What you have | What you want | Skill |
+|---|---|---|
+| An idea | A merged PR | `/plan-till-merge` |
+| A `plan.md` file | A merged PR | `/implement-till-merge` |
+| A finished branch (committed work) | A merged PR | `/pr-make-till-merge` |
+| An open PR | A merged PR | `/pr-babysit` |
+
+### Other daily tasks
+
+- Sync main: `/latest-update`
+- Rebase onto main: `/latest-rebase`
+- Review the current diff: `/review-and-fix` or `/multi-review`
+- Open a GitHub issue: `/issue-make`
+- Create a worktree for parallel work: `/wt-create`
+- Remove stale agent-generated worktrees (under `.claude/worktrees/agent-*/`): `/cleanup-worktrees`
+
 ## Components Overview
 
 | Component | Location | Description |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install everything non-interactively:
 
 ### Prerequisites
 
-- `gh` CLI authenticated (`gh auth login`) with repo scope
+- `gh` CLI authenticated (`gh auth login`) with `repo` scope; for project linking via `/make-pr` and `/issue-make`, also run `gh auth refresh -s read:project,project`
 - `jq` installed
 - Claude Code CLI installed
 - Verify the install with `./validate.sh`
@@ -113,7 +113,7 @@ Top-level skills that run full workflows by composing lower-level skills.
 | Skill | Command | Purpose |
 |-------|---------|---------|
 | **plan-till-merge** | `/plan-till-merge` | Plan -> implement -> PR -> babysit. Composes: clean-code-planner -> implement-orchestrator -> issue-make -> make-pr -> pr-babysit |
-| **implement-till-merge** | `/implement-till-merge` | Implement a plan -> PR -> babysit. Composes: implement-orchestrator -> make-pr -> pr-babysit |
+| **implement-till-merge** | `/implement-till-merge` | Implement a plan -> PR -> babysit -> cleanup. Composes: implement-orchestrator -> pr-make-till-merge -> cleanup-worktrees |
 | **pr-make-till-merge** | `/pr-make-till-merge` | Create PR from current branch -> babysit. Composes: make-pr -> pr-babysit |
 
 #### Building blocks -- you invoke directly
@@ -137,7 +137,7 @@ Top-level skills that run full workflows by composing lower-level skills.
 
 #### Dispatched internally -- don't invoke directly
 
-These are called by `/implement-orchestrator`; invoking them directly is not the intended use.
+These skills are internal sub-components for orchestrator pipelines. Most users shouldn't invoke them directly.
 
 | Skill | Purpose |
 |-------|---------|


### PR DESCRIPTION
## Summary

- Add a new **Getting Started** section to `README.md` between Quick Start and Components Overview (prerequisites, mental model, worked first-run example, "have X want Y" decision tree, other daily tasks).
- Expand the **Skills Reference** table from 7 rows to all 23 skills, re-organized into three sub-tables keyed on who invokes each skill (end-to-end pipelines with composition notes / building blocks grouped by purpose / internal sub-components), plus an aliases footnote for `/plan-code` and `/pr-make`.
- Drop phantom skills from the reference (`issue-create`, `plan-complex` — not in this repo's `skills/`) and fix composition inaccuracies found during agent review.

## Review cycles

- `/review-that` with 5 independent lenses (Correctness, Completeness, Simplicity, Alternatives, Audience fit) on the initial proposal
- Plan review (2 rounds) via `/clean-code-planner`'s reviewer loop — caught wt-create/cleanup-worktrees path mismatch
- Docs-focused `/simplify` pass after Step 1 — tightened Mental model, removed redundant Decision tree column
- `/review-and-fix` on the full diff — clean
- `/pr-review-toolkit:review-pr` with `code-reviewer` + `comment-analyzer` — caught Dispatched-internally preamble overclaim, `implement-till-merge` composition error, missing `read:project,project` prerequisite. All three fixed in commit `addfeee`.

## Known scope caveats

- `.claude/gates.json` does not exist for this repo — `/make-pr` ran `./validate.sh` (102 passed, 0 failed) as an ad-hoc gate. Formalizing `.claude/gates.json` with validate.sh as the sole gate is future work.
- Three "Dispatched internally" skills (`plan-tests`, `implement-parallel`, `review-parallel`) declare themselves as dispatch targets in their SKILL.md frontmatter, but `/implement-orchestrator` does not actually invoke them (only `plan-codebase` is dispatched). The preamble was softened to avoid the specific false claim. Fixing the underlying SKILL.md frontmatter inconsistency is a separate concern, out of scope for this docs PR.

## Test plan

- [x] `./validate.sh` passes (102 passed, 0 failed)
- [x] All 23 skills in `skills/` represented in the reference exactly once
- [x] No phantom skills (`issue-create`, `plan-complex`) in the tables
- [x] Composition chains match the corresponding `*-till-merge` SKILL.md phase lists
- [x] `/wt-create scratch` first-run example matches `wt-create/SKILL.md` behavior (sibling worktree, default base branch, cd/tmux output)
- [ ] Render preview on GitHub to confirm tables and heading nesting

Closes #60

Planning artifacts attached to #60 as a gist.