### PR TITLE
feat(installer): stage + symlink primitives (PR 2.1)

### DIFF
--- a/installer/placement.py
+++ b/installer/placement.py
@@ -31,10 +31,12 @@ def link_unit(*, staged_path: Path, link_path: Path) -> Path:
     """Symlink a staged unit into its live location so it is visible under
     ~/.claude/<kind>/ while ~/.claude/at stays the single source of truth."""
     link_path.parent.mkdir(parents=True, exist_ok=True)
-    # A pre-existing real (non-symlink) entry is the user's own data, never a
-    # prior install of ours, so preserve it before claiming the path; this also
-    # frees the path so symlink_to does not hit an existing entry.
-    if link_path.exists() and not link_path.is_symlink():
+    # An existing symlink is a prior install of ours, so just drop it; only a
+    # real (non-symlink) entry is the user's own data worth backing up. Either
+    # way the path is freed so symlink_to does not hit an existing entry.
+    if link_path.is_symlink():
+        link_path.unlink()
+    elif link_path.exists():
         backup_path: Path = link_path.with_name(link_path.name + _BACKUP_SUFFIX)
         link_path.replace(backup_path)
     link_path.symlink_to(staged_path)

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -1,7 +1,12 @@
 import shutil
 from pathlib import Path
+from typing import Final
 
 from catalog import Unit
+
+# A real file/dir displaced by linking is moved aside to "<name>.bak" so its
+# contents survive the install rather than being clobbered by our symlink.
+_BACKUP_SUFFIX: Final[str] = ".bak"
 
 
 def stage_unit(*, unit: Unit, source: Path, staged_root: Path) -> Path:
@@ -26,5 +31,11 @@ def link_unit(*, staged_path: Path, link_path: Path) -> Path:
     """Symlink a staged unit into its live location so it is visible under
     ~/.claude/<kind>/ while ~/.claude/at stays the single source of truth."""
     link_path.parent.mkdir(parents=True, exist_ok=True)
+    # A pre-existing real (non-symlink) entry is the user's own data, never a
+    # prior install of ours, so preserve it before claiming the path; this also
+    # frees the path so symlink_to does not hit an existing entry.
+    if link_path.exists() and not link_path.is_symlink():
+        backup_path: Path = link_path.with_name(link_path.name + _BACKUP_SUFFIX)
+        link_path.replace(backup_path)
     link_path.symlink_to(staged_path)
     return link_path

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -9,5 +9,8 @@ def stage_unit(*, unit: Unit, source: Path, staged_root: Path) -> Path:
     install can swap a fully-built tree into place instead of writing live."""
     destination: Path = staged_root / unit.kind / unit.name
     destination.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(source, destination)
+    if source.is_dir():
+        shutil.copytree(source, destination)
+    else:
+        shutil.copyfile(source, destination)
     return destination

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -20,10 +20,12 @@ def stage_unit(*, unit: Unit, source: Path, staged_root: Path) -> Path:
         shutil.rmtree(destination)
     elif destination.exists():
         destination.unlink()
+    # copy2 (not copyfile) carries the source's mode across, so an executable
+    # hook script stays executable once staged — matching copytree below.
     if source.is_dir():
         shutil.copytree(source, destination)
     else:
-        shutil.copyfile(source, destination)
+        shutil.copy2(source, destination)
     return destination
 
 

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -9,6 +9,12 @@ def stage_unit(*, unit: Unit, source: Path, staged_root: Path) -> Path:
     install can swap a fully-built tree into place instead of writing live."""
     destination: Path = staged_root / unit.kind / unit.name
     destination.parent.mkdir(parents=True, exist_ok=True)
+    # Clear any prior staging of this unit so a re-stage fully supersedes it,
+    # leaving no stale files behind, rather than colliding with the old tree.
+    if destination.is_dir():
+        shutil.rmtree(destination)
+    elif destination.exists():
+        destination.unlink()
     if source.is_dir():
         shutil.copytree(source, destination)
     else:

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -20,3 +20,11 @@ def stage_unit(*, unit: Unit, source: Path, staged_root: Path) -> Path:
     else:
         shutil.copyfile(source, destination)
     return destination
+
+
+def link_unit(*, staged_path: Path, link_path: Path) -> Path:
+    """Symlink a staged unit into its live location so it is visible under
+    ~/.claude/<kind>/ while ~/.claude/at stays the single source of truth."""
+    link_path.parent.mkdir(parents=True, exist_ok=True)
+    link_path.symlink_to(staged_path)
+    return link_path

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -1,0 +1,13 @@
+import shutil
+from pathlib import Path
+
+from catalog import Unit
+
+
+def stage_unit(*, unit: Unit, source: Path, staged_root: Path) -> Path:
+    """Lay a unit out under "<kind>/<name>" in a staging area first, so the real
+    install can swap a fully-built tree into place instead of writing live."""
+    destination: Path = staged_root / unit.kind / unit.name
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, destination)
+    return destination

