### PR TITLE
feat(skills): breakdown pipeline — to-prd, to-issues, pr-breakdown + orchestrator

### DIFF
--- a/skills/breakdown/SKILL.md
+++ b/skills/breakdown/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: breakdown
+description: Use when the user wants to turn a discussion into a published plan — a short PRD, vertical slices, and a PR breakdown, all in one growing GitHub issue — or invokes /breakdown.
+---
+
+# Breakdown
+
+Run the full planning pipeline — **PRD → slices → PR breakdown** — into **one
+growing GitHub issue**, pausing at each gate. Composes `to-prd`, `to-issues`, and
+`pr-breakdown`, each invoked directly.
+
+```
+/breakdown [description or context] [--title="..."] [--label=Plan]
+
+Phase 1: to-prd       → creates the issue   (gates: clarify, approve)
+Phase 2: to-issues    → appends slices                 (gate: discuss)
+Phase 3: pr-breakdown → appends PR rows                (gate: approve)
+```
+
+Run the phases in order; start each only after the previous reports success.
+The gates live inside each sub-skill — you just relay their results. A sub-skill
+that ends without its success line declined a gate: stop and report.
+
+## Phase 1 — PRD
+
+Invoke `to-prd` via the Skill tool. Pass the user's `[description or context]` and
+any `--title` / `--label`. Capture `N` from its final line —
+`PRD published: <url> (issue #N)`. If `to-prd` reports a declined gate (no issue
+published), stop. If it published but the line won't parse, confirm `N` with the
+user before continuing.
+
+## Phase 2 — Slices
+
+Invoke `to-issues` with `--issue=N`. It appends the slice plan and reports
+`Slices appended to issue #N`. Proceed on that; stop if it reports a declined gate.
+
+## Phase 3 — PR breakdown
+
+Invoke `pr-breakdown` with `--issue=N`. It appends the PRs and reports
+`PR breakdown appended to issue #N`. Stop if it reports a declined gate.
+
+## If a gate is declined or a phase fails
+
+Stop and report. Whatever already completed stays valid: a declined Phase 1
+leaves nothing, Phase 2 leaves the PRD, Phase 3 leaves PRD + slices — any is a
+fine stopping point.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Not threading `--issue=N` into Phases 2–3 | Capture `N` from Phase 1 and pass it on |
+| Nesting skills (skill → skill → skill) | Invoke each phase's skill directly |

--- a/skills/pr-breakdown/SKILL.md
+++ b/skills/pr-breakdown/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: pr-breakdown
+description: Use when a PRD issue's slice plan needs breaking into small ~100-200 LOC pull requests recorded as sub-rows in that issue, or invokes /pr-breakdown.
+---
+
+# PR Breakdown
+
+Break the slice plan in a PRD issue into **small PRs (~100–200 LOC, excluding
+tests)**, recorded as sub-rows in the **same issue**.
+
+```
+/pr-breakdown [--issue=N]
+
+  1. Find the issue and slice plan
+  2. Split each slice into PRs
+  3. Show it, wait for approval   (gate)
+  4. Append to the SAME issue
+```
+
+## Phase 1 — Find the issue and slice plan
+
+Use `--issue=N` if given. Otherwise scan the conversation for the last
+`PRD published: ... (issue #N)` line; if there's none, ask. If you auto-detected
+it, confirm the number with the user. Read the body. If it has no `## Build plan`
+section, **stop** and tell the user to run `/to-issues` first — don't invent a
+breakdown. If the Build plan says `No slicing — single PR`, emit one
+`### Slice 1 — <name> (1 PR)` row (derive `<name>` from the PRD's *What we're
+building*) and skip to Phase 3.
+
+## Rules for splitting
+
+- 100–200 LOC per PR, excluding tests. Over ~200 → split further; a tiny slice may be one PR.
+- One cohesive, reviewable, demoable change per PR.
+- Foundations first: reusable primitives before the PRs that wire them up.
+- Note where PRs in a slice run in parallel.
+- **Rows only.** Do NOT write coder prompts (module boundary, acceptance criteria, etc.) — those are generated later, one PR at a time.
+
+## Phase 2 — Draft sub-rows
+
+Derive each `<name>` from the slice's `What`.
+
+```markdown
+## PR breakdown
+
+### Slice <n> — <name> (<k> PRs)
+| PR | What | LOC | Done when |
+|----|------|-----|-----------|
+| n.1 | ... | ~150 | <observable result> |
+| n.2 | ... | ~120 | ... |
+
+*n.1 ∥ n.2 (independent)*
+```
+
+End with **Estimated total: ~N PRs.**
+
+## Phase 3 — Approve (gate)
+
+Show the full breakdown in chat. **Wait for approval or edits** before touching
+the issue.
+
+## Phase 4 — Append to the same issue
+
+Keep canonical order PRD → `## Build plan` → `## PR breakdown`: replace the PR
+breakdown in place, preserving everything above it. The rebuild keys on the exact
+`## PR breakdown` heading; `tr -d '\r'` guards CRLF; abort on an empty read:
+
+```bash
+ISSUE=<the issue number>; NEW=$(mktemp)
+# ...write the new "## PR breakdown" section to "$NEW"...
+CUR=$(gh issue view "$ISSUE" --json body -q .body | tr -d '\r')
+[ -n "$CUR" ] || { echo "abort: empty issue body" >&2; exit 1; }
+HEAD=$(printf '%s\n' "$CUR" | awk '/^## PR breakdown/{exit} {print}')
+OUT=$(mktemp)
+{ printf '%s\n\n' "$HEAD"; cat "$NEW"; } > "$OUT"
+gh issue edit "$ISSUE" --body-file "$OUT"
+rm -f "$NEW" "$OUT"
+echo "PR breakdown appended to issue #$ISSUE"
+```

