### PR TITLE
feat(installer): install a skill from the TUI (PR 2.2)

### DIFF
--- a/installer/actions.py
+++ b/installer/actions.py
@@ -4,9 +4,9 @@
 from pathlib import Path
 from typing import Final
 
-from catalog import Unit
+from catalog import Unit, skill_unit_id
 from placement import link_unit, stage_unit
-from state import State
+from state import State, save_state
 
 # The kind→subdir layout lives here, the first concrete caller of the placement
 # primitives: a skill stages under "staged/skill/<name>" and goes live under
@@ -14,6 +14,10 @@ from state import State
 _SKILL_KIND: Final[str] = "skill"
 _STAGED_DIRNAME: Final[str] = "staged"
 _SKILLS_DIRNAME: Final[str] = "skills"
+
+# content hash is recorded in the update slice (4.1); presence of the unit id is
+# what marks a skill "installed" today, so the value is a deliberate placeholder.
+_UNHASHED: Final[str] = ""
 
 
 def install_skill(
@@ -32,4 +36,9 @@ def install_skill(
         unit=unit, source=source, staged_root=state_root / _STAGED_DIRNAME
     )
     link_unit(staged_path=staged_path, link_path=claude_root / _SKILLS_DIRNAME / name)
-    return state
+    new_state: State = State(
+        version=state.version,
+        units={**state.units, skill_unit_id(name): _UNHASHED},
+    )
+    save_state(new_state, state_root)
+    return new_state

--- a/installer/actions.py
+++ b/installer/actions.py
@@ -1,0 +1,35 @@
+"""Compose the placement primitives into whole installs, so callers ask for
+"install this skill" rather than wiring stage + link + record themselves."""
+
+from pathlib import Path
+from typing import Final
+
+from catalog import Unit
+from placement import link_unit, stage_unit
+from state import State
+
+# The kind→subdir layout lives here, the first concrete caller of the placement
+# primitives: a skill stages under "staged/skill/<name>" and goes live under
+# "<claude>/skills/<name>", matching ~/.claude's per-kind directories.
+_SKILL_KIND: Final[str] = "skill"
+_STAGED_DIRNAME: Final[str] = "staged"
+_SKILLS_DIRNAME: Final[str] = "skills"
+
+
+def install_skill(
+    *,
+    name: str,
+    source_root: Path,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Place a skill on disk by staging its source then linking the staged tree
+    live, so the staged copy stays the single source of truth behind the symlink."""
+    unit: Unit = Unit(kind=_SKILL_KIND, name=name)
+    source: Path = source_root / _SKILLS_DIRNAME / name
+    staged_path: Path = stage_unit(
+        unit=unit, source=source, staged_root=state_root / _STAGED_DIRNAME
+    )
+    link_unit(staged_path=staged_path, link_path=claude_root / _SKILLS_DIRNAME / name)
+    return state

--- a/installer/actions.py
+++ b/installer/actions.py
@@ -4,14 +4,13 @@
 from pathlib import Path
 from typing import Final
 
-from catalog import Unit, skill_unit_id
+from catalog import skill_unit, skill_unit_id
 from placement import link_unit, stage_unit
 from state import State, save_state
 
 # The kind→subdir layout lives here, the first concrete caller of the placement
 # primitives: a skill stages under "staged/skill/<name>" and goes live under
 # "<claude>/skills/<name>", matching ~/.claude's per-kind directories.
-_SKILL_KIND: Final[str] = "skill"
 _STAGED_DIRNAME: Final[str] = "staged"
 _SKILLS_DIRNAME: Final[str] = "skills"
 
@@ -29,11 +28,13 @@ def install_skill(
     state: State,
 ) -> State:
     """Place a skill on disk by staging its source then linking the staged tree
-    live, so the staged copy stays the single source of truth behind the symlink."""
-    unit: Unit = Unit(kind=_SKILL_KIND, name=name)
+    live, so the staged copy stays the single source of truth behind the symlink.
+
+    Persists the updated state to state_root (via save_state) and returns a brand-new
+    immutable State; the passed-in state is never mutated."""
     source: Path = source_root / _SKILLS_DIRNAME / name
     staged_path: Path = stage_unit(
-        unit=unit, source=source, staged_root=state_root / _STAGED_DIRNAME
+        unit=skill_unit(name), source=source, staged_root=state_root / _STAGED_DIRNAME
     )
     link_unit(staged_path=staged_path, link_path=claude_root / _SKILLS_DIRNAME / name)
     new_state: State = State(

--- a/installer/at.py
+++ b/installer/at.py
@@ -11,6 +11,7 @@ import questionary
 from rich.console import Console
 from rich.panel import Panel
 
+from actions import install_skill
 from catalog import Catalog, list_skills, load_catalog, skill_unit_id
 from state import State, load_state
 
@@ -18,6 +19,12 @@ AT_VERSION: Final[str] = "0.2.0"
 
 CATALOG_PATH: Final[Path] = Path(__file__).parent / "catalog.toml"
 STATE_ROOT: Final[Path] = Path.home() / ".claude" / "at"
+# at.py lives in installer/; the repo root one level up holds skills/<name>/ sources.
+REPO_ROOT: Final[Path] = Path(__file__).parent.parent
+# Live link root where installs go; kept separate from STATE_ROOT so tests can pin each.
+CLAUDE_ROOT: Final[Path] = Path.home() / ".claude"
+# Sentinel choice that leaves the install picker and returns to the tab menu.
+BACK_CHOICE: Final[str] = "← Back"
 
 MARKER_INSTALLED: Final[str] = "✅"
 MARKER_NOT_INSTALLED: Final[str] = "❌"
@@ -85,6 +92,29 @@ def launch_tui() -> int:
                 state: State = load_state(STATE_ROOT)
                 for row in skill_rows(catalog=catalog, state=state):
                     console.print(row, markup=False)
+                installed: frozenset[str] = frozenset(state.units)
+                installable: list[str] = [
+                    name
+                    for name in list_skills(catalog)
+                    if skill_unit_id(name) not in installed
+                ]
+                if not installable:
+                    continue
+                pick: str | None = questionary.select(
+                    "Install which skill?", choices=[*installable, BACK_CHOICE]
+                ).ask()
+                if pick is None or pick == BACK_CHOICE:
+                    continue
+                if questionary.confirm(f"Install {pick}?").ask():
+                    state = install_skill(
+                        name=pick,
+                        source_root=REPO_ROOT,
+                        state_root=STATE_ROOT,
+                        claude_root=CLAUDE_ROOT,
+                        state=state,
+                    )
+                    for row in skill_rows(catalog=catalog, state=state):
+                        console.print(row, markup=False)
                 continue
             console.print(TAB_PLACEHOLDER)
     except KeyboardInterrupt:

--- a/installer/catalog.py
+++ b/installer/catalog.py
@@ -53,10 +53,16 @@ def _unit_id(unit: Unit) -> str:
     return f"{unit.kind}{_REF_SEP}{unit.name}"
 
 
+def skill_unit(name: str) -> Unit:
+    """Own the skill-kind decision here, so callers stage skills without
+    re-encoding the "skill" kind token this module is the source of truth for."""
+    return Unit(kind=_SKILL_KIND, name=name)
+
+
 def skill_unit_id(name: str) -> str:
     """Expose the id a skill unit is keyed by, so callers render install status
     without re-encoding the "<kind>/<name>" join this module owns."""
-    return _unit_id(Unit(kind=_SKILL_KIND, name=name))
+    return _unit_id(skill_unit(name))
 
 
 def list_skills(catalog: Catalog) -> list[str]:

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
 from actions import install_skill
-from state import State
+from catalog import skill_unit_id
+from state import State, load_state
 
 
 def test_install_skill_stages_source_and_links_into_claude_skills(
@@ -37,3 +38,29 @@ def test_install_skill_stages_source_and_links_into_claude_skills(
     assert link_path.is_symlink()
     assert link_path.resolve() == staged_path.resolve()
     assert (link_path / "SKILL.md").read_text(encoding="utf-8") == skill_content
+
+
+def test_install_skill_records_and_persists_installed_unit(tmp_path: Path) -> None:
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "demo-skill"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text(
+        "# Demo Skill\n", encoding="utf-8"
+    )
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    initial_state: State = State(version=1, units={})
+
+    result: State = install_skill(
+        name="demo-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=initial_state,
+    )
+
+    unit_id: str = skill_unit_id("demo-skill")
+    assert unit_id in result.units
+    assert unit_id in load_state(state_root).units
+    assert initial_state.units == {}

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from actions import install_skill
+from state import State
+
+
+def test_install_skill_stages_source_and_links_into_claude_skills(
+    tmp_path: Path,
+) -> None:
+    skill_content: str = "# Demo Skill\n\nDemonstrates installation.\n"
+    nested_content: str = '{"type": "object"}\n'
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "demo-skill"
+    (skill_source / "schemas").mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text(skill_content, encoding="utf-8")
+    (skill_source / "schemas" / "x.json").write_text(nested_content, encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    install_skill(
+        name="demo-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    staged_path: Path = state_root / "staged" / "skill" / "demo-skill"
+    assert staged_path.is_dir()
+    assert (staged_path / "SKILL.md").read_text(encoding="utf-8") == skill_content
+    assert (staged_path / "schemas" / "x.json").read_text(
+        encoding="utf-8"
+    ) == nested_content
+
+    link_path: Path = claude_root / "skills" / "demo-skill"
+    assert link_path.is_symlink()
+    assert link_path.resolve() == staged_path.resolve()
+    assert (link_path / "SKILL.md").read_text(encoding="utf-8") == skill_content

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -44,9 +44,7 @@ def test_install_skill_records_and_persists_installed_unit(tmp_path: Path) -> No
     source_root: Path = tmp_path / "repo"
     skill_source: Path = source_root / "skills" / "demo-skill"
     skill_source.mkdir(parents=True)
-    (skill_source / "SKILL.md").write_text(
-        "# Demo Skill\n", encoding="utf-8"
-    )
+    (skill_source / "SKILL.md").write_text("# Demo Skill\n", encoding="utf-8")
 
     state_root: Path = tmp_path / "at"
     claude_root: Path = tmp_path / "claude"

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -12,8 +12,8 @@ from at import (
     main,
     skill_rows,
 )
-from catalog import Catalog, Unit
-from state import State
+from catalog import Catalog, Unit, skill_unit_id
+from state import State, load_state
 
 
 def test_version_flag_prints_version_and_exits_zero(
@@ -168,3 +168,48 @@ def test_skills_tab_install_picker_marks_chosen_skill_installed(
     assert exit_code == 0
     assert f"{MARKER_INSTALLED} demo-skill" in captured
     assert (tmp_path / "claude" / "skills" / "demo-skill").is_symlink()
+
+
+def test_skills_tab_declining_install_confirmation_installs_nothing(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("at.STATE_ROOT", tmp_path / "at")
+    monkeypatch.setattr("at.CLAUDE_ROOT", tmp_path / "claude")
+    monkeypatch.setattr("at.REPO_ROOT", tmp_path / "repo")
+
+    source_skill: Path = tmp_path / "repo" / "skills" / "demo-skill" / "SKILL.md"
+    source_skill.parent.mkdir(parents=True)
+    source_skill.write_text("# demo skill\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-skill"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    # Tab menu, then pick the skill at the install picker, then exit the tab menu.
+    select_answers: Iterator[str] = iter(["Skills", "demo-skill", "Exit"])
+
+    class FakeSelect:
+        def ask(self) -> str:
+            return next(select_answers)
+
+    # The confirm gate is declined, so the install must be a true no-op.
+    class DeclinePrompt:
+        def ask(self) -> bool:
+            return False
+
+    monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakeSelect())
+    monkeypatch.setattr("questionary.confirm", lambda *args, **kwargs: DeclinePrompt())
+
+    exit_code: int = main(["install"])
+
+    captured: str = capsys.readouterr().out
+    live_link: Path = tmp_path / "claude" / "skills" / "demo-skill"
+    final_state: State = load_state(tmp_path / "at")
+    assert exit_code == 0
+    assert not live_link.exists() and not live_link.is_symlink()
+    assert skill_unit_id("demo-skill") not in final_state.units
+    assert f"{MARKER_NOT_INSTALLED} demo-skill" in captured

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
 
+import at
 from at import (
     MARKER_INSTALLED,
     MARKER_NOT_INSTALLED,
@@ -105,13 +106,20 @@ def test_skills_tab_renders_skill_rows_instead_of_placeholder(
         encoding="utf-8",
     )
     monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
-    answers: Iterator[str] = iter(["Skills", "Exit"])
+    # Entering the Skills tab now leads to an install-picker select; pick the
+    # Back sentinel so this read-only test installs nothing and falls through.
+    answers: Iterator[str] = iter(["Skills", at.BACK_CHOICE, "Exit"])
 
     class FakePrompt:
         def ask(self) -> str:
             return next(answers)
 
+    class DeclinePrompt:
+        def ask(self) -> bool:
+            return False
+
     monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakePrompt())
+    monkeypatch.setattr("questionary.confirm", lambda *args, **kwargs: DeclinePrompt())
 
     exit_code: int = main(["install"])
 
@@ -119,3 +127,44 @@ def test_skills_tab_renders_skill_rows_instead_of_placeholder(
     assert exit_code == 0
     assert f"{MARKER_NOT_INSTALLED} demo-skill" in captured
     assert TAB_PLACEHOLDER not in captured
+
+
+def test_skills_tab_install_picker_marks_chosen_skill_installed(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("at.STATE_ROOT", tmp_path / "at")
+    monkeypatch.setattr("at.CLAUDE_ROOT", tmp_path / "claude")
+    monkeypatch.setattr("at.REPO_ROOT", tmp_path / "repo")
+
+    source_skill: Path = tmp_path / "repo" / "skills" / "demo-skill" / "SKILL.md"
+    source_skill.parent.mkdir(parents=True)
+    source_skill.write_text("# demo skill\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-skill"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    # Tab menu, then the install-picker pick, then the tab menu again to exit.
+    select_answers: Iterator[str] = iter(["Skills", "demo-skill", "Exit"])
+
+    class FakeSelect:
+        def ask(self) -> str:
+            return next(select_answers)
+
+    class ConfirmPrompt:
+        def ask(self) -> bool:
+            return True
+
+    monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakeSelect())
+    monkeypatch.setattr("questionary.confirm", lambda *args, **kwargs: ConfirmPrompt())
+
+    exit_code: int = main(["install"])
+
+    captured: str = capsys.readouterr().out
+    assert exit_code == 0
+    assert f"{MARKER_INSTALLED} demo-skill" in captured
+    assert (tmp_path / "claude" / "skills" / "demo-skill").is_symlink()


### PR DESCRIPTION
## PR 2.2 — Install action + Skills-tab wiring

First real install. Composes the merged 2.1 placement primitives into a one-call skill install and wires it into the Skills tab (issue #74, slice 2). Closes out slice 2 (2 / 2) when merged.

### `installer/actions.py` (new) — the install action
`install_skill(*, name, source_root, state_root, claude_root, state) -> State`:
1. **stage** — `stage_unit` copies `<source_root>/skills/<name>` into `<state_root>/staged/skill/<name>` (self-contained under `~/.claude/at/`),
2. **link** — `link_unit` symlinks it live at `<claude_root>/skills/<name>`,
3. **record + persist** — records the unit id in a *new* immutable `State` and `save_state`s it; returns the new State (input never mutated).

The `"skill"` kind is owned solely by `catalog.skill_unit()` (added here), so the staged-path kind and the state-key kind can't drift. The content hash is a placeholder until slice 4.1 — install today is marked by key presence.

### `installer/at.py` — Skills tab goes interactive
Added `REPO_ROOT` / `CLAUDE_ROOT` / `BACK_CHOICE` constants and rewired the Skills tab from read-only browse to: **render rows → select an installable skill (or Back) → confirm → install → re-render** with the ✅ marker. Declining the confirm is a true no-op.

Scope is the install action + Skills-tab wiring only — uninstall, reconcile, content hashing, and other unit types are later PRs.

### How it was built
Driven through the `/make-pr` architect workflow — live RED→GREEN TDD, gates, reviewer + critic.

- **Behaviors (tests, 28 passed):** install_skill stages + symlinks onto disk; records + persists the unit (returned State has the id, `load_state` sees it, input State unmutated); Skills-tab install-picker installs the chosen skill on confirm and re-renders it installed (driven end-to-end through `main(["install"])` with scripted prompts, asserting a real live symlink); declining the confirm installs nothing (regression guard); the read-only browse test was adapted to the new interactive flow.
- **Gates:** ruff format ✓, ruff check ✓, mypy --strict ✓, pytest -W error → 28 passed.
- **Reviewer:** initial 81 → a MAJOR (duplicated `"skill"` kind token) and a MINOR (undocumented side effects) fixed in one behavior-preserving refactor; re-review **97**, no findings.
- **Critic:** `achieved` (93), all four behaviors proven end-to-end, deferrals match the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)