### PR TITLE
feat(installer): skills browse view — Skills tab lists skills with installed marker (PR 1.4)

### DIFF
--- a/installer/at.py
+++ b/installer/at.py
@@ -4,13 +4,23 @@
 # dependencies = ["questionary", "rich"]
 # ///
 import sys
+from pathlib import Path
 from typing import Final
 
 import questionary
 from rich.console import Console
 from rich.panel import Panel
 
+from catalog import Catalog, list_skills, load_catalog, skill_unit_id
+from state import State, load_state
+
 AT_VERSION: Final[str] = "0.2.0"
+
+CATALOG_PATH: Final[Path] = Path(__file__).parent / "catalog.toml"
+STATE_ROOT: Final[Path] = Path.home() / ".claude" / "at"
+
+MARKER_INSTALLED: Final[str] = "✅"
+MARKER_NOT_INSTALLED: Final[str] = "❌"
 
 HEADER_TEXT: Final[str] = "Agent Templates Installer"
 NON_TTY_NOTICE: Final[str] = (
@@ -42,6 +52,19 @@ KNOWN_TOKENS: Final[frozenset[str]] = frozenset(
 )
 
 
+def _skill_marker(name: str, installed: frozenset[str]) -> str:
+    if skill_unit_id(name) in installed:
+        return MARKER_INSTALLED
+    return MARKER_NOT_INSTALLED
+
+
+def skill_rows(*, catalog: Catalog, state: State) -> list[str]:
+    """Pair each catalog skill with its on-disk install marker so the Skills tab
+    renders status, keying install state by the unit id catalog.py owns."""
+    installed: frozenset[str] = frozenset(state.units)
+    return [f"{_skill_marker(name, installed)} {name}" for name in list_skills(catalog)]
+
+
 def launch_tui() -> int:
     """Bail out on non-interactive stdin: questionary's prompt would otherwise
     block forever waiting on input no CI session can supply."""
@@ -57,6 +80,12 @@ def launch_tui() -> int:
             ).ask()
             if choice is None or choice == "Exit":
                 return 0
+            if choice == "Skills":
+                catalog: Catalog = load_catalog(CATALOG_PATH)
+                state: State = load_state(STATE_ROOT)
+                for row in skill_rows(catalog=catalog, state=state):
+                    console.print(row, markup=False)
+                continue
             console.print(TAB_PLACEHOLDER)
     except KeyboardInterrupt:
         return 0

--- a/installer/catalog.py
+++ b/installer/catalog.py
@@ -53,6 +53,12 @@ def _unit_id(unit: Unit) -> str:
     return f"{unit.kind}{_REF_SEP}{unit.name}"
 
 
+def skill_unit_id(name: str) -> str:
+    """Expose the id a skill unit is keyed by, so callers render install status
+    without re-encoding the "<kind>/<name>" join this module owns."""
+    return _unit_id(Unit(kind=_SKILL_KIND, name=name))
+
+
 def list_skills(catalog: Catalog) -> list[str]:
     """Surface the installable skills by name in a stable order, so a UI listing
     doesn't depend on declaration order in the toml."""

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -1,7 +1,18 @@
+from collections.abc import Iterator
+from pathlib import Path
+
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
 
