### PR TITLE
feat(installer): state store — state.json schema + atomic load/save (PR 1.2)

### DIFF
--- a/installer/pyproject.toml
+++ b/installer/pyproject.toml
@@ -35,7 +35,7 @@ pythonpath = ["."]  # rootdir is installer/, so tests import the module under te
 # Coverage is a diagnostic (term-missing), never a gate target — a 100% mandate just
 # manufactures tests to paint branches green. Test behaviour, then read coverage to spot
 # a genuinely untested path; don't write a test solely to colour a line.
-addopts = ["--cov=at", "--cov-report=term-missing"]
+addopts = ["--cov=at", "--cov=state", "--cov-report=term-missing"]
 filterwarnings = ["error"]
 
 [tool.coverage.run]

--- a/installer/state.py
+++ b/installer/state.py
@@ -1,6 +1,7 @@
+import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final
+from typing import Final, cast
 
 STATE_VERSION: Final[int] = 1
 
@@ -21,11 +22,24 @@ def default_state() -> State:
     return State(version=STATE_VERSION, units={})
 
 
+def save_state(state: State, root: Path) -> None:
+    """Persist a snapshot so a later run can see what this one installed."""
+    root.mkdir(parents=True, exist_ok=True)
+    state_file: Path = root / STATE_FILENAME
+    payload: dict[str, object] = {"version": state.version, "units": state.units}
+    with state_file.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle)
+
+
 def load_state(root: Path) -> State:
     """Treat a missing store as a first run rather than an error, so callers get
     a usable default instead of having to handle absence themselves."""
     state_file: Path = root / STATE_FILENAME
     if state_file.exists():
-        raise NotImplementedError("reading an existing state store lands in a later PR")
+        with state_file.open(encoding="utf-8") as handle:
+            raw: dict[str, object] = json.load(handle)
+        version: int = cast("int", raw["version"])
+        units: dict[str, str] = cast("dict[str, str]", raw["units"])
+        return State(version=version, units=units)
     root.mkdir(parents=True, exist_ok=True)
     return default_state()

--- a/installer/state.py
+++ b/installer/state.py
@@ -1,4 +1,5 @@
 import json
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final, cast
@@ -27,8 +28,14 @@ def save_state(state: State, root: Path) -> None:
     root.mkdir(parents=True, exist_ok=True)
     state_file: Path = root / STATE_FILENAME
     payload: dict[str, object] = {"version": state.version, "units": state.units}
-    with state_file.open("w", encoding="utf-8") as handle:
+    # Write a sibling temp file and atomically swap it in, so a failed write
+    # leaves the prior store intact rather than a half-written file.
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=root, suffix=".tmp", delete=False
+    ) as handle:
         json.dump(payload, handle)
+        tmp_path: Path = Path(handle.name)
+    tmp_path.replace(state_file)
 
 
 def load_state(root: Path) -> State:

--- a/installer/state.py
+++ b/installer/state.py
@@ -35,7 +35,13 @@ def save_state(state: State, root: Path) -> None:
     ) as handle:
         json.dump(payload, handle)
         tmp_path: Path = Path(handle.name)
-    tmp_path.replace(state_file)
+    # A failed swap must not leave the sibling temp behind; the original error
+    # still propagates so callers see the write failed.
+    try:
+        tmp_path.replace(state_file)
+    except OSError:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def load_state(root: Path) -> State:

--- a/installer/state.py
+++ b/installer/state.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+STATE_VERSION: Final[int] = 1
+
+STATE_FILENAME: Final[str] = "state.json"
+
+
+@dataclass(frozen=True)
+class State:
+    """Snapshot of which units the installer has placed, versioned so a future
+    read can migrate older on-disk layouts."""
+
+    version: int
+    units: dict[str, str]
+
+
+def default_state() -> State:
+    """The starting point for a root that has never been installed into."""
+    return State(version=STATE_VERSION, units={})
+
+
+def load_state(root: Path) -> State:
+    """Treat a missing store as a first run rather than an error, so callers get
+    a usable default instead of having to handle absence themselves."""
+    state_file: Path = root / STATE_FILENAME
+    if state_file.exists():
+        raise NotImplementedError("reading an existing state store lands in a later PR")
+    root.mkdir(parents=True, exist_ok=True)
+    return default_state()

--- a/installer/tests/test_state.py
+++ b/installer/tests/test_state.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from state import STATE_VERSION, State, load_state
+
+
+def test_load_state_on_first_run_creates_dir_and_returns_default(
+    tmp_path: Path,
+) -> None:
+    root: Path = tmp_path / "at"
+
+    state: State = load_state(root)
+
+    assert state.version == STATE_VERSION
+    assert len(state.units) == 0
+    assert root.is_dir()

--- a/installer/tests/test_state.py
+++ b/installer/tests/test_state.py
@@ -1,4 +1,8 @@
+import contextlib
 from pathlib import Path
