### PR TITLE
feat(installer): add improve-architecture skill to catalog

### DIFF
--- a/installer/catalog.toml
+++ b/installer/catalog.toml
@@ -20,6 +20,10 @@ name = "course-correct"
 
 [[units]]
 kind = "skill"
+name = "improve-architecture"
+
+[[units]]
+kind = "skill"
 name = "latest-rebase"
 
 [[units]]


### PR DESCRIPTION
## What

Adds the `improve-architecture` skill as a `[[units]]` entry in `installer/catalog.toml`, slotted alphabetically between `course-correct` and `latest-rebase`.

## Why

The `improve-architecture` skill merged to main (`599781b`) with its source at `skills/improve-architecture/`, but the installer catalog was never updated to include it. As a result the installer's **Skills** tab couldn't list or install it. This wires the existing skill into the catalog so the TUI offers it.

## Verification

- `list_skills` now returns all 12 skills including `improve-architecture`.
- `pytest tests/test_catalog.py` — 5 passed, catalog still parses.
- Manually: `./at install` → **Skills** now shows `improve-architecture` with an install marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)