### PR TITLE
feat(installer): remove primitives + uninstall_skill (PR 3.1)

### DIFF
--- a/installer/actions.py
+++ b/installer/actions.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Final
 
 from catalog import skill_unit, skill_unit_id
-from placement import link_unit, stage_unit
+from placement import link_unit, stage_unit, unlink_unit, unstage_unit
 from state import State, save_state
 
 # The kind→subdir layout lives here, the first concrete caller of the placement
@@ -40,6 +40,34 @@ def install_skill(
     new_state: State = State(
         version=state.version,
         units={**state.units, skill_unit_id(name): _UNHASHED},
+    )
+    save_state(new_state, state_root)
+    return new_state
+
+
+def uninstall_skill(
+    *,
+    name: str,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Take a skill back off disk by dropping its live symlink then its staged
+    tree, so neither a dangling link nor an orphaned staging area survives — the
+    inverse of install_skill.
+
+    Persists the updated state to state_root (via save_state) and returns a brand-new
+    immutable State without the skill's unit; the passed-in state is never mutated."""
+    unlink_unit(link_path=claude_root / _SKILLS_DIRNAME / name)
+    unstage_unit(unit=skill_unit(name), staged_root=state_root / _STAGED_DIRNAME)
+    removed_id: str = skill_unit_id(name)
+    new_state: State = State(
+        version=state.version,
+        units={
+            unit_id: content
+            for unit_id, content in state.units.items()
+            if unit_id != removed_id
+        },
     )
     save_state(new_state, state_root)
     return new_state

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -49,6 +49,11 @@ def unlink_unit(*, link_path: Path) -> None:
     """Remove a unit's live symlink so it is no longer visible under
     ~/.claude/<kind>/, while the staged tree it pointed at survives untouched
     as the single source of truth."""
+    # Only a symlink is a prior install of ours to drop; a real entry is the
+    # user's own data, so leave it untouched as a quiet no-op — the inverse of
+    # link_unit, which likewise treats only a real non-symlink entry as the user's.
+    if not link_path.is_symlink():
+        return
     # unlink drops the symlink itself, never following it, so the staged target
     # is left in place — the inverse of link_unit's symlink_to.
     link_path.unlink()

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -52,3 +52,8 @@ def unlink_unit(*, link_path: Path) -> None:
     # unlink drops the symlink itself, never following it, so the staged target
     # is left in place — the inverse of link_unit's symlink_to.
     link_path.unlink()
+    # If linking displaced the user's own file to "<name>.bak", move it back over
+    # the now-freed path so the original is restored — inverse of link_unit's backup.
+    backup_path: Path = link_path.with_name(link_path.name + _BACKUP_SUFFIX)
+    if backup_path.exists():
+        backup_path.replace(link_path)

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -43,3 +43,12 @@ def link_unit(*, staged_path: Path, link_path: Path) -> Path:
         link_path.replace(backup_path)
     link_path.symlink_to(staged_path)
     return link_path
+
+
+def unlink_unit(*, link_path: Path) -> None:
+    """Remove a unit's live symlink so it is no longer visible under
+    ~/.claude/<kind>/, while the staged tree it pointed at survives untouched
+    as the single source of truth."""
+    # unlink drops the symlink itself, never following it, so the staged target
+    # is left in place — the inverse of link_unit's symlink_to.
+    link_path.unlink()

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -9,6 +9,16 @@ from catalog import Unit
 _BACKUP_SUFFIX: Final[str] = ".bak"
 
 
+def _remove_staged_entry(path: Path) -> None:
+    """Drop a staged entry without the caller minding its shape — a unit stages
+    as a directory tree (skill) or a single file (agent/rule), and an absent path
+    is a quiet no-op so re-staging and unstaging share one removal decision."""
+    if path.is_dir():
+        shutil.rmtree(path)
+    elif path.exists():
+        path.unlink()
+
+
 def stage_unit(*, unit: Unit, source: Path, staged_root: Path) -> Path:
     """Lay a unit out under "<kind>/<name>" in a staging area first, so the real
     install can swap a fully-built tree into place instead of writing live."""
@@ -16,10 +26,7 @@ def stage_unit(*, unit: Unit, source: Path, staged_root: Path) -> Path:
     destination.parent.mkdir(parents=True, exist_ok=True)
     # Clear any prior staging of this unit so a re-stage fully supersedes it,
     # leaving no stale files behind, rather than colliding with the old tree.
-    if destination.is_dir():
-        shutil.rmtree(destination)
-    elif destination.exists():
-        destination.unlink()
+    _remove_staged_entry(destination)
     # copy2 (not copyfile) carries the source's mode across, so an executable
     # hook script stays executable once staged — matching copytree below.
     if source.is_dir():
@@ -27,6 +34,14 @@ def stage_unit(*, unit: Unit, source: Path, staged_root: Path) -> Path:
     else:
         shutil.copy2(source, destination)
     return destination
+
+
+def unstage_unit(*, unit: Unit, staged_root: Path) -> None:
+    """Tear down a unit's staged entry at "<kind>/<name>" so the staging area no
+    longer holds it — the inverse of stage_unit, dropping either the directory
+    tree or the single file it laid down."""
+    staged_path: Path = staged_root / unit.kind / unit.name
+    _remove_staged_entry(staged_path)
 
 
 def link_unit(*, staged_path: Path, link_path: Path) -> Path:

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from actions import install_skill
+from actions import install_skill, uninstall_skill
 from catalog import skill_unit_id
 from state import State, load_state
 
@@ -62,3 +62,34 @@ def test_install_skill_records_and_persists_installed_unit(tmp_path: Path) -> No
     assert unit_id in result.units
     assert unit_id in load_state(state_root).units
     assert initial_state.units == {}
+
+
+def test_uninstall_skill_undoes_install_and_forgets_unit(tmp_path: Path) -> None:
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "demo-skill"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text("# Demo Skill\n", encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    installed_state: State = install_skill(
+        name="demo-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    result: State = uninstall_skill(
+        name="demo-skill",
+        state_root=state_root,
+        claude_root=claude_root,
+        state=installed_state,
+    )
+
+    unit_id: str = skill_unit_id("demo-skill")
+    assert not (claude_root / "skills" / "demo-skill").is_symlink()
+    assert not (state_root / "staged" / "skill" / "demo-skill").exists()
+    assert unit_id not in result.units
+    assert unit_id not in load_state(state_root).units
+    assert unit_id in installed_state.units

--- a/installer/tests/test_placement.py
+++ b/installer/tests/test_placement.py
@@ -3,7 +3,7 @@ import stat
 from pathlib import Path
 
 from catalog import Unit
-from placement import link_unit, stage_unit, unlink_unit
+from placement import link_unit, stage_unit, unlink_unit, unstage_unit
 
 
 def test_stage_unit_copies_single_file_to_kind_name_destination(tmp_path: Path) -> None:
@@ -178,6 +178,31 @@ def test_unlink_unit_leaves_real_non_symlink_file_untouched(tmp_path: Path) -> N
     assert link_path.is_file()
     assert not link_path.is_symlink()
     assert link_path.read_text(encoding="utf-8") == user_content
+
+
+def test_unstage_unit_removes_staged_entry_for_both_tree_and_file_shapes(
+    tmp_path: Path,
+) -> None:
+    staged_root: Path = tmp_path / "staged"
+
+    skill: Unit = Unit(kind="skill", name="make-pr")
+    skill_path: Path = staged_root / skill.kind / skill.name
+    (skill_path / "schemas").mkdir(parents=True)
+    (skill_path / "SKILL.md").write_text("# Make PR\n", encoding="utf-8")
+    (skill_path / "schemas" / "x.json").write_text(
+        '{"type": "object"}\n', encoding="utf-8"
+    )
+
+    agent: Unit = Unit(kind="agent", name="reviewer")
+    agent_path: Path = staged_root / agent.kind / agent.name
+    agent_path.parent.mkdir(parents=True)
+    agent_path.write_text("# Reviewer\n", encoding="utf-8")
+
+    unstage_unit(unit=skill, staged_root=staged_root)
+    unstage_unit(unit=agent, staged_root=staged_root)
+
+    assert not skill_path.exists()
+    assert not agent_path.exists()
 
 
 def test_unlink_unit_restores_displaced_backup_over_removed_symlink(

--- a/installer/tests/test_placement.py
+++ b/installer/tests/test_placement.py
@@ -165,3 +165,26 @@ def test_unlink_unit_removes_live_symlink_and_leaves_staged_target_intact(
     assert not link_path.exists()
     assert staged_path.is_dir()
     assert (staged_path / "SKILL.md").read_text(encoding="utf-8") == content
+
+
+def test_unlink_unit_restores_displaced_backup_over_removed_symlink(
+    tmp_path: Path,
+) -> None:
+    staged_content: str = "# Make PR\n\nOurs.\n"
+    staged_path: Path = tmp_path / "at" / "skill" / "make-pr.md"
+    staged_path.parent.mkdir(parents=True)
+    staged_path.write_text(staged_content, encoding="utf-8")
+
+    user_content: str = "user's own data\n"
+    link_path: Path = tmp_path / "claude" / "commands" / "make-pr.md"
+    link_path.parent.mkdir(parents=True)
+    link_path.write_text(user_content, encoding="utf-8")
+    link_unit(staged_path=staged_path, link_path=link_path)
+
+    unlink_unit(link_path=link_path)
+
+    backup_path: Path = link_path.with_name(link_path.name + ".bak")
+    assert link_path.is_file()
+    assert not link_path.is_symlink()
+    assert link_path.read_text(encoding="utf-8") == user_content
+    assert not backup_path.exists()

--- a/installer/tests/test_placement.py
+++ b/installer/tests/test_placement.py
@@ -3,7 +3,7 @@ import stat
 from pathlib import Path
 
 from catalog import Unit
-from placement import link_unit, stage_unit
+from placement import link_unit, stage_unit, unlink_unit
 
 
 def test_stage_unit_copies_single_file_to_kind_name_destination(tmp_path: Path) -> None:
@@ -147,3 +147,21 @@ def test_link_unit_backs_up_existing_real_file_before_linking(tmp_path: Path) ->
     assert backup_path.exists()
     assert not backup_path.is_symlink()
     assert backup_path.read_text(encoding="utf-8") == user_content
+
+
+def test_unlink_unit_removes_live_symlink_and_leaves_staged_target_intact(
+    tmp_path: Path,
+) -> None:
+    content: str = "# Make PR\n\nOpens a pull request.\n"
+    staged_path: Path = tmp_path / "at" / "skill" / "make-pr"
+    staged_path.mkdir(parents=True)
+    (staged_path / "SKILL.md").write_text(content, encoding="utf-8")
+    link_path: Path = tmp_path / "claude" / "skills" / "make-pr"
+    link_unit(staged_path=staged_path, link_path=link_path)
+
+    unlink_unit(link_path=link_path)
+
+    assert not link_path.is_symlink()
+    assert not link_path.exists()
+    assert staged_path.is_dir()
+    assert (staged_path / "SKILL.md").read_text(encoding="utf-8") == content

--- a/installer/tests/test_placement.py
+++ b/installer/tests/test_placement.py
@@ -167,6 +167,19 @@ def test_unlink_unit_removes_live_symlink_and_leaves_staged_target_intact(
     assert (staged_path / "SKILL.md").read_text(encoding="utf-8") == content
 
 
+def test_unlink_unit_leaves_real_non_symlink_file_untouched(tmp_path: Path) -> None:
+    user_content: str = "user's own data\n"
+    link_path: Path = tmp_path / "claude" / "commands" / "make-pr.md"
+    link_path.parent.mkdir(parents=True)
+    link_path.write_text(user_content, encoding="utf-8")
+
+    unlink_unit(link_path=link_path)
+
+    assert link_path.is_file()
+    assert not link_path.is_symlink()
+    assert link_path.read_text(encoding="utf-8") == user_content
+
+
 def test_unlink_unit_restores_displaced_backup_over_removed_symlink(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Part of #74 — slice 3 (Uninstall a skill), PR 3.1.

## What

The destructive inverse of the slice-2 placement primitives, plus the uninstall action:

- **`unlink_unit(*, link_path)`** (`installer/placement.py`) — removes our live symlink. If linking had displaced the user's real file to `<name>.bak`, that backup is restored over the freed path. A real (non-symlink) entry is the user's own data and survives the call untouched — the primitive only ever removes symlinks.
- **`unstage_unit(*, unit, staged_root)`** (`installer/placement.py`) — removes the staged entry at `staged/<kind>/<name>`, whether a directory tree (skill) or a single file (agent/rule). The dir/file removal branch `stage_unit` already carried for re-staging is now a shared `_remove_staged_entry` helper, so staging and unstaging share one removal decision (absence is a quiet no-op).
- **`uninstall_skill(*, name, state_root, claude_root, state)`** (`installer/actions.py`) — composes unlink + unstage, drops the skill's unit id, persists via `save_state`, and returns a new immutable `State` (input never mutated) — the exact mirror of `install_skill`.

## How it was built

Strict TDD: 4 RED/GREEN cycles (symlink removal · `.bak` restore · real-entry safety · unstage both shapes) plus an end-to-end uninstall cycle; every RED verified failing for the right reason, every GREEN reproduced independently. One logged TDD skip: "unstage of a missing entry" was already a no-op after the minimal unstage implementation, so no failing test was constructible.

Gates green in `installer/`: `ruff format --check`, `ruff check`, `mypy --strict`, `pytest -W error` (33 passed, up from 28 at base; `placement.py` at 100% branch coverage). Reviewer: zero findings. Critic: achieved, no gaps.

Sets up 3.2 (declarative reconcile — untick to remove in the Skills tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