+from typing import NoReturn
+
+import pytest
 
 from state import STATE_VERSION, State, load_state, save_state
 
@@ -22,3 +26,22 @@ def test_save_then_load_round_trips_recorded_state(tmp_path: Path) -> None:
     loaded: State = load_state(tmp_path)
 
     assert loaded == saved
+
+
+def test_save_is_atomic_failed_replace_keeps_prior_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    prior: State = State(version=STATE_VERSION, units={"skill/make-pr": "aaaa1111"})
+    save_state(prior, tmp_path)
+
+    def fail_replace(src: object, dst: object) -> NoReturn:
+        raise OSError("replace interrupted before the swap")
+
+    monkeypatch.setattr("os.replace", fail_replace)
+
+    clobber: State = State(version=STATE_VERSION, units={"skill/make-pr": "bbbb2222"})
+    with contextlib.suppress(OSError):
+        save_state(clobber, tmp_path)
+
+    survivor: State = load_state(tmp_path)
+    assert survivor == prior

--- a/installer/tests/test_state.py
+++ b/installer/tests/test_state.py
@@ -4,7 +4,7 @@ from typing import NoReturn
 
 import pytest
 
-from state import STATE_VERSION, State, load_state, save_state
+from state import STATE_FILENAME, STATE_VERSION, State, load_state, save_state
 
 
 def test_load_state_on_first_run_creates_dir_and_returns_default(
@@ -45,3 +45,22 @@ def test_save_is_atomic_failed_replace_keeps_prior_state(
 
     survivor: State = load_state(tmp_path)
     assert survivor == prior
+
+
+def test_failed_save_leaves_no_orphan_temp_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    prior: State = State(version=STATE_VERSION, units={"skill/make-pr": "aaaa1111"})
+    save_state(prior, tmp_path)
+
+    def fail_replace(src: object, dst: object) -> NoReturn:
+        raise OSError("replace interrupted before the swap")
+
+    monkeypatch.setattr("os.replace", fail_replace)
+
+    clobber: State = State(version=STATE_VERSION, units={"skill/make-pr": "bbbb2222"})
+    with pytest.raises(OSError):
+        save_state(clobber, tmp_path)
+
+    remaining: set[str] = {entry.name for entry in tmp_path.iterdir()}
+    assert remaining == {STATE_FILENAME}

--- a/installer/tests/test_state.py
+++ b/installer/tests/test_state.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from state import STATE_VERSION, State, load_state
+from state import STATE_VERSION, State, load_state, save_state
 
 
 def test_load_state_on_first_run_creates_dir_and_returns_default(
@@ -13,3 +13,12 @@ def test_load_state_on_first_run_creates_dir_and_returns_default(
     assert state.version == STATE_VERSION
     assert len(state.units) == 0
     assert root.is_dir()
+
+
+def test_save_then_load_round_trips_recorded_state(tmp_path: Path) -> None:
+    saved: State = State(version=STATE_VERSION, units={"skill/make-pr": "deadbeef"})
+
+    save_state(saved, tmp_path)
+    loaded: State = load_state(tmp_path)
+
+    assert loaded == saved


### PR DESCRIPTION
## What

Implements **PR 1.2 — State store** from the installer PRD (#74, Slice 1 / Wave 0): the
`~/.claude/at/state.json` schema with atomic load/save and first-run defaults. This is the
schema the rest of the installer builds on (install/uninstall/update record into it in later
slices).

Blocked-by 1.1 (#76, merged) — builds on `installer/at.py`.

## Public interface (`installer/state.py`)

- `STATE_VERSION: Final[int]` — versioned schema, persisted to and read from disk.
- `State` — frozen dataclass `{version: int, units: dict[str, str]}`.
- `default_state()` — fresh default (current version, empty units).
- `load_state(root)` — reads `<root>/state.json`; on **first run** (no file) creates the
  directory and returns the default.
- `save_state(state, root)` — **atomic** write: sibling temp file + `Path.replace`, so an
  interrupted swap leaves the prior store intact (and cleans up its temp file on failure).

## Behaviors (TDD — one test pins each)

1. First-run `load_state` creates the dir and returns the default state.
2. `save_state` → `load_state` round-trips a recorded state to equality.
3. Atomic save: a failed `os.replace` leaves the previously-saved state intact.
4. (review fix) A failed swap leaves no orphaned `*.tmp` behind.

## Out of scope (later slices)

Recording real installs into `units`, content hashing, refcounting, corrupt-file / version
migration, and CLI/TUI wiring.

## Validation

`installer/` gates all green: `pytest -W error` (9 passed, `state.py` 100%), `ruff format
--check`, `ruff check`, `mypy --strict`. Reviewer: no critical findings (one minor —
orphaned temp on failed replace — fixed in commit 4). Critic: goal-fit achieved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
