### PR TITLE
feat(installer): at update — pull + re-stage drifted skills (PR 4.2)

### DIFF
--- a/installer/actions.py
+++ b/installer/actions.py
@@ -2,18 +2,12 @@
 "install this skill" rather than wiring stage + link + record themselves."""
 
 from pathlib import Path
-from typing import Final
 
 from catalog import skill_unit, skill_unit_id
+from constants import SKILLS_DIRNAME, STAGED_DIRNAME
 from hashing import hash_unit
 from placement import link_unit, stage_unit, unlink_unit, unstage_unit
 from state import State, save_state
-
-# The kind→subdir layout lives here, the first concrete caller of the placement
-# primitives: a skill stages under "staged/skill/<name>" and goes live under
-# "<claude>/skills/<name>", matching ~/.claude's per-kind directories.
-_STAGED_DIRNAME: Final[str] = "staged"
-_SKILLS_DIRNAME: Final[str] = "skills"
 
 
 def install_skill(
@@ -29,11 +23,11 @@ def install_skill(
 
     Persists the updated state to state_root (via save_state) and returns a brand-new
     immutable State; the passed-in state is never mutated."""
-    source: Path = source_root / _SKILLS_DIRNAME / name
+    source: Path = source_root / SKILLS_DIRNAME / name
     staged_path: Path = stage_unit(
-        unit=skill_unit(name), source=source, staged_root=state_root / _STAGED_DIRNAME
+        unit=skill_unit(name), source=source, staged_root=state_root / STAGED_DIRNAME
     )
