### PR TITLE
feat(installer): declarative reconcile for the Skills tab (PR 3.2)

### DIFF
--- a/installer/at.py
+++ b/installer/at.py
@@ -90,8 +90,13 @@ def launch_tui() -> int:
                 state: State = load_state(STATE_ROOT)
                 for row in skill_rows(catalog=catalog, state=state):
                     console.print(row, markup=False)
+                installed: frozenset[str] = frozenset(state.units)
+                choices: list[questionary.Choice] = [
+                    questionary.Choice(name, checked=skill_unit_id(name) in installed)
+                    for name in list_skills(catalog)
+                ]
                 ticked: list[str] | None = questionary.checkbox(
-                    "Select installed skills", choices=list_skills(catalog)
+                    "Select installed skills", choices=choices
                 ).ask()
                 if ticked is None:
                     continue

--- a/installer/at.py
+++ b/installer/at.py
@@ -98,6 +98,8 @@ def launch_tui() -> int:
                 plan: ReconcilePlan = plan_skill_reconcile(
                     ticked=frozenset(ticked), catalog=catalog, state=state
                 )
+                if plan.is_empty:
+                    continue
                 confirmed: bool | None = questionary.confirm(
                     "Apply skill changes?"
                 ).ask()

--- a/installer/at.py
+++ b/installer/at.py
@@ -98,8 +98,11 @@ def launch_tui() -> int:
                 plan: ReconcilePlan = plan_skill_reconcile(
                     ticked=frozenset(ticked), catalog=catalog, state=state
                 )