-from at import main
+from at import (
+    MARKER_INSTALLED,
+    MARKER_NOT_INSTALLED,
+    TAB_PLACEHOLDER,
+    main,
+    skill_rows,
+)
+from catalog import Catalog, Unit
+from state import State
 
 
 def test_version_flag_prints_version_and_exits_zero(
@@ -48,3 +59,63 @@ def test_install_on_non_tty_prints_notice_and_exits_without_hanging(
     assert exit_code == 0
     assert "Agent Templates Installer" in captured
     assert "terminal" in captured.lower()
+
+
+def test_skill_rows_marks_installed_and_not_installed_skills() -> None:
+    catalog: Catalog = Catalog(
+        units=(Unit(kind="skill", name="alpha"), Unit(kind="skill", name="beta")),
+        packages=(),
+        bundles=(),
+    )
+    state: State = State(version=1, units={"skill/alpha": "hash"})
+
+    rows: list[str] = skill_rows(catalog=catalog, state=state)
+
+    assert f"{MARKER_INSTALLED} alpha" in rows
+    assert f"{MARKER_NOT_INSTALLED} beta" in rows
+
+
+def test_skill_rows_lists_every_skill_sorted_and_excludes_non_skills() -> None:
+    catalog: Catalog = Catalog(
+        units=(
+            Unit(kind="skill", name="zeta"),
+            Unit(kind="agent", name="some-agent"),
+            Unit(kind="skill", name="alpha"),
+            Unit(kind="rule", name="some-rule"),
+        ),
+        packages=(),
+        bundles=(),
+    )
+    state: State = State(version=1, units={})
+
+    rows: list[str] = skill_rows(catalog=catalog, state=state)
+
+    assert rows == [f"{MARKER_NOT_INSTALLED} alpha", f"{MARKER_NOT_INSTALLED} zeta"]
+
+
+def test_skills_tab_renders_skill_rows_instead_of_placeholder(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("at.STATE_ROOT", tmp_path)
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-skill"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    answers: Iterator[str] = iter(["Skills", "Exit"])
+
+    class FakePrompt:
+        def ask(self) -> str:
+            return next(answers)
+
+    monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakePrompt())
+
+    exit_code: int = main(["install"])
+
+    captured: str = capsys.readouterr().out
+    assert exit_code == 0
+    assert f"{MARKER_NOT_INSTALLED} demo-skill" in captured
+    assert TAB_PLACEHOLDER not in captured

--- a/installer/tests/test_catalog.py
+++ b/installer/tests/test_catalog.py
@@ -3,7 +3,15 @@ from typing import Final
 
 import pytest
 
-from catalog import Bundle, Catalog, Package, Unit, list_skills, load_catalog
+from catalog import (
+    Bundle,
+    Catalog,
+    Package,
+    Unit,
+    list_skills,
+    load_catalog,
+    skill_unit_id,
+)
 
 SEED: Final[Path] = Path(__file__).resolve().parent.parent / "catalog.toml"
 
@@ -62,6 +70,12 @@ def test_list_skills_returns_only_skill_names_sorted(tmp_path: Path) -> None:
 
     # Only skill-kind units, and sorted (declaration order is beta, alpha).
     assert list_skills(catalog) == ["alpha", "beta"]
+
+
+def test_skill_unit_id_joins_kind_and_name() -> None:
+    # The skill-unit id is the join key install status is keyed by; pin it here
+    # so the "<kind>/<name>" format lives in exactly one module.
+    assert skill_unit_id("make-pr") == "skill/make-pr"
 
 
 def test_load_catalog_rejects_package_referencing_undeclared_unit(


### PR DESCRIPTION
## PR 1.4 — Skills browse view (Slice 1, read-only)

Closes the last PR of Slice 1 in #74. Makes the TUI **Skills** tab render a read-only list of every catalog skill, each prefixed with an installed marker by cross-referencing on-disk state.

### What changed
- `skill_rows(*, catalog, state)` in `at.py` — pure function pairing each `list_skills()` entry with `✅`/`❌` by checking whether its `skill/<name>` id is present in `State.units`. Fully unit-tested.
- Skills tab wired in `launch_tui()` to load the catalog + state and print the rows (markup disabled so catalog-derived names are rendered literally). Other tabs keep the placeholder. Read-only — no install/uninstall, no state mutation, no filesystem writes.
- `catalog.skill_unit_id(name)` — new public helper that owns the `"<kind>/<name>"` join key, so `at.py` no longer re-encodes the format (resolves a review-flagged information-leakage).

### Scope
`installer/{at.py, catalog.py, tests/test_at.py, tests/test_catalog.py}`. No new dependencies.

### Verification
- `uv run pytest -W error` → 17 passed
- `ruff format --check` · `ruff check` · `mypy --strict` → all clean

### Process (make-pr-lite)
One `coder-lite` build (full RED→GREEN TDD), independent gate re-run, a parallel 3-reviewer panel + critic (**achieved**, 92). Round 1 surfaced a MAJOR information-leakage flagged by two reviewers; one batched fix round resolved it plus three MINORs. Re-review of the fix hunks: zero findings across all three reviewers. Squashed to one commit.