--- a/skills/to-issues/SKILL.md
+++ b/skills/to-issues/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: to-issues
+description: Use when a PRD issue needs breaking into vertical, tracer-bullet slices recorded as a table in that same issue, or invokes /to-issues.
+---
+
+# To Issues
+
+Break a PRD issue into **vertical, tracer-bullet slices** — each a narrow but
+COMPLETE path through every layer it touches (schema, API, UI, tests), demoable on
+its own — recorded as one growing table inside the same issue, never fanned out.
+Prefer many thin slices over a few thick ones; order them thinnest-first.
+
+```
+/to-issues [--issue=N]
+
+  1. Find the issue and read it
+  2. Draft slices + parallelization
+  3. Discuss and refine          (gate)
+  4. Append the plan to the SAME issue
+```
+
+## Phase 1 — Find the issue
+
+Use `--issue=N` if given. Otherwise scan the conversation for the last
+`PRD published: ... (issue #N)` line; if there's none, ask. If you auto-detected
+it, confirm the number with the user. Read the body; use the codebase's own
+vocabulary; respect ADRs.
+
+## Phase 2 — Draft slices
+
+Each slice carries a **Demoable as** line (how you'd demo or verify it — if you
+can't write one, it isn't end-to-end), a **Mode** (`AFK` = an agent runs it alone;
+`HITL` = needs the user: design taste, UX, a judgment call), a **Size** (`S`/`M`/`L`,
+a rough feel — real LOC come in pr-breakdown), and **Blocked by**.
+
+```markdown
+## Build plan — vertical slices
+
+| # | What | Demoable as | Mode | Size | Blocked by |
+|---|------|-------------|------|------|------------|
+| 1 | ... | ... | AFK | M | — |
+
+### Parallelization
+
+| Wave | Runs together | Notes |
+|------|---------------|-------|
+| 0 | 1 | foundation |
+| 1 | 2 + 3 | independent |
+
+**Critical path:** 1 → 2 → ...
+```
+
+Waves are a topological grouping of `Blocked by`: same-wave slices share no
+blocking relationship. If the work has **no real slices** (e.g. one tiny change),
+say so — and still write the `## Build plan — vertical slices` heading with a
+single line, `No slicing — single PR`, so the next phase proceeds.
+
+## Phase 3 — Discuss (gate)
+
+Present the slices as a numbered list, then ask the user:
+
+- Is the **granularity** right — too coarse, too fine?
+- Are the **dependencies** correct?
+- **Merge or split** any (e.g. an `L` slice worth splitting)?
+- Are the **HITL/AFK** calls right?
+
+Iterate until they approve. **Don't touch the issue until then.** With no real
+slices, skip these questions — just confirm the single-PR plan.
+
+## Phase 4 — Append to the same issue
+
+The issue stays in canonical order: PRD → `## Build plan` → `## PR breakdown`.
+Rebuild it from those parts so a re-run replaces the Build plan in place — never
+duplicating or reordering. The rebuild keys on those exact headings (so don't use
+them in PRD prose); `tr -d '\r'` guards CRLF; abort if the read comes back empty:
+
+```bash
+ISSUE=<the issue number>; NEW=$(mktemp)
+# ...write the new "## Build plan — vertical slices" + "### Parallelization" to "$NEW"...
+BODY=$(gh issue view "$ISSUE" --json body -q .body | tr -d '\r')
+[ -n "$BODY" ] || { echo "abort: empty issue body" >&2; exit 1; }
+HEAD=$(printf '%s\n' "$BODY" | awk '/^## Build plan/{exit} /^## PR breakdown/{exit} {print}')
+PRS=$(printf '%s\n' "$BODY"  | awk '/^## PR breakdown/{f=1} f')
+OUT=$(mktemp)
+{ printf '%s\n\n' "$HEAD"; printf '%s\n' "$(cat "$NEW")"; [ -n "$PRS" ] && printf '\n%s\n' "$PRS"; } > "$OUT"
+gh issue edit "$ISSUE" --body-file "$OUT"
+rm -f "$NEW" "$OUT"
+echo "Slices appended to issue #$ISSUE"
+```
+
+If a `## PR breakdown` already existed, warn the user it may now be stale and
+suggest re-running `/pr-breakdown`.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Horizontal layers (all schema, then all API) | Each slice goes end-to-end |