--- a/installer/pyproject.toml
+++ b/installer/pyproject.toml
@@ -35,7 +35,7 @@ pythonpath = ["."]  # rootdir is installer/, so tests import the module under te
 # Coverage is a diagnostic (term-missing), never a gate target — a 100% mandate just
 # manufactures tests to paint branches green. Test behaviour, then read coverage to spot
 # a genuinely untested path; don't write a test solely to colour a line.
-addopts = ["--cov=at", "--cov=state", "--cov=catalog", "--cov-report=term-missing"]
+addopts = ["--cov=at", "--cov=state", "--cov=catalog", "--cov=placement", "--cov-report=term-missing"]
 filterwarnings = ["error"]
 
 [tool.coverage.run]

--- a/installer/tests/test_placement.py
+++ b/installer/tests/test_placement.py
@@ -40,3 +40,24 @@ def test_stage_unit_copies_directory_source_recursively(tmp_path: Path) -> None:
     assert destination.is_dir()
     assert (destination / "SKILL.md").read_text(encoding="utf-8") == skill_content
     assert (destination / "schemas" / "x.json").read_text(encoding="utf-8") == schema_content
+
+
+def test_stage_unit_replaces_previously_staged_tree_for_same_unit(tmp_path: Path) -> None:
+    unit: Unit = Unit(kind="skill", name="make-pr")
+    staged_root: Path = tmp_path / "staged"
+
+    source_a: Path = tmp_path / "srcA"
+    source_a.mkdir()
+    (source_a / "old.txt").write_text("stale\n", encoding="utf-8")
+    (source_a / "SKILL.md").write_text("# Old\n", encoding="utf-8")
+    stage_unit(unit=unit, source=source_a, staged_root=staged_root)
+
+    new_content: str = "# New\n\nUpdated skill.\n"
+    source_b: Path = tmp_path / "srcB"
+    source_b.mkdir()
+    (source_b / "SKILL.md").write_text(new_content, encoding="utf-8")
+
+    destination: Path = stage_unit(unit=unit, source=source_b, staged_root=staged_root)
+
+    assert (destination / "SKILL.md").read_text(encoding="utf-8") == new_content
+    assert not (destination / "old.txt").exists()