-    link_unit(staged_path=staged_path, link_path=claude_root / _SKILLS_DIRNAME / name)
+    link_unit(staged_path=staged_path, link_path=claude_root / SKILLS_DIRNAME / name)
     content_hash: str = hash_unit(staged_path)
     new_state: State = State(
         version=state.version,
@@ -56,8 +50,8 @@ def uninstall_skill(
 
     Persists the updated state to state_root (via save_state) and returns a brand-new
     immutable State without the skill's unit; the passed-in state is never mutated."""
-    unlink_unit(link_path=claude_root / _SKILLS_DIRNAME / name)
-    unstage_unit(unit=skill_unit(name), staged_root=state_root / _STAGED_DIRNAME)
+    unlink_unit(link_path=claude_root / SKILLS_DIRNAME / name)
+    unstage_unit(unit=skill_unit(name), staged_root=state_root / STAGED_DIRNAME)
     removed_id: str = skill_unit_id(name)
     new_state: State = State(
         version=state.version,

--- a/installer/at.py
+++ b/installer/at.py
@@ -3,6 +3,7 @@
 # requires-python = ">=3.11"
 # dependencies = ["questionary", "rich"]
 # ///
+import subprocess
 import sys
 from pathlib import Path
 from typing import Final
@@ -21,6 +22,7 @@ from rich.panel import Panel
 from catalog import Catalog, list_skills, load_catalog, skill_unit_id
 from reconcile import ReconcilePlan, apply_skill_reconcile, plan_skill_reconcile
 from state import State, load_state
+from update import update_installed_skills
 
 AT_VERSION: Final[str] = "0.2.0"
 
@@ -53,6 +55,7 @@ Usage: at [command]
 
 Commands:
   install        Launch the interactive menu
+  update         Pull the repo and refresh installed skills
 
 Flags:
   -h, --help     Show this help screen and exit
@@ -60,7 +63,7 @@ Flags:
 """
 
 KNOWN_TOKENS: Final[frozenset[str]] = frozenset(
-    {"--version", "-h", "--help", "install"}
+    {"--version", "-h", "--help", "install", "update"}
 )
 
 
@@ -155,6 +158,22 @@ def launch_tui() -> int:
         return 0
 
 
+def _run_update() -> int:
+    """Fast-forward the repo, then refresh only the installed skills whose upstream
+    content changed, so `at update` is a single non-interactive sync."""
+    subprocess.run(["git", "pull", "--ff-only"], cwd=REPO_ROOT, check=True)
+    catalog: Catalog = load_catalog(CATALOG_PATH)
+    state: State = load_state(STATE_ROOT)
+    update_installed_skills(
+        source_root=REPO_ROOT,
+        state_root=STATE_ROOT,
+        claude_root=CLAUDE_ROOT,
+        catalog=catalog,
+        state=state,
+    )
+    return 0
+
+
 def main(argv: list[str]) -> int:
     if "--version" in argv:
         print(f"at {AT_VERSION}")
@@ -166,6 +185,8 @@ def main(argv: list[str]) -> int:
         print(f"error: unknown argument '{argv[0]}'", file=sys.stderr)
         print("Try 'at --help' for usage.", file=sys.stderr)
         return 2
+    if argv and argv[0] == "update":
+        return _run_update()
     return launch_tui()
 
 

--- a/installer/constants.py
+++ b/installer/constants.py
@@ -1,0 +1,7 @@
+from typing import Final
+
+# One home for the installer's on-disk layout tokens, shared by the install/update
+# composition layer: where units stage under the state root, and where skill
+# sources live in the repo (~/.claude's per-kind dirs and the repo's skills/ tree).
+STAGED_DIRNAME: Final[str] = "staged"
+SKILLS_DIRNAME: Final[str] = "skills"

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -20,10 +20,16 @@ def _remove_staged_entry(path: Path) -> None:
         path.unlink()
 
 
+def staged_unit_path(*, unit: Unit, staged_root: Path) -> Path:
+    """Own the "<kind>/<name>" staged-layout decision in one place, so callers
+    locate a unit's staged copy without re-encoding the path this module lays down."""
+    return staged_root / unit.kind / unit.name
+
+
 def stage_unit(*, unit: Unit, source: Path, staged_root: Path) -> Path:
     """Lay a unit out under "<kind>/<name>" in a staging area first, so the real
     install can swap a fully-built tree into place instead of writing live."""
-    destination: Path = staged_root / unit.kind / unit.name
+    destination: Path = staged_unit_path(unit=unit, staged_root=staged_root)
     destination.parent.mkdir(parents=True, exist_ok=True)
     # Clear any prior staging of this unit so a re-stage fully supersedes it,
     # leaving no stale files behind, rather than colliding with the old tree.
@@ -41,7 +47,7 @@ def unstage_unit(*, unit: Unit, staged_root: Path) -> None:
     """Tear down a unit's staged entry at "<kind>/<name>" so the staging area no
     longer holds it — the inverse of stage_unit, dropping either the directory
     tree or the single file it laid down."""
-    staged_path: Path = staged_root / unit.kind / unit.name
+    staged_path: Path = staged_unit_path(unit=unit, staged_root=staged_root)
     _remove_staged_entry(staged_path)
 
 
@@ -49,7 +55,7 @@ def backup_staged_unit(*, unit: Unit, staged_root: Path) -> Path | None:
     """Move a hand-edited staged unit aside to "<name>.bak" so the user's local
     edit survives a following re-stage that overwrites the staged tree, returning
     None when nothing is staged to rescue."""
-    staged_path: Path = staged_root / unit.kind / unit.name
+    staged_path: Path = staged_unit_path(unit=unit, staged_root=staged_root)
     if not staged_path.exists():
         return None
     backup_path: Path = staged_path.with_name(staged_path.name + _BACKUP_SUFFIX)

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -4,8 +4,9 @@ from typing import Final
 
 from catalog import Unit
 
-# A real file/dir displaced by linking is moved aside to "<name>.bak" so its
-# contents survive the install rather than being clobbered by our symlink.
+# The shared "<name>.bak" convention: an entry about to be overwritten is moved
+# aside so its contents survive — a real file displaced by our symlink, or a
+# hand-edited staged tree rescued before a re-stage — rather than being clobbered.
 _BACKUP_SUFFIX: Final[str] = ".bak"
 
 
@@ -42,6 +43,19 @@ def unstage_unit(*, unit: Unit, staged_root: Path) -> None:
     tree or the single file it laid down."""
     staged_path: Path = staged_root / unit.kind / unit.name
     _remove_staged_entry(staged_path)
+
+
+def backup_staged_unit(*, unit: Unit, staged_root: Path) -> Path | None:
+    """Move a hand-edited staged unit aside to "<name>.bak" so the user's local
+    edit survives a following re-stage that overwrites the staged tree, returning
+    None when nothing is staged to rescue."""
+    staged_path: Path = staged_root / unit.kind / unit.name
+    if not staged_path.exists():
+        return None
+    backup_path: Path = staged_path.with_name(staged_path.name + _BACKUP_SUFFIX)
+    _remove_staged_entry(backup_path)  # supersede any prior .bak, idempotently
+    staged_path.replace(backup_path)
+    return backup_path
 
 
 def link_unit(*, staged_path: Path, link_path: Path) -> Path:

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -1,3 +1,4 @@
+import subprocess
 from collections.abc import Callable, Iterator
 from pathlib import Path
 
@@ -17,6 +18,7 @@ from at import (
     skill_rows,
 )
 from catalog import Catalog, Unit, skill_unit_id
+from hashing import hash_unit
 from state import State, load_state
 
 
@@ -638,3 +640,64 @@ def test_esc_at_tab_menu_exits_cleanly(
     captured: str = capsys.readouterr().out
     assert exit_code == 0
     assert TAB_PLACEHOLDER not in captured
+
+
+def test_update_pulls_repo_then_refreshes_installed_skill(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # Install demo-skill from its repo source through the real public action, so
+    # state, staging, and the live symlink all exist before the update runs.
+    source: Path = repo_root / "skills" / "demo-skill" / "SKILL.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("# demo-skill\n", encoding="utf-8")
+    install_skill(
+        name="demo-skill",
+        source_root=repo_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=load_state(state_root),
+    )
+    install_hash: str = load_state(state_root).units[skill_unit_id("demo-skill")]
+
+    # Stand in for what `git pull` fetched: the faked run below shells out to
+    # nothing, so rewriting the source here is the only "upstream" change, leaving
+    # the installed skill stale against its now-updated repo source.
+    source.write_text("# demo-skill upstream change\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-skill"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # subprocess.run is the one true external boundary (process exec + network):
+    # record each call and hand back a success so the faked pull never runs git.
+    recorded_runs: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        recorded_runs.append((args, kwargs))
+        return subprocess.CompletedProcess(args=[], returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    exit_code: int = main(["update"])
+
+    skill_source: Path = repo_root / "skills" / "demo-skill"
+    final_hash: str = load_state(state_root).units[skill_unit_id("demo-skill")]
+    assert exit_code == 0
+    assert len(recorded_runs) == 1
+    pull_args: tuple[object, ...] = recorded_runs[0][0]
+    pull_kwargs: dict[str, object] = recorded_runs[0][1]
+    assert pull_args[0] == ["git", "pull", "--ff-only"]
+    assert pull_kwargs["cwd"] == repo_root
+    assert final_hash == hash_unit(skill_source)
+    assert final_hash != install_hash

--- a/installer/tests/test_update.py
+++ b/installer/tests/test_update.py
@@ -95,3 +95,54 @@ def test_update_skill_preserves_local_edit_when_upstream_unchanged(
     assert not backup_path.exists()
     assert result.units[unit_id] == install_hash
     assert load_state(state_root).units[unit_id] == install_hash
+
+
+def test_update_skill_backs_up_local_edit_before_restaging_upstream_change(
+    tmp_path: Path,
+) -> None:
+    original_content: str = "# Demo Skill\n\nOriginal upstream copy.\n"
+    hand_edited_content: str = "# Demo Skill\n\nHand-edited; must be rescued.\n"
+    updated_content: str = "# Demo Skill\n\nRevised upstream copy.\n"
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "demo-skill"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text(original_content, encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    installed_state: State = install_skill(
+        name="demo-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    unit_id: str = skill_unit_id("demo-skill")
+    install_hash: str = installed_state.units[unit_id]
+
+    # A user's edit to their installed skill lands in the staged tree (the source
+    # of truth behind the live symlink); here upstream changes too, so the update
+    # must rescue the hand-edit to .bak before the re-stage overwrites it.
+    staged_path: Path = state_root / "staged" / "skill" / "demo-skill"
+    staged_skill_md: Path = staged_path / "SKILL.md"
+    staged_skill_md.write_text(hand_edited_content, encoding="utf-8")
+    (skill_source / "SKILL.md").write_text(updated_content, encoding="utf-8")
+
+    result: State = update_skill(
+        name="demo-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=installed_state,
+    )
+
+    backup_path: Path = staged_path.with_name(staged_path.name + ".bak")
+    refreshed_hash: str = hash_unit(skill_source)
+
+    assert staged_skill_md.read_text(encoding="utf-8") == updated_content
+    assert backup_path.exists()
+    assert (backup_path / "SKILL.md").read_text(encoding="utf-8") == hand_edited_content
+    assert result.units[unit_id] == refreshed_hash
+    assert result.units[unit_id] != install_hash
+    assert load_state(state_root).units[unit_id] == refreshed_hash

--- a/installer/tests/test_update.py
+++ b/installer/tests/test_update.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 
 from actions import install_skill
-from catalog import skill_unit_id
+from catalog import Catalog, Unit, skill_unit_id
 from hashing import hash_unit
 from state import State, load_state
-from update import update_skill
+from update import update_installed_skills, update_skill
 
 
 def test_update_skill_restages_upstream_change_and_refreshes_recorded_hash(
@@ -146,3 +146,57 @@ def test_update_skill_backs_up_local_edit_before_restaging_upstream_change(
     assert result.units[unit_id] == refreshed_hash
     assert result.units[unit_id] != install_hash
     assert load_state(state_root).units[unit_id] == refreshed_hash
+
+
+def test_update_installed_skills_updates_installed_skill_and_skips_uninstalled(
+    tmp_path: Path,
+) -> None:
+    original_a: str = "# Demo A\n\nOriginal upstream copy.\n"
+    updated_a: str = "# Demo A\n\nRevised upstream copy.\n"
+    uninstalled_b: str = "# Demo B\n\nNever installed; an update must not adopt it.\n"
+    source_root: Path = tmp_path / "repo"
+    skill_a_source: Path = source_root / "skills" / "demo-a"
+    skill_b_source: Path = source_root / "skills" / "demo-b"
+    skill_a_source.mkdir(parents=True)
+    skill_b_source.mkdir(parents=True)
+    (skill_a_source / "SKILL.md").write_text(original_a, encoding="utf-8")
+    (skill_b_source / "SKILL.md").write_text(uninstalled_b, encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    # Install only demo-a; demo-b stays a catalog entry that was never installed.
+    installed_state: State = install_skill(
+        name="demo-a",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+    install_hash_a: str = installed_state.units[skill_unit_id("demo-a")]
+
+    # An upstream change to demo-a means the orchestrator must re-stage it.
+    (skill_a_source / "SKILL.md").write_text(updated_a, encoding="utf-8")
+
+    # The catalog lists both skills, but only the installed one should be touched.
+    catalog: Catalog = Catalog(
+        units=(Unit(kind="skill", name="demo-a"), Unit(kind="skill", name="demo-b")),
+        packages=(),
+        bundles=(),
+    )
+
+    result: State = update_installed_skills(
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        catalog=catalog,
+        state=installed_state,
+    )
+
+    staged_a: Path = state_root / "staged" / "skill" / "demo-a"
+    staged_b: Path = state_root / "staged" / "skill" / "demo-b"
+
+    assert result.units[skill_unit_id("demo-a")] == hash_unit(skill_a_source)
+    assert result.units[skill_unit_id("demo-a")] != install_hash_a
+    assert (staged_a / "SKILL.md").read_text(encoding="utf-8") == updated_a
+    assert skill_unit_id("demo-b") not in result.units
+    assert not staged_b.exists()

--- a/installer/tests/test_update.py
+++ b/installer/tests/test_update.py
@@ -49,3 +49,49 @@ def test_update_skill_restages_upstream_change_and_refreshes_recorded_hash(
     assert result.units[unit_id] != install_hash
     assert load_state(state_root).units[unit_id] == refreshed_hash
     assert installed_state.units[unit_id] == install_hash
+
+
+def test_update_skill_preserves_local_edit_when_upstream_unchanged(
+    tmp_path: Path,
+) -> None:
+    original_content: str = "# Demo Skill\n\nPristine upstream copy.\n"
+    hand_edited_content: str = "# Demo Skill\n\nHand-edited; must survive.\n"
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "demo-skill"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text(original_content, encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    installed_state: State = install_skill(
+        name="demo-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    unit_id: str = skill_unit_id("demo-skill")
+    install_hash: str = installed_state.units[unit_id]
+
+    # The staged tree is the documented source of truth behind the live symlink,
+    # so a user's edit to their installed skill lands here. Upstream is left
+    # untouched, so only the staged copy now diverges from the recorded hash.
+    staged_path: Path = state_root / "staged" / "skill" / "demo-skill"
+    staged_skill_md: Path = staged_path / "SKILL.md"
+    staged_skill_md.write_text(hand_edited_content, encoding="utf-8")
+
+    result: State = update_skill(
+        name="demo-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=installed_state,
+    )
+
+    backup_path: Path = staged_path.with_name(staged_path.name + ".bak")
+
+    assert staged_skill_md.read_text(encoding="utf-8") == hand_edited_content
+    assert not backup_path.exists()
+    assert result.units[unit_id] == install_hash
+    assert load_state(state_root).units[unit_id] == install_hash

--- a/installer/tests/test_update.py
+++ b/installer/tests/test_update.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from actions import install_skill
+from catalog import skill_unit_id
+from hashing import hash_unit
+from state import State, load_state
+from update import update_skill
+
+
+def test_update_skill_restages_upstream_change_and_refreshes_recorded_hash(
+    tmp_path: Path,
+) -> None:
+    original_content: str = "# Demo Skill\n\nOriginal upstream copy.\n"
+    updated_content: str = "# Demo Skill\n\nRevised upstream copy.\n"
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "demo-skill"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text(original_content, encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    installed_state: State = install_skill(
+        name="demo-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    unit_id: str = skill_unit_id("demo-skill")
+    install_hash: str = installed_state.units[unit_id]
+
+    # Simulate an upstream change to the repo source after the skill was installed.
+    (skill_source / "SKILL.md").write_text(updated_content, encoding="utf-8")
+
+    result: State = update_skill(
+        name="demo-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=installed_state,
+    )
+
+    staged_path: Path = state_root / "staged" / "skill" / "demo-skill"
+    refreshed_hash: str = hash_unit(skill_source)
+
+    assert (staged_path / "SKILL.md").read_text(encoding="utf-8") == updated_content
+    assert result.units[unit_id] == refreshed_hash
+    assert result.units[unit_id] != install_hash
+    assert load_state(state_root).units[unit_id] == refreshed_hash
+    assert installed_state.units[unit_id] == install_hash

--- a/installer/update.py
+++ b/installer/update.py
@@ -1,16 +1,11 @@
 from pathlib import Path
-from typing import Final
 
 from actions import install_skill
 from catalog import skill_unit, skill_unit_id
+from constants import SKILLS_DIRNAME, STAGED_DIRNAME
 from hashing import Drift, detect_drift
 from placement import backup_staged_unit
 from state import State
-
-# The kind→subdir layout is mirrored from actions.py for now; a follow-up
-# refactor will consolidate these shared layout tokens into one home.
-_STAGED_DIRNAME: Final[str] = "staged"
-_SKILLS_DIRNAME: Final[str] = "skills"
 
 
 def update_skill(
@@ -24,15 +19,15 @@ def update_skill(
     """Reconcile a skill against its upstream source: leave a local edit to the
     staged copy untouched when upstream is unchanged, otherwise rescue it to
     "<name>.bak" before re-staging the new source, so an edit is never lost."""
-    source: Path = source_root / _SKILLS_DIRNAME / name
-    staged: Path = state_root / _STAGED_DIRNAME / skill_unit(name).kind / name
+    source: Path = source_root / SKILLS_DIRNAME / name
+    staged: Path = state_root / STAGED_DIRNAME / skill_unit(name).kind / name
     recorded: str = state.units[skill_unit_id(name)]
     drift: Drift = detect_drift(source=source, staged=staged, recorded=recorded)
     if not drift.upstream_changed:
         return state
     if drift.locally_edited:
         backup_staged_unit(
-            unit=skill_unit(name), staged_root=state_root / _STAGED_DIRNAME
+            unit=skill_unit(name), staged_root=state_root / STAGED_DIRNAME
         )
     return install_skill(
         name=name,

--- a/installer/update.py
+++ b/installer/update.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from actions import install_skill
-from catalog import skill_unit, skill_unit_id
+from catalog import Catalog, list_skills, skill_unit, skill_unit_id
 from constants import SKILLS_DIRNAME, STAGED_DIRNAME
 from hashing import Drift, detect_drift
 from placement import backup_staged_unit
@@ -36,3 +36,26 @@ def update_skill(
         claude_root=claude_root,
         state=state,
     )
+
+
+def update_installed_skills(
+    *,
+    source_root: Path,
+    state_root: Path,
+    claude_root: Path,
+    catalog: Catalog,
+    state: State,
+) -> State:
+    """Refresh every installed skill against upstream in one pass, so one update
+    run reconciles the whole installation instead of one skill at a time."""
+    current: State = state
+    for name in list_skills(catalog):
+        if skill_unit_id(name) in state.units:
+            current = update_skill(
+                name=name,
+                source_root=source_root,
+                state_root=state_root,
+                claude_root=claude_root,
+                state=current,
+            )
+    return current

--- a/installer/update.py
+++ b/installer/update.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from actions import install_skill
+from state import State
+
+
+def update_skill(
+    *,
+    name: str,
+    source_root: Path,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Give refreshing an already-installed skill its own named entry point,
+    distinct from a first install, so update-only behavior (skip-unchanged, drift
+    handling) has one place to grow as it diverges from install — for now a
+    re-stage of the current source is exactly what install already does."""
+    return install_skill(
+        name=name,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state,
+    )

--- a/installer/update.py
+++ b/installer/update.py
@@ -4,6 +4,7 @@ from typing import Final
 from actions import install_skill
 from catalog import skill_unit, skill_unit_id
 from hashing import Drift, detect_drift
+from placement import backup_staged_unit
 from state import State
 
 # The kind→subdir layout is mirrored from actions.py for now; a follow-up
@@ -20,15 +21,19 @@ def update_skill(
     claude_root: Path,
     state: State,
 ) -> State:
-    """Skip re-staging a skill whose upstream source is unchanged, so a user's
-    local edit to the staged copy survives an update instead of being clobbered
-    by an identical re-stage."""
+    """Reconcile a skill against its upstream source: leave a local edit to the
+    staged copy untouched when upstream is unchanged, otherwise rescue it to
+    "<name>.bak" before re-staging the new source, so an edit is never lost."""
     source: Path = source_root / _SKILLS_DIRNAME / name
     staged: Path = state_root / _STAGED_DIRNAME / skill_unit(name).kind / name
     recorded: str = state.units[skill_unit_id(name)]
     drift: Drift = detect_drift(source=source, staged=staged, recorded=recorded)
     if not drift.upstream_changed:
         return state
+    if drift.locally_edited:
+        backup_staged_unit(
+            unit=skill_unit(name), staged_root=state_root / _STAGED_DIRNAME
+        )
     return install_skill(
         name=name,
         source_root=source_root,

--- a/installer/update.py
+++ b/installer/update.py
@@ -1,7 +1,15 @@
 from pathlib import Path
+from typing import Final
 
 from actions import install_skill
+from catalog import skill_unit, skill_unit_id
+from hashing import Drift, detect_drift
 from state import State
+
+# The kind→subdir layout is mirrored from actions.py for now; a follow-up
+# refactor will consolidate these shared layout tokens into one home.
+_STAGED_DIRNAME: Final[str] = "staged"
+_SKILLS_DIRNAME: Final[str] = "skills"
 
 
 def update_skill(
@@ -12,10 +20,15 @@ def update_skill(
     claude_root: Path,
     state: State,
 ) -> State:
-    """Give refreshing an already-installed skill its own named entry point,
-    distinct from a first install, so update-only behavior (skip-unchanged, drift
-    handling) has one place to grow as it diverges from install — for now a
-    re-stage of the current source is exactly what install already does."""
+    """Skip re-staging a skill whose upstream source is unchanged, so a user's
+    local edit to the staged copy survives an update instead of being clobbered
+    by an identical re-stage."""
+    source: Path = source_root / _SKILLS_DIRNAME / name
+    staged: Path = state_root / _STAGED_DIRNAME / skill_unit(name).kind / name
+    recorded: str = state.units[skill_unit_id(name)]
+    drift: Drift = detect_drift(source=source, staged=staged, recorded=recorded)
+    if not drift.upstream_changed:
+        return state
     return install_skill(
         name=name,
         source_root=source_root,

--- a/installer/update.py
+++ b/installer/update.py
@@ -4,7 +4,7 @@ from actions import install_skill
 from catalog import Catalog, list_skills, skill_unit, skill_unit_id
 from constants import SKILLS_DIRNAME, STAGED_DIRNAME
 from hashing import Drift, detect_drift
-from placement import backup_staged_unit
+from placement import backup_staged_unit, staged_unit_path
 from state import State
 
 
@@ -20,7 +20,9 @@ def update_skill(
     staged copy untouched when upstream is unchanged, otherwise rescue it to
     "<name>.bak" before re-staging the new source, so an edit is never lost."""
     source: Path = source_root / SKILLS_DIRNAME / name
-    staged: Path = state_root / STAGED_DIRNAME / skill_unit(name).kind / name
+    staged: Path = staged_unit_path(
+        unit=skill_unit(name), staged_root=state_root / STAGED_DIRNAME
+    )
     recorded: str = state.units[skill_unit_id(name)]
     drift: Drift = detect_drift(source=source, staged=staged, recorded=recorded)
     if not drift.upstream_changed:


### PR DESCRIPTION
## Slice 4.2 — `at update`

Implements `at update` for skills (issue #74, slice 4): pull the repo fast-forward-only, then re-stage **only** the skills whose upstream content actually changed, backing up a hand-edited staged copy to `.bak` first, and refreshing the recorded content hashes. Consumes 4.1's `detect_drift`.

Built test-first (RED→GREEN per behavior) by the architect workflow; 5 behavioral slices + 2 refactors.

### What it does
- **`at update` command** (`at.py`): non-interactive; runs `git pull --ff-only` in the repo, then refreshes installed skills. Added to `KNOWN_TOKENS` and the help text.
- **`update_skill`** (`update.py`): for one installed skill, decides via `detect_drift`:
  - upstream unchanged → **no-op** (a hand-edited staged copy is preserved; nothing re-staged, hash untouched);
  - upstream changed → re-stage the new source and refresh the recorded hash;
  - upstream changed **and** locally edited → rescue the hand-edit to `<name>.bak` **before** the re-stage clobbers it.
- **`update_installed_skills`** (`update.py`): orchestrates over the catalog, updating only installed skills (threads `State`, skips never-installed entries).
- **`backup_staged_unit`** (`placement.py`): moves a staged tree/file aside to `<name>.bak`, idempotently superseding any prior backup — lives where the `.bak` convention already lives.

### Design notes
- `update_skill` composes the existing `install_skill` for the re-stage path, so staging/linking/hashing/persistence aren't re-implemented; it adds only the drift guard and the `.bak` rescue.
- Two small refactors consolidate shared decisions into one home: the `staged`/`skills` layout tokens (`constants.py`) and the `<staged_root>/<kind>/<name>` path formula (`staged_unit_path` in `placement.py`).
- `git pull` is the only external boundary; it's mocked in the `at update` test (no network in CI).

### Verification
- `ruff format --check`, `ruff check`, `mypy --strict`, and `pytest -W error` (**51 passed**) all green from `installer/`.
- Reviewer: no CRITICAL; one MAJOR (path-formula duplication) fixed and re-reviewed clean. Critic: goal achieved (all four acceptance parts proven by tests).

### Known follow-up (not in this PR)
A failed `git pull --ff-only` (diverged history / offline) currently surfaces a raw `CalledProcessError` traceback rather than a concise stderr + nonzero exit. Deferred deliberately — the slice spec names no pull-failure UX, and the installer has no operational-error-handling pattern yet; better addressed uniformly across commands later. Reviewer scored it MINOR (28).

Closes part of #74 (slice 4.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