-                # Confirm is shown now; gating apply on the answer is a later slice.
-                questionary.confirm("Apply skill changes?").ask()
+                confirmed: bool | None = questionary.confirm(
+                    "Apply skill changes?"
+                ).ask()
+                if not confirmed:
+                    continue
                 state = apply_skill_reconcile(
                     plan=plan,
                     source_root=REPO_ROOT,

--- a/installer/at.py
+++ b/installer/at.py
@@ -11,8 +11,8 @@ import questionary
 from rich.console import Console
 from rich.panel import Panel
 
-from actions import install_skill
 from catalog import Catalog, list_skills, load_catalog, skill_unit_id
+from reconcile import ReconcilePlan, apply_skill_reconcile, plan_skill_reconcile
 from state import State, load_state
 
 AT_VERSION: Final[str] = "0.2.0"
@@ -23,8 +23,6 @@ STATE_ROOT: Final[Path] = Path.home() / ".claude" / "at"
 REPO_ROOT: Final[Path] = Path(__file__).parent.parent
 # Live link root where installs go; kept separate from STATE_ROOT so tests can pin each.
 CLAUDE_ROOT: Final[Path] = Path.home() / ".claude"
-# Sentinel choice that leaves the install picker and returns to the tab menu.
-BACK_CHOICE: Final[str] = "← Back"
 
 MARKER_INSTALLED: Final[str] = "✅"
 MARKER_NOT_INSTALLED: Final[str] = "❌"
@@ -92,29 +90,25 @@ def launch_tui() -> int:
                 state: State = load_state(STATE_ROOT)
                 for row in skill_rows(catalog=catalog, state=state):
                     console.print(row, markup=False)
-                installed: frozenset[str] = frozenset(state.units)
-                installable: list[str] = [
-                    name
-                    for name in list_skills(catalog)
-                    if skill_unit_id(name) not in installed
-                ]
-                if not installable:
-                    continue
-                pick: str | None = questionary.select(
-                    "Install which skill?", choices=[*installable, BACK_CHOICE]
+                ticked: list[str] | None = questionary.checkbox(
+                    "Select installed skills", choices=list_skills(catalog)
                 ).ask()
-                if pick is None or pick == BACK_CHOICE:
+                if ticked is None:
                     continue
-                if questionary.confirm(f"Install {pick}?").ask():
-                    state = install_skill(
-                        name=pick,
-                        source_root=REPO_ROOT,
-                        state_root=STATE_ROOT,
-                        claude_root=CLAUDE_ROOT,
-                        state=state,
-                    )
-                    for row in skill_rows(catalog=catalog, state=state):
-                        console.print(row, markup=False)
+                plan: ReconcilePlan = plan_skill_reconcile(
+                    ticked=frozenset(ticked), catalog=catalog, state=state
+                )
+                # Confirm is shown now; gating apply on the answer is a later slice.
+                questionary.confirm("Apply skill changes?").ask()
+                state = apply_skill_reconcile(
+                    plan=plan,
+                    source_root=REPO_ROOT,
+                    state_root=STATE_ROOT,
+                    claude_root=CLAUDE_ROOT,
+                    state=state,
+                )
+                for row in skill_rows(catalog=catalog, state=state):
+                    console.print(row, markup=False)
                 continue
             console.print(TAB_PLACEHOLDER)
     except KeyboardInterrupt:

--- a/installer/pyproject.toml
+++ b/installer/pyproject.toml
@@ -35,7 +35,7 @@ pythonpath = ["."]  # rootdir is installer/, so tests import the module under te
 # Coverage is a diagnostic (term-missing), never a gate target — a 100% mandate just
 # manufactures tests to paint branches green. Test behaviour, then read coverage to spot
 # a genuinely untested path; don't write a test solely to colour a line.
-addopts = ["--cov=at", "--cov=state", "--cov=catalog", "--cov=placement", "--cov-report=term-missing"]
+addopts = ["--cov=at", "--cov=state", "--cov=catalog", "--cov=placement", "--cov=reconcile", "--cov-report=term-missing"]
 filterwarnings = ["error"]
 
 [tool.coverage.run]

--- a/installer/reconcile.py
+++ b/installer/reconcile.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
+from pathlib import Path
 
+from actions import install_skill, uninstall_skill
 from catalog import Catalog, list_skills, skill_unit_id
 from state import State
 
@@ -29,3 +31,32 @@ def plan_skill_reconcile(
         name for name in skills if name in installed and name not in ticked
     )
     return ReconcilePlan(to_install=to_install, to_remove=to_remove)
+
+
+def apply_skill_reconcile(
+    *,
+    plan: ReconcilePlan,
+    source_root: Path,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Carry out a planned diff by installing then uninstalling each named skill,
+    threading the persisted State through so the final return reflects every action."""
+    current: State = state
+    for name in plan.to_install:
+        current = install_skill(
+            name=name,
+            source_root=source_root,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=current,
+        )
+    for name in plan.to_remove:
+        current = uninstall_skill(
+            name=name,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=current,
+        )
+    return current

--- a/installer/reconcile.py
+++ b/installer/reconcile.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+from catalog import Catalog, list_skills, skill_unit_id
+from state import State
+
+
+@dataclass(frozen=True)
+class ReconcilePlan:
+    """The decided skill diff for one reconcile run, each side sorted so applying
+    it is deterministic and the plan reads the same as it runs."""
+
+    to_install: tuple[str, ...]
+    to_remove: tuple[str, ...]
+
+
+def plan_skill_reconcile(
+    *, ticked: frozenset[str], catalog: Catalog, state: State
+) -> ReconcilePlan:
+    """Diff the ticked selection against installed state over the catalog's skills,
+    so the apply step works from a decided plan instead of re-deriving the diff."""
+    skills: list[str] = list_skills(catalog)
+    installed: set[str] = {
+        name for name in skills if skill_unit_id(name) in state.units
+    }
+    to_install: tuple[str, ...] = tuple(
+        name for name in skills if name in ticked and name not in installed
+    )
+    to_remove: tuple[str, ...] = tuple(
+        name for name in skills if name in installed and name not in ticked
+    )
+    return ReconcilePlan(to_install=to_install, to_remove=to_remove)

--- a/installer/reconcile.py
+++ b/installer/reconcile.py
@@ -14,6 +14,11 @@ class ReconcilePlan:
     to_install: tuple[str, ...]
     to_remove: tuple[str, ...]
 
+    @property
+    def is_empty(self) -> bool:
+        """A no-op plan lets callers skip the confirm/apply step: nothing to confirm."""
+        return not self.to_install and not self.to_remove
+
 
 def plan_skill_reconcile(
     *, ticked: frozenset[str], catalog: Catalog, state: State

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -270,3 +270,77 @@ def test_skills_tab_declining_confirm_leaves_install_state_untouched(
     assert not demo_b_link.exists() and not demo_b_link.is_symlink()
     assert not demo_b_staging.exists()
     assert skill_unit_id("demo-b") not in final_state.units
+
+
+def test_skills_tab_unchanged_selection_asks_no_confirm_and_changes_nothing(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # Real sources for both skills exist, but only demo-a is installed up front.
+    for name in ("demo-a", "demo-b"):
+        source: Path = repo_root / "skills" / name / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(f"# {name}\n", encoding="utf-8")
+    install_skill(
+        name="demo-a",
+        source_root=repo_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=load_state(state_root),
+    )
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-a"\n\n'
+        '[[units]]\nkind = "skill"\nname = "demo-b"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    # The tab menu opens the Skills tab, then closes it after the no-op reconcile.
+    select_answers: Iterator[str] = iter(["Skills", "Exit"])
+
+    class FakeSelect:
+        def ask(self) -> str:
+            return next(select_answers)
+
+    # Ticking exactly the installed set leaves the plan empty: nothing to reconcile.
+    class FakeCheckbox:
+        def ask(self) -> list[str]:
+            return ["demo-a"]
+
+    # Reaching the confirm prompt at all is the failure: an unchanged selection must
+    # short-circuit before any confirmation is asked.
+    class ConfirmForbidden:
+        def ask(self) -> bool:
+            raise AssertionError(
+                "no confirmation should be asked for an unchanged selection"
+            )
+
+    monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakeSelect())
+    monkeypatch.setattr("questionary.checkbox", lambda *args, **kwargs: FakeCheckbox())
+    monkeypatch.setattr(
+        "questionary.confirm", lambda *args, **kwargs: ConfirmForbidden()
+    )
+
+    exit_code: int = main(["install"])
+
+    final_state: State = load_state(state_root)
+    demo_a_link: Path = claude_root / "skills" / "demo-a"
+    demo_a_staging: Path = state_root / "staged" / "skill" / "demo-a"
+    demo_b_link: Path = claude_root / "skills" / "demo-b"
+    demo_b_staging: Path = state_root / "staged" / "skill" / "demo-b"
+    assert exit_code == 0
+    assert demo_a_link.is_symlink()
+    assert demo_a_staging.exists()
+    assert skill_unit_id("demo-a") in final_state.units
+    assert not demo_b_link.exists() and not demo_b_link.is_symlink()
+    assert not demo_b_staging.exists()
+    assert skill_unit_id("demo-b") not in final_state.units

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
 
-import at
+from actions import install_skill
 from at import (
     MARKER_INSTALLED,
     MARKER_NOT_INSTALLED,
@@ -106,19 +106,24 @@ def test_skills_tab_renders_skill_rows_instead_of_placeholder(
         encoding="utf-8",
     )
     monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
-    # Entering the Skills tab now leads to an install-picker select; pick the
-    # Back sentinel so this read-only test installs nothing and falls through.
-    answers: Iterator[str] = iter(["Skills", at.BACK_CHOICE, "Exit"])
+    # Enter the Skills tab, then close it; the empty tick set is an unchanged
+    # selection, so this read-only test installs nothing and falls through.
+    answers: Iterator[str] = iter(["Skills", "Exit"])
 
     class FakePrompt:
         def ask(self) -> str:
             return next(answers)
+
+    class FakeCheckbox:
+        def ask(self) -> list[str]:
+            return []
 
     class DeclinePrompt:
         def ask(self) -> bool:
             return False
 
     monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakePrompt())
+    monkeypatch.setattr("questionary.checkbox", lambda *args, **kwargs: FakeCheckbox())
     monkeypatch.setattr("questionary.confirm", lambda *args, **kwargs: DeclinePrompt())
 
     exit_code: int = main(["install"])
@@ -129,87 +134,69 @@ def test_skills_tab_renders_skill_rows_instead_of_placeholder(
     assert TAB_PLACEHOLDER not in captured
 
 
-def test_skills_tab_install_picker_marks_chosen_skill_installed(
-    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+def test_skills_tab_unticking_skill_removes_it_while_ticked_stays_installed(
+    monkeypatch: MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-    monkeypatch.setattr("at.STATE_ROOT", tmp_path / "at")
-    monkeypatch.setattr("at.CLAUDE_ROOT", tmp_path / "claude")
-    monkeypatch.setattr("at.REPO_ROOT", tmp_path / "repo")
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
 
-    source_skill: Path = tmp_path / "repo" / "skills" / "demo-skill" / "SKILL.md"
-    source_skill.parent.mkdir(parents=True)
-    source_skill.write_text("# demo skill\n", encoding="utf-8")
+    # Pre-install both skills through the real public install action, so on-disk
+    # state, staging, and live symlinks all exist before the reconcile runs.
+    state: State = load_state(state_root)
+    for name in ("demo-a", "demo-b"):
+        source: Path = repo_root / "skills" / name / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(f"# {name}\n", encoding="utf-8")
+        state = install_skill(
+            name=name,
+            source_root=repo_root,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=state,
+        )
 
     catalog_file: Path = tmp_path / "catalog.toml"
     catalog_file.write_text(
         "packages = []\nbundles = []\n\n"
-        '[[units]]\nkind = "skill"\nname = "demo-skill"\n',
+        '[[units]]\nkind = "skill"\nname = "demo-a"\n\n'
+        '[[units]]\nkind = "skill"\nname = "demo-b"\n',
         encoding="utf-8",
     )
     monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
-    # Tab menu, then the install-picker pick, then the tab menu again to exit.
-    select_answers: Iterator[str] = iter(["Skills", "demo-skill", "Exit"])
+    # The tab menu opens the Skills tab, then closes it after the reconcile.
+    select_answers: Iterator[str] = iter(["Skills", "Exit"])
 
     class FakeSelect:
         def ask(self) -> str:
             return next(select_answers)
+
+    # demo-a is left unticked; only demo-b stays in the desired set.
+    class FakeCheckbox:
+        def ask(self) -> list[str]:
+            return ["demo-b"]
 
     class ConfirmPrompt:
         def ask(self) -> bool:
             return True
 
     monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakeSelect())
+    monkeypatch.setattr("questionary.checkbox", lambda *args, **kwargs: FakeCheckbox())
     monkeypatch.setattr("questionary.confirm", lambda *args, **kwargs: ConfirmPrompt())
 
     exit_code: int = main(["install"])
 
-    captured: str = capsys.readouterr().out
+    final_state: State = load_state(state_root)
+    demo_a_link: Path = claude_root / "skills" / "demo-a"
+    demo_a_staging: Path = state_root / "staged" / "skill" / "demo-a"
+    demo_b_link: Path = claude_root / "skills" / "demo-b"
     assert exit_code == 0
-    assert f"{MARKER_INSTALLED} demo-skill" in captured
-    assert (tmp_path / "claude" / "skills" / "demo-skill").is_symlink()
-
-
-def test_skills_tab_declining_install_confirmation_installs_nothing(
-    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
-) -> None:
-    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-    monkeypatch.setattr("at.STATE_ROOT", tmp_path / "at")
-    monkeypatch.setattr("at.CLAUDE_ROOT", tmp_path / "claude")
-    monkeypatch.setattr("at.REPO_ROOT", tmp_path / "repo")
-
-    source_skill: Path = tmp_path / "repo" / "skills" / "demo-skill" / "SKILL.md"
-    source_skill.parent.mkdir(parents=True)
-    source_skill.write_text("# demo skill\n", encoding="utf-8")
-
-    catalog_file: Path = tmp_path / "catalog.toml"
-    catalog_file.write_text(
-        "packages = []\nbundles = []\n\n"
-        '[[units]]\nkind = "skill"\nname = "demo-skill"\n',
-        encoding="utf-8",
-    )
-    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
-    # Tab menu, then pick the skill at the install picker, then exit the tab menu.
-    select_answers: Iterator[str] = iter(["Skills", "demo-skill", "Exit"])
-
-    class FakeSelect:
-        def ask(self) -> str:
-            return next(select_answers)
-
-    # The confirm gate is declined, so the install must be a true no-op.
-    class DeclinePrompt:
-        def ask(self) -> bool:
-            return False
-
-    monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakeSelect())
-    monkeypatch.setattr("questionary.confirm", lambda *args, **kwargs: DeclinePrompt())
-
-    exit_code: int = main(["install"])
-
-    captured: str = capsys.readouterr().out
-    live_link: Path = tmp_path / "claude" / "skills" / "demo-skill"
-    final_state: State = load_state(tmp_path / "at")
-    assert exit_code == 0
-    assert not live_link.exists() and not live_link.is_symlink()
-    assert skill_unit_id("demo-skill") not in final_state.units
-    assert f"{MARKER_NOT_INSTALLED} demo-skill" in captured
+    assert not demo_a_link.exists() and not demo_a_link.is_symlink()
+    assert not demo_a_staging.exists()
+    assert skill_unit_id("demo-a") not in final_state.units
+    assert demo_b_link.is_symlink()
+    assert skill_unit_id("demo-b") in final_state.units

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -200,3 +200,73 @@ def test_skills_tab_unticking_skill_removes_it_while_ticked_stays_installed(
     assert skill_unit_id("demo-a") not in final_state.units
     assert demo_b_link.is_symlink()
     assert skill_unit_id("demo-b") in final_state.units
+
+
+def test_skills_tab_declining_confirm_leaves_install_state_untouched(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # Real sources for both skills exist, but only demo-a is installed up front, so
+    # the declined reconcile must neither remove demo-a nor add demo-b.
+    for name in ("demo-a", "demo-b"):
+        source: Path = repo_root / "skills" / name / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(f"# {name}\n", encoding="utf-8")
+    install_skill(
+        name="demo-a",
+        source_root=repo_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=load_state(state_root),
+    )
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-a"\n\n'
+        '[[units]]\nkind = "skill"\nname = "demo-b"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    # The tab menu opens the Skills tab, then closes it after the declined reconcile.
+    select_answers: Iterator[str] = iter(["Skills", "Exit"])
+
+    class FakeSelect:
+        def ask(self) -> str:
+            return next(select_answers)
+
+    # A both-directions change: untick installed demo-a and tick uninstalled demo-b.
+    class FakeCheckbox:
+        def ask(self) -> list[str]:
+            return ["demo-b"]
+
+    # Declining the confirm must gate the apply: the selection change is discarded.
+    class DeclinePrompt:
+        def ask(self) -> bool:
+            return False
+
+    monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakeSelect())
+    monkeypatch.setattr("questionary.checkbox", lambda *args, **kwargs: FakeCheckbox())
+    monkeypatch.setattr("questionary.confirm", lambda *args, **kwargs: DeclinePrompt())
+
+    exit_code: int = main(["install"])
+
+    final_state: State = load_state(state_root)
+    demo_a_link: Path = claude_root / "skills" / "demo-a"
+    demo_a_staging: Path = state_root / "staged" / "skill" / "demo-a"
+    demo_b_link: Path = claude_root / "skills" / "demo-b"
+    demo_b_staging: Path = state_root / "staged" / "skill" / "demo-b"
+    assert exit_code == 0
+    assert demo_a_link.is_symlink()
+    assert demo_a_staging.exists()
+    assert skill_unit_id("demo-a") in final_state.units
+    assert not demo_b_link.exists() and not demo_b_link.is_symlink()
+    assert not demo_b_staging.exists()
+    assert skill_unit_id("demo-b") not in final_state.units

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -344,3 +344,78 @@ def test_skills_tab_unchanged_selection_asks_no_confirm_and_changes_nothing(
     assert not demo_b_link.exists() and not demo_b_link.is_symlink()
     assert not demo_b_staging.exists()
     assert skill_unit_id("demo-b") not in final_state.units
+
+
+def test_skills_tab_checkbox_pre_ticks_installed_skills_and_cancel_is_noop(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # Real sources for both skills exist, but only demo-a is installed up front, so
+    # the checkbox must offer demo-a pre-ticked and demo-b unticked.
+    for name in ("demo-a", "demo-b"):
+        source: Path = repo_root / "skills" / name / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(f"# {name}\n", encoding="utf-8")
+    install_skill(
+        name="demo-a",
+        source_root=repo_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=load_state(state_root),
+    )
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-a"\n\n'
+        '[[units]]\nkind = "skill"\nname = "demo-b"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    # The tab menu opens the Skills tab, then closes it after the cancelled prompt.
+    select_answers: Iterator[str] = iter(["Skills", "Exit"])
+
+    class FakeSelect:
+        def ask(self) -> str:
+            return next(select_answers)
+
+    # Capture whatever choices the checkbox is offered (the message is positional, so
+    # choices may arrive positionally or by keyword), then cancel with a None answer.
+    captured_choices: list[object] = []
+
+    class CancellingCheckbox:
+        def ask(self) -> None:
+            return None
+
+    def capture_checkbox(*args: object, **kwargs: object) -> CancellingCheckbox:
+        choices: object = kwargs.get("choices") if "choices" in kwargs else args[1]
+        assert isinstance(choices, list)
+        captured_choices.extend(choices)
+        return CancellingCheckbox()
+
+    monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakeSelect())
+    monkeypatch.setattr("questionary.checkbox", capture_checkbox)
+
+    exit_code: int = main(["install"])
+
+    # Normalise bare strings and questionary.Choice objects alike: a plain string has
+    # no .checked, so today's string choices read as unticked and fail this assertion.
+    presented: list[tuple[object, object]] = [
+        (getattr(c, "title", c), getattr(c, "checked", False)) for c in captured_choices
+    ]
+    final_state: State = load_state(state_root)
+    demo_a_link: Path = claude_root / "skills" / "demo-a"
+    demo_b_link: Path = claude_root / "skills" / "demo-b"
+    assert exit_code == 0
+    assert presented == [("demo-a", True), ("demo-b", False)]
+    assert demo_a_link.is_symlink()
+    assert skill_unit_id("demo-a") in final_state.units
+    assert not demo_b_link.exists() and not demo_b_link.is_symlink()
+    assert skill_unit_id("demo-b") not in final_state.units

--- a/installer/tests/test_reconcile.py
+++ b/installer/tests/test_reconcile.py
@@ -1,0 +1,24 @@
+from catalog import Catalog, Unit
+from reconcile import ReconcilePlan, plan_skill_reconcile
+from state import State
+
+
+def test_plan_classifies_skills_by_tick_against_installed_state() -> None:
+    catalog: Catalog = Catalog(
+        units=(
+            Unit(kind="skill", name="alpha"),
+            Unit(kind="skill", name="beta"),
+            Unit(kind="skill", name="gamma"),
+        ),
+        packages=(),
+        bundles=(),
+    )
+    state: State = State(version=1, units={"skill/beta": "hash", "skill/gamma": "hash"})
+    ticked: frozenset[str] = frozenset({"alpha", "gamma"})
+
+    plan: ReconcilePlan = plan_skill_reconcile(
+        ticked=ticked, catalog=catalog, state=state
+    )
+
+    assert plan.to_install == ("alpha",)
+    assert plan.to_remove == ("beta",)

--- a/installer/tests/test_reconcile.py
+++ b/installer/tests/test_reconcile.py
@@ -1,6 +1,9 @@
-from catalog import Catalog, Unit
-from reconcile import ReconcilePlan, plan_skill_reconcile
-from state import State
+from pathlib import Path
+
+from actions import install_skill
+from catalog import Catalog, Unit, skill_unit_id
+from reconcile import ReconcilePlan, apply_skill_reconcile, plan_skill_reconcile
+from state import State, load_state
 
 
 def test_plan_classifies_skills_by_tick_against_installed_state() -> None:
@@ -22,3 +25,48 @@ def test_plan_classifies_skills_by_tick_against_installed_state() -> None:
 
     assert plan.to_install == ("alpha",)
     assert plan.to_remove == ("beta",)
+
+
+def test_apply_installs_planned_skills_and_uninstalls_removed_ones(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    for name in ("old-skill", "new-skill"):
+        skill_source: Path = source_root / "skills" / name
+        skill_source.mkdir(parents=True)
+        (skill_source / "SKILL.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    installed_state: State = install_skill(
+        name="old-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    plan: ReconcilePlan = ReconcilePlan(
+        to_install=("new-skill",), to_remove=("old-skill",)
+    )
+    result: State = apply_skill_reconcile(
+        plan=plan,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=installed_state,
+    )
+
+    persisted: State = load_state(state_root)
+    new_id: str = skill_unit_id("new-skill")
+    old_id: str = skill_unit_id("old-skill")
+
+    assert (claude_root / "skills" / "new-skill").is_symlink()
+    assert (state_root / "staged" / "skill" / "new-skill").is_dir()
+    assert new_id in result.units
+    assert new_id in persisted.units
+
+    assert not (claude_root / "skills" / "old-skill").is_symlink()
+    assert not (state_root / "staged" / "skill" / "old-skill").exists()
+    assert old_id not in result.units
+    assert old_id not in persisted.units


### PR DESCRIPTION
Part of #74 (slice 3, PR 3.2). Built with the architect workflow: six live-RED TDD cycles, then gates → reviewer → critic.

## What

The Skills tab becomes declarative. It shows a checkbox of every catalog skill with installed ones pre-ticked; tick to install, untick to remove. The diff of your ticks against `state.json` becomes a plan (to-install / to-remove) that is applied only after an explicit confirmation. Unchanged or cancelled selections are true no-ops and ask nothing.

- New `installer/reconcile.py`: frozen `ReconcilePlan` (+ `is_empty`), `plan_skill_reconcile()` (pure diff over the catalog skill universe), `apply_skill_reconcile()` (composes the existing `install_skill`/`uninstall_skill` actions, threads + persists `State`).
- `installer/at.py`: the select-style install picker is replaced by the checkbox → plan → confirm → apply flow; `BACK_CHOICE` and the picker block are gone.

## Behaviors (each RED→GREEN, one commit per cycle)

| Behavior | Test |
|---|---|
| Plan classifies ticked-not-installed → install, installed-unticked → remove | `test_reconcile.py::test_plan_classifies_skills_by_tick_against_installed_state` |
| Applying a plan makes disk + persisted state match it | `test_reconcile.py::test_apply_installs_planned_skills_and_uninstalls_removed_ones` |
| Untick + confirm removes; ticked stays installed | `test_at.py::test_skills_tab_unticking_skill_removes_it_while_ticked_stays_installed` |
| Declined confirmation is a true no-op | `test_at.py::test_skills_tab_declining_confirm_leaves_install_state_untouched` |
| Unchanged selection asks no confirmation, changes nothing | `test_at.py::test_skills_tab_unchanged_selection_asks_no_confirm_and_changes_nothing` |
| Checkbox pre-ticks installed skills; cancel is safe | `test_at.py::test_skills_tab_checkbox_pre_ticks_installed_skills_and_cancel_is_noop` |

“Tick installs” through the TUI rides the same checkbox→plan→apply path the untick test exercises end-to-end; its classification and application are pinned by the two reconcile tests (fewest-tests-that-pin).

Three tests pinning the superseded select-picker flow were deleted/adapted under a logged architect authorization; their surviving concerns (decline no-op, row rendering) are re-pinned against the new flow.

## Verification

- Gates green in `installer/`: `ruff format --check`, `ruff check`, `mypy --strict`, `pytest -W error` → **37 passed**.
- Reviewer: score 85, no CRITICAL; three MINOR nits left as follow-ups (installed-ness predicate repeated in three places, a comment claiming a sortedness invariant the type doesn't enforce, checkbox prompt wording).
- Critic: **achieved** (89), zero gaps.
- Full run log: `.v1-runs/feat_installer-reconcile-3.2.jsonl` (19 rows, includes the two retried dispatches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)