--- a/skills/to-prd/SKILL.md
+++ b/skills/to-prd/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: to-prd
+description: Use when the user wants to turn the current conversation into a short, human-readable PRD published as a GitHub issue, or invokes /to-prd.
+---
+
+# To PRD
+
+Turn the conversation and codebase into a **short PRD a human actually reads**,
+then publish it as a GitHub issue.
+
+```
+/to-prd [--title="..."] [--label=Plan] [--issue=N]
+
+  1. Gather context (conversation + light repo read)
+  2. Clarify gaps via AskUserQuestion   (gate, only if thin)
+  3. Draft the PRD
+  4. Show it, wait for approval          (gate)
+  5. Publish the issue; print URL + number
+```
+
+## Arguments
+
+| Arg | Default | Notes |
+|-----|---------|-------|
+| `--title="..."` | Derived from context | Issue title |
+| `--label=...` | `Plan` | Dropped if the repo has no such label; pass `--label=` for none |
+| `--issue=N` | Create new | Re-publish: replace the PRD, keep any appended slices/PRs |
+
+## Phase 1 — Gather context
+
+Read the conversation; explore the repo only if you haven't. Use the codebase's
+own vocabulary and respect existing ADRs.
+
+## Phase 2 — Clarify (gate)
+
+If a fact that changes the design is missing, ask with **AskUserQuestion** (≤4 at
+a time, concrete options) — otherwise skip when context is rich.
+
+## Phase 3 — Draft
+
+**Write it tight:**
+
+- One screen. Cut anything that doesn't change a decision.
+- Plain English, no filler. Ban "robust", "seamless", "leverage", "comprehensive", "powerful" — and all hedging.
+- Short declarative sentences. Concrete nouns. Say the thing.
+- Tables and bullets over paragraphs.
+- Only what was discussed or confirmed — invent nothing.
+- No file paths or code; they rot. Rare exception: a tiny snippet that nails a decision — a type, a schema.
+
+**Use these sections:**
+
+```markdown
+## The problem
+<What's wrong today, in the reader's words. One short paragraph.>
+
+## What we're building
+<A few sharp sentences. The core idea.>
+
+## How it works
+<The key mechanics as bullets.>
+
+## Decisions already made
+<Table: Area | Choice.>
+
+## In scope / Out of scope
+<Two short lists.>
+
+## Open questions
+<What still needs the user's call. Omit if none.>
+```
+
+## Phase 4 — Approve (gate)
+
+Show the draft in chat. Wait for an OK or edits. **Don't publish until approved.**
+
+## Phase 5 — Publish
+
+Write the approved body to a temp file (dodges shell-escaping), drop an unknown
+label so the create can't fail on it, then print one parseable line:
+
+```bash
+TITLE="..."; LABEL="${LABEL-Plan}"; BODY=$(mktemp)
+# ...write the approved PRD to "$BODY"...
+[ -n "$LABEL" ] && { gh label list --json name -q '.[].name' | grep -Fqx "$LABEL" || LABEL=""; }
+URL=$(gh issue create --title "$TITLE" ${LABEL:+--label "$LABEL"} --body-file "$BODY")
+rm -f "$BODY"
+[ -n "$URL" ] || { echo "abort: issue create failed" >&2; exit 1; }
+echo "PRD published: $URL (issue #${URL##*/})"
+```
+
+For `--issue=N`, replace only the PRD and keep the downstream sections in place.
+The rebuild keys on the exact `## Build plan` / `## PR breakdown` headings (so
+never use those headings in PRD prose); `tr -d '\r'` guards CRLF:
+
+```bash
+ISSUE=<the issue number>; BODY=$(mktemp)
+# ...write the approved PRD to "$BODY"...
+CUR=$(gh issue view "$ISSUE" --json body -q .body | tr -d '\r')
+[ -n "$CUR" ] || { echo "abort: empty issue body" >&2; exit 1; }
+DOWN=$(printf '%s\n' "$CUR" | awk '/^## Build plan/{f=1} /^## PR breakdown/{f=1} f')
+OUT=$(mktemp)
+{ printf '%s\n\n' "$(cat "$BODY")"; [ -n "$DOWN" ] && printf '%s\n' "$DOWN"; } > "$OUT"
+gh issue edit "$ISSUE" --body-file "$OUT"
+rm -f "$BODY" "$OUT"
+echo "PRD published: $(gh issue view "$ISSUE" --json url -q .url) (issue #$ISSUE)"
+```


