### PR TITLE
Dead-simple 2-script install UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ The two scripts above cover the common case. For anything more specific, use the
 - `./at install` — interactive component picker (rules / skills / hooks / everything)
 - `./at install --all --dry-run` — preview a full install without writing
 - `./at install --all --target=/path/to/project` — install into a specific project
+- `./at uninstall --deep` — uninstall and also remove generated artifacts (`plans/`, `impl-temp/`, `code-spec.md`, `test-plan.md`)
 - `./at status` — show installation dashboard (what's installed, where, and when)
-- `./at update --all` — pull latest and reinstall tracked components
 - `./at --help` — full command reference
 
 ## Installation Details

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Re-run `./install.sh` to reinstall (picks up local changes). To sync with upstre
 
 For interactive component picking, dry-runs, or installing into a specific project, see [Advanced: `at` CLI](#advanced-at-cli) below.
 
-## Getting Started
+## Using the Skills
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,18 @@
 
 A shareable collection of Claude Code skills, hooks, language rules, and templates -- centered around a multi-phase agentic implementation workflow.
 
-## Quick Start
+## Getting Started
 
 ```bash
 git clone https://github.com/anthropics/agent-templates.git
 cd agent-templates
-./install.sh          # Interactive: pick components to install
+./install.sh      # install everything (rules + skills + hooks)
+./uninstall.sh    # remove everything (restores backups)
 ```
 
-Or install everything non-interactively:
+Re-run `./install.sh` to reinstall (picks up local changes). To sync with upstream: `git pull && ./install.sh`.
 
-```bash
-./install.sh --non-interactive --all
-./install.sh --target=/path/to/project --all   # Install to a specific project
-./install.sh --dry-run --all                   # Preview without changes
-./install.sh --uninstall                       # Restore from backups
-```
+For interactive component picking, dry-runs, or installing into a specific project, see [Advanced: `at` CLI](#advanced-at-cli) below.
 
 ## Getting Started
 
@@ -161,13 +157,7 @@ Opinionated, per-language coding standards that load automatically when editing 
 
 ### Installation
 
-Rules are installed per-project into `.claude/rules/`:
-
-```bash
-./install.sh   # Select [1] Language Rules
-```
-
-This copies each `rules/*.md` file to `<project>/.claude/rules/`, where Claude Code picks them up automatically based on the file type being edited.
+Rules are installed per-project into `.claude/rules/` by `./install.sh`. Each `rules/*.md` file is copied to `<project>/.claude/rules/`, where Claude Code picks them up automatically based on the file type being edited.
 
 ## Hooks
 
@@ -220,19 +210,24 @@ Runs on `PreToolUse` and auto-approves safe, read-only tools (Read, Glob, Grep, 
 
 ### Installation
 
-Hooks are installed globally to `~/.claude/hooks/` and registered in `~/.claude/settings.json`:
-
-```bash
-./install.sh   # Select [3] Hooks
-```
-
-The installer merges hook configuration from `templates/settings-hooks.json` into your existing `settings.json` using `jq`. If `jq` is not available, it prints the JSON for manual merging.
+Hooks are installed globally to `~/.claude/hooks/` and registered in `~/.claude/settings.json` by `./install.sh`. The installer merges hook configuration from `templates/settings-hooks.json` into your existing `settings.json` using `jq`. If `jq` is not available, it prints the JSON for manual merging.
 
 ## Templates
 
 ### Settings Hook Template (`templates/settings-hooks.json`)
 
 Pre-configured `settings.json` fragment that registers the Slack notification and auto-approve hooks on the correct event types (`Notification`, `Stop`, `PreToolUse`). The settings template is merged automatically when installing hooks.
+
+## Advanced: `at` CLI
+
+The two scripts above cover the common case. For anything more specific, use the `at` CLI directly:
+
+- `./at install` — interactive component picker (rules / skills / hooks / everything)
+- `./at install --all --dry-run` — preview a full install without writing
+- `./at install --all --target=/path/to/project` — install into a specific project
+- `./at status` — show installation dashboard (what's installed, where, and when)
+- `./at update --all` — pull latest and reinstall tracked components
+- `./at --help` — full command reference
 
 ## Installation Details
 
@@ -243,7 +238,7 @@ Pre-configured `settings.json` fragment that registers the Slack notification an
 | Hooks | `~/.claude/hooks/*.sh` | Global (all projects) |
 | Settings | `~/.claude/settings.json` | Global (all projects) |
 
-The installer creates timestamped backups (`.bak.<timestamp>`) of any file it overwrites and records them in `.claude/.install-backup-manifest`. Run `./install.sh --uninstall` to restore all backups.
+The installer creates timestamped backups (`.bak.<timestamp>`) of any file it overwrites and records them in `.claude/.install-backup-manifest`. Run `./uninstall.sh` to restore all backups.
 
 ## Validation
 

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
-# Backwards-compatible wrapper — delegates to ./at install
-exec "$(dirname "$0")/at" install "$@"
+# One-shot install — installs all components non-interactively.
+# Safe to re-run; overwritten files are backed up to .bak.<timestamp>.
+# For the interactive component picker or advanced flags, run ./at install directly.
+exec "$(dirname "$0")/at" install --all --non-interactive "$@"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# One-shot uninstall — restores backups recorded during install.
+exec "$(dirname "$0")/at" uninstall "$@"


### PR DESCRIPTION
## Summary

Polish the install experience so this repo is easy to advertise to teammates. The first-time story collapses to two commands:

```bash
./install.sh     # install / reinstall everything (safe to re-run)
./uninstall.sh   # remove everything (restores backups)
```

The underlying `at` CLI is unchanged — power users keep every flag and subcommand. This is purely an onboarding UX change.

## Changes

- **`install.sh`** — forces `--all --non-interactive` when invoked as a wrapper, so running it alone installs everything silently. Safe to re-run (existing files back up to `.bak.<timestamp>` first). User-passed flags like `--dry-run` or `--target=` still pass through.
- **`uninstall.sh` (new)** — one-line wrapper around `at uninstall`, mirrors the existing `validate.sh` pattern.
- **`README.md`** — leads with the two-command Getting Started block. Interactive menu, dry-run, selective targets, and other flags moved to a new "Advanced: `at` CLI" section. Stale `./install.sh --non-interactive --all` / `./install.sh --uninstall` references swept throughout.
- **`at` CLI unchanged** — `./at install` (no wrappers) still opens the interactive menu for power users.

## Test plan

- [x] `./install.sh --dry-run` shows a full dry-run install of all components
- [x] `./install.sh --help` shows `at install` help
- [x] `./uninstall.sh --help` shows `at uninstall` help
- [x] `./at install` (no wrappers) still opens the interactive menu
- [x] `./at validate` passes 105/105
- [ ] Manually run `./install.sh` then `./uninstall.sh` end-to-end on a throwaway `$HOME` after merge

Planning artifacts: see the gist linked in #62.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)