### PR TITLE
feat(installer): content hashing + drift detection (PR 4.1)

### DIFF
--- a/installer/actions.py
+++ b/installer/actions.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Final
 
 from catalog import skill_unit, skill_unit_id
+from hashing import hash_unit
 from placement import link_unit, stage_unit, unlink_unit, unstage_unit
 from state import State, save_state
 
@@ -13,10 +14,6 @@ from state import State, save_state
 # "<claude>/skills/<name>", matching ~/.claude's per-kind directories.
 _STAGED_DIRNAME: Final[str] = "staged"
 _SKILLS_DIRNAME: Final[str] = "skills"
-
-# content hash is recorded in the update slice (4.1); presence of the unit id is
-# what marks a skill "installed" today, so the value is a deliberate placeholder.
-_UNHASHED: Final[str] = ""
 
 
 def install_skill(
@@ -37,9 +34,10 @@ def install_skill(
         unit=skill_unit(name), source=source, staged_root=state_root / _STAGED_DIRNAME
     )
     link_unit(staged_path=staged_path, link_path=claude_root / _SKILLS_DIRNAME / name)
+    content_hash: str = hash_unit(staged_path)
     new_state: State = State(
         version=state.version,
-        units={**state.units, skill_unit_id(name): _UNHASHED},
+        units={**state.units, skill_unit_id(name): content_hash},
     )
     save_state(new_state, state_root)
     return new_state

--- a/installer/hashing.py
+++ b/installer/hashing.py
@@ -8,9 +8,14 @@ def hash_unit(path: Path) -> str:
     whether the file on disk still matches what was installed."""
     if not path.is_dir():
         return hashlib.sha256(path.read_bytes()).hexdigest()
-    # Bind each file's content to its relative path, sorted so the digest is
-    # independent of traversal order and changes when bytes move to a new path.
-    files: list[Path] = sorted(p for p in path.rglob("*") if p.is_file())
+    # Bind each file's content to its relative path, sorted by that same
+    # canonical relative-posix key so the sort agrees with the emitted key on
+    # every platform: the digest stays independent of traversal order (and of
+    # platform path-casing) and still changes when bytes move to a new path.
+    files: list[Path] = sorted(
+        (p for p in path.rglob("*") if p.is_file()),
+        key=lambda p: p.relative_to(path).as_posix(),
+    )
     manifest: bytes = b"".join(
         file.relative_to(path).as_posix().encode()
         + b"\0"

--- a/installer/hashing.py
+++ b/installer/hashing.py
@@ -32,6 +32,7 @@ class Drift:
 def detect_drift(*, source: Path, staged: Path, recorded: str) -> Drift:
     """Reports how an installed unit diverges from its recorded install-time hash
     so a reconcile step can choose between updating it and preserving it."""
-    # Only the upstream axis is pinned by a test so far; the staged-vs-recorded
-    # local-edit axis lands in a later slice.
-    return Drift(upstream_changed=hash_unit(source) != recorded, locally_edited=False)
+    return Drift(
+        upstream_changed=hash_unit(source) != recorded,
+        locally_edited=hash_unit(staged) != recorded,
+    )

--- a/installer/hashing.py
+++ b/installer/hashing.py
@@ -1,0 +1,8 @@
+import hashlib
+from pathlib import Path
+
+
+def hash_unit(path: Path) -> str:
+    """Fingerprint a unit's content as a stable digest so a later run can tell
+    whether the file on disk still matches what was installed."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()

--- a/installer/hashing.py
+++ b/installer/hashing.py
@@ -1,4 +1,5 @@
 import hashlib
+from dataclasses import dataclass
 from pathlib import Path
 
 
@@ -17,3 +18,20 @@ def hash_unit(path: Path) -> str:
         for file in files
     )
     return hashlib.sha256(manifest).hexdigest()
+
+
+@dataclass(frozen=True)
+class Drift:
+    """Separates the two independent axes of divergence so a caller can tell an
+    upstream update apart from a local edit."""
+
+    upstream_changed: bool
+    locally_edited: bool
+
+
+def detect_drift(*, source: Path, staged: Path, recorded: str) -> Drift:
+    """Reports how an installed unit diverges from its recorded install-time hash
+    so a reconcile step can choose between updating it and preserving it."""
+    # Only the upstream axis is pinned by a test so far; the staged-vs-recorded
+    # local-edit axis lands in a later slice.
+    return Drift(upstream_changed=hash_unit(source) != recorded, locally_edited=False)

--- a/installer/hashing.py
+++ b/installer/hashing.py
@@ -5,4 +5,15 @@ from pathlib import Path
 def hash_unit(path: Path) -> str:
     """Fingerprint a unit's content as a stable digest so a later run can tell
     whether the file on disk still matches what was installed."""
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+    if not path.is_dir():
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    # Bind each file's content to its relative path, sorted so the digest is
+    # independent of traversal order and changes when bytes move to a new path.
+    files: list[Path] = sorted(p for p in path.rglob("*") if p.is_file())
+    manifest: bytes = b"".join(
+        file.relative_to(path).as_posix().encode()
+        + b"\0"
+        + hashlib.sha256(file.read_bytes()).digest()
+        for file in files
+    )
+    return hashlib.sha256(manifest).hexdigest()

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from actions import install_skill, uninstall_skill
 from catalog import skill_unit_id