--- a/installer/tests/test_placement.py
+++ b/installer/tests/test_placement.py
@@ -78,6 +78,28 @@ def test_link_unit_symlinks_to_staged_path_and_creates_missing_parent(tmp_path: 
     assert (link_path / "SKILL.md").read_text(encoding="utf-8") == content
 
 
+def test_link_unit_replaces_prior_symlink_in_place_without_backup(tmp_path: Path) -> None:
+    old_content: str = "# Old staged\n\nFrom a prior install run.\n"
+    staged_old: Path = tmp_path / "at" / "skill" / "old.md"
+    staged_old.parent.mkdir(parents=True)
+    staged_old.write_text(old_content, encoding="utf-8")
+
+    new_content: str = "# New staged\n\nFrom the current install run.\n"
+    staged_new: Path = tmp_path / "at" / "skill" / "new.md"
+    staged_new.write_text(new_content, encoding="utf-8")
+
+    link_path: Path = tmp_path / "claude" / "commands" / "make-pr.md"
+    link_unit(staged_path=staged_old, link_path=link_path)
+
+    link_unit(staged_path=staged_new, link_path=link_path)
+
+    backup_path: Path = link_path.with_name(link_path.name + ".bak")
+    assert link_path.is_symlink()
+    assert link_path.resolve() == staged_new.resolve()
+    assert link_path.read_text(encoding="utf-8") == new_content
+    assert not backup_path.exists()
+
+
 def test_link_unit_backs_up_existing_real_file_before_linking(tmp_path: Path) -> None:
     staged_content: str = "# Make PR\n\nOurs.\n"
     staged_path: Path = tmp_path / "at" / "skill" / "make-pr.md"

--- a/installer/tests/test_placement.py
+++ b/installer/tests/test_placement.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from catalog import Unit
-from placement import stage_unit
+from placement import link_unit, stage_unit
 
 
 def test_stage_unit_copies_single_file_to_kind_name_destination(tmp_path: Path) -> None:
@@ -61,3 +61,18 @@ def test_stage_unit_replaces_previously_staged_tree_for_same_unit(tmp_path: Path
 
     assert (destination / "SKILL.md").read_text(encoding="utf-8") == new_content
     assert not (destination / "old.txt").exists()
+
+
+def test_link_unit_symlinks_to_staged_path_and_creates_missing_parent(tmp_path: Path) -> None:
+    content: str = "# Make PR\n\nOpens a pull request.\n"
+    staged_path: Path = tmp_path / "at" / "skill" / "make-pr"
+    staged_path.mkdir(parents=True)
+    (staged_path / "SKILL.md").write_text(content, encoding="utf-8")
+    link_path: Path = tmp_path / "claude" / "skills" / "make-pr"
+
+    returned: Path = link_unit(staged_path=staged_path, link_path=link_path)
+
+    assert returned == link_path
+    assert link_path.is_symlink()
+    assert link_path.resolve() == staged_path.resolve()
+    assert (link_path / "SKILL.md").read_text(encoding="utf-8") == content

--- a/installer/tests/test_placement.py
+++ b/installer/tests/test_placement.py
@@ -39,10 +39,14 @@ def test_stage_unit_copies_directory_source_recursively(tmp_path: Path) -> None:
     assert destination == staged_root / "skill" / "make-pr"
     assert destination.is_dir()
     assert (destination / "SKILL.md").read_text(encoding="utf-8") == skill_content
-    assert (destination / "schemas" / "x.json").read_text(encoding="utf-8") == schema_content
+    assert (destination / "schemas" / "x.json").read_text(
+        encoding="utf-8"
+    ) == schema_content
 
 
-def test_stage_unit_replaces_previously_staged_tree_for_same_unit(tmp_path: Path) -> None:
+def test_stage_unit_replaces_previously_staged_tree_for_same_unit(
+    tmp_path: Path,
+) -> None:
     unit: Unit = Unit(kind="skill", name="make-pr")
     staged_root: Path = tmp_path / "staged"
 
@@ -63,7 +67,9 @@ def test_stage_unit_replaces_previously_staged_tree_for_same_unit(tmp_path: Path
     assert not (destination / "old.txt").exists()
 
 
-def test_link_unit_symlinks_to_staged_path_and_creates_missing_parent(tmp_path: Path) -> None:
+def test_link_unit_symlinks_to_staged_path_and_creates_missing_parent(
+    tmp_path: Path,
+) -> None:
     content: str = "# Make PR\n\nOpens a pull request.\n"
     staged_path: Path = tmp_path / "at" / "skill" / "make-pr"
     staged_path.mkdir(parents=True)
@@ -78,7 +84,9 @@ def test_link_unit_symlinks_to_staged_path_and_creates_missing_parent(tmp_path: 
     assert (link_path / "SKILL.md").read_text(encoding="utf-8") == content
 
 
-def test_link_unit_replaces_prior_symlink_in_place_without_backup(tmp_path: Path) -> None:
+def test_link_unit_replaces_prior_symlink_in_place_without_backup(
+    tmp_path: Path,
+) -> None:
     old_content: str = "# Old staged\n\nFrom a prior install run.\n"
     staged_old: Path = tmp_path / "at" / "skill" / "old.md"
     staged_old.parent.mkdir(parents=True)

--- a/installer/tests/test_placement.py
+++ b/installer/tests/test_placement.py
@@ -1,3 +1,5 @@
+import os
+import stat
 from pathlib import Path
 
 from catalog import Unit
@@ -19,6 +21,24 @@ def test_stage_unit_copies_single_file_to_kind_name_destination(tmp_path: Path) 
     assert destination == staged_root / "agent" / "reviewer"
     assert destination.is_file()
     assert destination.read_text(encoding="utf-8") == content
+
+
+def test_stage_unit_preserves_executable_bit_of_single_file(tmp_path: Path) -> None:
+    source: Path = tmp_path / "pre-commit.sh"
+    source.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    source.chmod(0o755)
+    source_exec_bits: int = source.stat().st_mode & 0o777
+    staged_root: Path = tmp_path / "staged"
+
+    destination: Path = stage_unit(
+        unit=Unit(kind="hook", name="pre-commit"),
+        source=source,
+        staged_root=staged_root,
+    )
+
+    assert os.access(destination, os.X_OK)
+    assert destination.stat().st_mode & stat.S_IXUSR
+    assert destination.stat().st_mode & 0o777 == source_exec_bits
 
 
 def test_stage_unit_copies_directory_source_recursively(tmp_path: Path) -> None:

--- a/installer/tests/test_placement.py
+++ b/installer/tests/test_placement.py
@@ -76,3 +76,24 @@ def test_link_unit_symlinks_to_staged_path_and_creates_missing_parent(tmp_path: 
     assert link_path.is_symlink()
     assert link_path.resolve() == staged_path.resolve()
     assert (link_path / "SKILL.md").read_text(encoding="utf-8") == content
+
+
+def test_link_unit_backs_up_existing_real_file_before_linking(tmp_path: Path) -> None:
+    staged_content: str = "# Make PR\n\nOurs.\n"
+    staged_path: Path = tmp_path / "at" / "skill" / "make-pr.md"
+    staged_path.parent.mkdir(parents=True)
+    staged_path.write_text(staged_content, encoding="utf-8")
+
+    user_content: str = "user's own data\n"
+    link_path: Path = tmp_path / "claude" / "commands" / "make-pr.md"
+    link_path.parent.mkdir(parents=True)
+    link_path.write_text(user_content, encoding="utf-8")
+
+    link_unit(staged_path=staged_path, link_path=link_path)
+
+    backup_path: Path = link_path.with_name(link_path.name + ".bak")
+    assert link_path.is_symlink()
+    assert link_path.resolve() == staged_path.resolve()
+    assert backup_path.exists()
+    assert not backup_path.is_symlink()
+    assert backup_path.read_text(encoding="utf-8") == user_content

--- a/installer/tests/test_placement.py
+++ b/installer/tests/test_placement.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from catalog import Unit
+from placement import stage_unit
+
+
+def test_stage_unit_copies_single_file_to_kind_name_destination(tmp_path: Path) -> None:
+    content: str = "# Reviewer\n\nReviews code.\n"
+    source: Path = tmp_path / "reviewer.md"
+    source.write_text(content, encoding="utf-8")
+    staged_root: Path = tmp_path / "staged"
+
+    destination: Path = stage_unit(
+        unit=Unit(kind="agent", name="reviewer"),
+        source=source,
+        staged_root=staged_root,
+    )
+
+    assert destination == staged_root / "agent" / "reviewer"
+    assert destination.is_file()
+    assert destination.read_text(encoding="utf-8") == content

--- a/installer/tests/test_placement.py
+++ b/installer/tests/test_placement.py
@@ -19,3 +19,24 @@ def test_stage_unit_copies_single_file_to_kind_name_destination(tmp_path: Path) 
     assert destination == staged_root / "agent" / "reviewer"
     assert destination.is_file()
     assert destination.read_text(encoding="utf-8") == content
+
+
+def test_stage_unit_copies_directory_source_recursively(tmp_path: Path) -> None:
+    skill_content: str = "# Make PR\n\nOpens a pull request.\n"
+    schema_content: str = '{"type": "object"}\n'
+    source: Path = tmp_path / "src" / "make-pr"
+    (source / "schemas").mkdir(parents=True)
+    (source / "SKILL.md").write_text(skill_content, encoding="utf-8")
+    (source / "schemas" / "x.json").write_text(schema_content, encoding="utf-8")
+    staged_root: Path = tmp_path / "staged"
+
+    destination: Path = stage_unit(
+        unit=Unit(kind="skill", name="make-pr"),
+        source=source,
+        staged_root=staged_root,
+    )
+
+    assert destination == staged_root / "skill" / "make-pr"
+    assert destination.is_dir()
+    assert (destination / "SKILL.md").read_text(encoding="utf-8") == skill_content
+    assert (destination / "schemas" / "x.json").read_text(encoding="utf-8") == schema_content


### PR DESCRIPTION
## PR 2.1 — Stage + symlink primitives

Implements the two unit-type-agnostic filesystem primitives for the installer (issue #74, slice 2). These are reused across every later slice (install / uninstall / update / agents / rules / hooks).

`installer/placement.py`:

- **`stage_unit(*, unit, source, staged_root) -> Path`** — copies a unit's source (file *or* directory) into `staged_root/<kind>/<name>`, so installs are self-contained under `~/.claude/at/`. Re-staging fully supersedes any prior content (no stale files). Uses `shutil.copy2`/`copytree` so file mode is preserved consistently — an executable hook script stays executable once staged.
- **`link_unit(*, staged_path, link_path) -> Path`** — symlinks `link_path → staged_path`, creating parent dirs. A pre-existing **real** target (the user's own file/dir) is backed up to a sibling `<name>.bak` before linking; a pre-existing **symlink** (a prior install of ours) is replaced in place **without** piling up `.bak`s, keeping re-install/reconcile idempotent.

Scope is deliberately just the two primitives — state recording, `install_skill`, TUI wiring, and the kind→target-dir mapping are PR 2.2+.

### How it was built
Driven through the `/make-pr` architect workflow: 7 behaviors via live RED→GREEN TDD, full gate suite (ruff format, ruff check, mypy --strict, pytest -W error) green, then reviewer + critic.

- **Tests:** 7 new behaviors in `installer/tests/test_placement.py` — stage file, stage directory, re-stage replaces stale, link creates symlink+parents, link backs up a real target, link replaces a prior symlink without `.bak`, stage preserves the executable bit. Full suite: **24 passed**.
- **Reviewer:** 97/100, no findings (an initial MINOR — file-copy dropping the executable bit — was fixed test-first via `copy2`).
- **Critic:** `achieved` (96/100), all behaviors covered, out-of-scope items correctly deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)