### PR DESCRIPTION
## What

Adds a four-skill **breakdown pipeline** that turns a discussion into a published
plan, all in **one growing GitHub issue**.

| Skill | Command | Role |
|-------|---------|------|
| `breakdown` | `/breakdown` | Orchestrator — runs the three in order, threads `--issue=N`, honors each gate |
| `to-prd` | `/to-prd` | Conversation → short, human-readable PRD → **clarify** + **approve** gates → `gh issue create` |
| `to-issues` | `/to-issues` | PRD issue → vertical tracer-bullet slices + parallelization → **discuss** gate → append |
| `pr-breakdown` | `/pr-breakdown` | Slices → ~100–200 LOC PR rows → **approve** gate → append |

## How it works

- **One growing issue.** `to-prd` creates it and prints `PRD published: <url> (issue #N)`; the orchestrator captures `N` and passes `--issue=N` to the other two, which append.
- **Canonical order** PRD → `## Build plan` → `## PR breakdown`. Each writer rebuilds the body from those parts, so re-runs replace their own section in place — idempotent, CRLF-safe, with an empty-read abort and a label-drop guard.
- **Human-readable PRD.** `to-prd` encodes a tight writing style (one screen, plain English, banned filler) — the PRD is for a person, not an agent.
- **Sub-skills also run standalone** (pass `--issue=N`, else they detect/ask).

## Provenance

Modeled on [Matt Pocock's](https://github.com/mattpocock/skills) `to-prd` / `to-issues`, with deliberate divergences: short human PRD instead of an exhaustive user-story list; slices as a table in one issue instead of one-issue-per-slice; a clarify gate instead of silent synthesis; added parallelization waves and a `pr-breakdown` stage.

## Quality

Reviewed by 5 parallel agents across 4 rounds (quality, compactness, no-extra-words, effectiveness, correctness, Matt comparison, sharpness). Mean **83.6 → 91.6**, all reviewers ≥90. `at validate --skills` passes (88/0); the issue-body rebuild bash was tested against CRLF / empty / round-trip cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