+from hashing import hash_unit
 from state import State, load_state
 
 
@@ -62,6 +63,34 @@ def test_install_skill_records_and_persists_installed_unit(tmp_path: Path) -> No
     assert unit_id in result.units
     assert unit_id in load_state(state_root).units
     assert initial_state.units == {}
+
+
+def test_install_skill_records_staged_content_hash_as_unit_value(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "demo-skill"
+    (skill_source / "schemas").mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text("# Demo Skill\n", encoding="utf-8")
+    (skill_source / "schemas" / "x.json").write_text(
+        '{"type": "object"}\n', encoding="utf-8"
+    )
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    result: State = install_skill(
+        name="demo-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    staged_path: Path = state_root / "staged" / "skill" / "demo-skill"
+    recorded_hash: str = result.units[skill_unit_id("demo-skill")]
+    assert recorded_hash == hash_unit(staged_path)
+    assert recorded_hash != ""
 
 
 def test_uninstall_skill_undoes_install_and_forgets_unit(tmp_path: Path) -> None:

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -87,9 +87,8 @@ def test_install_skill_records_staged_content_hash_as_unit_value(
         state=State(version=1, units={}),
     )
 
-    staged_path: Path = state_root / "staged" / "skill" / "demo-skill"
     recorded_hash: str = result.units[skill_unit_id("demo-skill")]
-    assert recorded_hash == hash_unit(staged_path)
+    assert recorded_hash == hash_unit(skill_source)
     assert recorded_hash != ""
 
 

--- a/installer/tests/test_hashing.py
+++ b/installer/tests/test_hashing.py
@@ -20,3 +20,36 @@ def test_hash_unit_is_stable_for_equal_content_and_differs_on_change(
     assert original_hash == repeated_hash
     assert hash_unit(duplicate) == original_hash
     assert hash_unit(altered) != original_hash
+
+
+def test_hash_unit_fingerprints_a_directory_tree_by_path_and_content(
+    tmp_path: Path,
+) -> None:
+    skill_bytes: bytes = b"# Reviewer\n\nReviews code.\n"
+    schema_bytes: bytes = b'{"name": "reviewer"}\n'
+
+    def build_tree(root: Path, *, skill: bytes, schema: bytes) -> Path:
+        (root / "schemas").mkdir(parents=True)
+        (root / "SKILL.md").write_bytes(skill)
+        (root / "schemas" / "x.json").write_bytes(schema)
+        return root
+
+    tree: Path = build_tree(tmp_path / "tree", skill=skill_bytes, schema=schema_bytes)
+    twin: Path = build_tree(tmp_path / "twin", skill=skill_bytes, schema=schema_bytes)
+    edited: Path = build_tree(
+        tmp_path / "edited", skill=skill_bytes, schema=schema_bytes + b" changed\n"
+    )
+    swapped: Path = build_tree(
+        tmp_path / "swapped", skill=schema_bytes, schema=skill_bytes
+    )
+
+    tree_hash: str = hash_unit(tree)
+
+    # (a) an independently built, identical tree hashes equal, so the digest does
+    #     not depend on filesystem traversal order.
+    assert hash_unit(twin) == tree_hash
+    # (b) changing a nested file's bytes changes the hash (the walk must descend).
+    assert hash_unit(edited) != tree_hash
+    # (c) the same bytes rearranged onto different paths changes the hash, guarding
+    #     against concatenating file bytes while ignoring paths.
+    assert hash_unit(swapped) != tree_hash

--- a/installer/tests/test_hashing.py
+++ b/installer/tests/test_hashing.py
@@ -84,3 +84,34 @@ def test_detect_drift_upstream_changed_reflects_whether_source_matches_recorded(
         ).upstream_changed
         is True
     )
+
+
+def test_detect_drift_locally_edited_reflects_whether_staged_matches_recorded(
+    tmp_path: Path,
+) -> None:
+    installed_bytes: bytes = b"# Reviewer\n\nReviews code.\n"
+
+    # `recorded` is the install-time hash; hold the repo `source` equal to it in
+    # both scenarios so only the staged (local-edit) axis can move the result.
+    source: Path = tmp_path / "source.md"
+    source.write_bytes(installed_bytes)
+    recorded: str = hash_unit(source)
+
+    pristine_staged: Path = tmp_path / "pristine.md"
+    pristine_staged.write_bytes(installed_bytes)
+
+    edited_staged: Path = tmp_path / "edited.md"
+    edited_staged.write_bytes(installed_bytes + b"\n## Hand-edited note\n")
+
+    assert (
+        detect_drift(
+            source=source, staged=pristine_staged, recorded=recorded
+        ).locally_edited
+        is False
+    )
+    assert (
+        detect_drift(
+            source=source, staged=edited_staged, recorded=recorded
+        ).locally_edited
+        is True
+    )

--- a/installer/tests/test_hashing.py
+++ b/installer/tests/test_hashing.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from hashing import hash_unit
+from hashing import detect_drift, hash_unit
 
 
 def test_hash_unit_is_stable_for_equal_content_and_differs_on_change(
@@ -53,3 +53,34 @@ def test_hash_unit_fingerprints_a_directory_tree_by_path_and_content(
     # (c) the same bytes rearranged onto different paths changes the hash, guarding
     #     against concatenating file bytes while ignoring paths.
     assert hash_unit(swapped) != tree_hash
+
+
+def test_detect_drift_upstream_changed_reflects_whether_source_matches_recorded(
+    tmp_path: Path,
+) -> None:
+    installed_bytes: bytes = b"# Reviewer\n\nReviews code.\n"
+
+    # Derive `recorded` from `staged` so the staged copy always matches the
+    # install-time hash; this isolates the upstream (source-vs-recorded) axis.
+    staged: Path = tmp_path / "staged.md"
+    staged.write_bytes(installed_bytes)
+    recorded: str = hash_unit(staged)
+
+    pristine_source: Path = tmp_path / "pristine.md"
+    pristine_source.write_bytes(installed_bytes)
+
+    upstream_source: Path = tmp_path / "upstream.md"
+    upstream_source.write_bytes(installed_bytes + b"\n## New upstream section\n")
+
+    assert (
+        detect_drift(
+            source=pristine_source, staged=staged, recorded=recorded
+        ).upstream_changed
+        is False
+    )
+    assert (
+        detect_drift(
+            source=upstream_source, staged=staged, recorded=recorded
+        ).upstream_changed
+        is True
+    )

--- a/installer/tests/test_hashing.py
+++ b/installer/tests/test_hashing.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from hashing import hash_unit
+
+
+def test_hash_unit_is_stable_for_equal_content_and_differs_on_change(
+    tmp_path: Path,
+) -> None:
+    content: bytes = b"# Reviewer\n\nReviews code.\n"
+    original: Path = tmp_path / "original.md"
+    duplicate: Path = tmp_path / "duplicate.md"
+    altered: Path = tmp_path / "altered.md"
+    original.write_bytes(content)
+    duplicate.write_bytes(content)
+    altered.write_bytes(content + b" changed\n")
+
+    original_hash: str = hash_unit(original)
+    repeated_hash: str = hash_unit(original)
+
+    assert original_hash == repeated_hash
+    assert hash_unit(duplicate) == original_hash
+    assert hash_unit(altered) != original_hash


### PR DESCRIPTION
## PR 4.1 — Content hashing + drift detection

Part of #74 (slice 4: *Update + content hash*). This is the **primitives** PR; the `at update` command that consumes drift lands in 4.2.

### What

- **`hash_unit(path)`** (new `installer/hashing.py`) — a stable content hash of a unit, over either a single file or a whole directory tree (skills are trees). The tree digest binds each file's content to its **relative path** and folds them in sorted order, so it is independent of filesystem traversal order yet changes when bytes change *or* move to a different path. Files are sorted by the same canonical `as_posix()` key the manifest emits, so the digest is identical across platforms.
- **Store on install** — `install_skill` now records `hash_unit(staged_tree)` as the unit's value in `state.json`, replacing the empty `_UNHASHED` placeholder slice 2 left behind. (All existing key-presence checks — reconcile, the Skills tab marker — are unaffected.)
- **`detect_drift(*, source, staged, recorded) -> Drift`** — compares the three states along two **independent** axes:
  - `upstream_changed` — the repo's copy differs from what we recorded (an update is available);
  - `locally_edited` — the staged copy differs from what we recorded (a user hand-edit).

  `Drift` is a frozen dataclass with the two booleans rather than one enum, because the axes are genuinely independent (both can be true at once).

### How it was built

Architect track (`/make-pr`): **five behaviors, each test-first** (RED→GREEN through the public interface), then the objective gates (`ruff format --check`, `ruff check`, `mypy --strict`, `pytest -W error`), then reviewer + critic on the gate-green diff. The critic scored goal-fit **achieved**. Two MINOR reviewer findings — a latent cross-platform sort-key inconsistency in the tree hash, and a test coupled to the internal staged path — were addressed in one behavior-preserving refactor and re-reviewed clean.

### Tests

`installer/tests/test_hashing.py` (new) and `installer/tests/test_actions.py`. Full suite: **46 passed**; `ruff` + `mypy --strict` clean.

- single-file hash — determinism, content-sensitivity
- tree hash — traversal-order independence, nested-content sensitivity, path-rearrangement (collision) sensitivity
- install records the content hash (non-empty, equals the hash of the installed content)
- drift **upstream** axis (both directions) and **local-edit** axis (both directions)

### Commits

1. content hash of a single file
2. content hash of a directory tree
3. record content hash on skill install
4. detect upstream drift of an installed unit
5. detect local-edit drift of a staged unit
6. refactor: stabilize tree-hash sort key; decouple install-hash test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
