### PR TITLE
feat(installer): non-interactive skills CLI + AT_SOURCE_ROOT/AT_CATALOG seams (PR 4.5.1)

### DIFF
--- a/installer/at.py
+++ b/installer/at.py
@@ -52,15 +52,21 @@ MENU_CHOICES: Final[tuple[str, ...]] = (
 )
 
 USAGE: Final[str] = """\
-Usage: at [command]
+Usage: at [command] [flags]
 
 Commands:
-  install        Launch the interactive menu
-  update         Pull the repo and refresh installed skills
+  install                      Launch the interactive menu
+  install --skill <name>...    Install the named skills, no menu
+  install --all                Install every catalog skill, no menu
+  uninstall --skill <name>...  Uninstall the named skills, no menu
+  update                       Pull the repo and refresh installed skills
 
 Flags:
-  -h, --help     Show this help screen and exit
-  --version      Show the version and exit
+  --skill <name>     Skill to install or uninstall; repeat to act on several
+  --all              With 'install', act on every catalog skill
+  --non-interactive  Accepted with 'install --all' for scripted, non-TTY runs
+  -h, --help         Show this help screen and exit
+  --version          Show the version and exit
 """
 
 KNOWN_TOKENS: Final[frozenset[str]] = frozenset(

--- a/installer/at.py
+++ b/installer/at.py
@@ -63,7 +63,7 @@ Flags:
 """
 
 KNOWN_TOKENS: Final[frozenset[str]] = frozenset(
-    {"--version", "-h", "--help", "install", "update"}
+    {"--version", "-h", "--help", "install", "uninstall", "update"}
 )
 
 
@@ -197,6 +197,30 @@ def _install_named_skills(names: list[str]) -> int:
     return 0
 
 
+def _uninstall_named_skills(names: list[str]) -> int:
+    """Remove every named skill without the TUI, so `at uninstall --skill <name> ...`
+    is a scriptable path that drives the same declarative reconcile the menu does.
+    Uninstall is subtractive: the named skills drop out of whatever is installed,
+    and every other installed skill stays ticked and thus untouched."""
+    catalog: Catalog = load_catalog(CATALOG_PATH)
+    state: State = load_state(STATE_ROOT)
+    installed: set[str] = {
+        n for n in list_skills(catalog) if skill_unit_id(n) in state.units
+    }
+    ticked: frozenset[str] = frozenset(installed - set(names))
+    plan: ReconcilePlan = plan_skill_reconcile(
+        ticked=ticked, catalog=catalog, state=state
+    )
+    apply_skill_reconcile(
+        plan=plan,
+        source_root=REPO_ROOT,
+        state_root=STATE_ROOT,
+        claude_root=CLAUDE_ROOT,
+        state=state,
+    )
+    return 0
+
+
 def main(argv: list[str]) -> int:
     if "--version" in argv:
         print(f"at {AT_VERSION}")
@@ -218,6 +242,11 @@ def main(argv: list[str]) -> int:
     if argv and argv[0] == "install" and "--all" in argv:
         all_skills: list[str] = list_skills(load_catalog(CATALOG_PATH))
         return _install_named_skills(all_skills)
+    if argv and argv[0] == "uninstall" and "--skill" in argv:
+        removed_names: list[str] = [
+            argv[i + 1] for i, token in enumerate(argv) if token == "--skill"
+        ]
+        return _uninstall_named_skills(removed_names)
     return launch_tui()
 
 

--- a/installer/at.py
+++ b/installer/at.py
@@ -191,11 +191,28 @@ def _run_update() -> int:
     return 0
 
 
+def _reject_unknown_skills(names: list[str], catalog: Catalog) -> int | None:
+    """Reject a --skill the catalog doesn't list before any reconcile runs, so a typo
+    fails atomically instead of silently no-opping; names the unknowns on stderr and
+    returns exit code 2, or None when every name is known."""
+    known: frozenset[str] = frozenset(list_skills(catalog))
+    unknown: list[str] = [name for name in names if name not in known]
+    if not unknown:
+        return None
+    for name in unknown:
+        print(f"error: unknown skill '{name}'", file=sys.stderr)
+    print("Try 'at --help' for usage.", file=sys.stderr)
+    return 2
+
+
 def _install_named_skills(names: list[str]) -> int:
     """Install every named skill without the TUI, so `at install --skill <name> ...`
     is a scriptable path that drives the same declarative reconcile the menu does.
     Install is additive: the named skills join whatever is already installed."""
     catalog: Catalog = load_catalog(_catalog_path())
+    rejection: int | None = _reject_unknown_skills(names, catalog)
+    if rejection is not None:
+        return rejection
     state: State = load_state(STATE_ROOT)
     installed: set[str] = {
         n for n in list_skills(catalog) if skill_unit_id(n) in state.units
@@ -220,6 +237,9 @@ def _uninstall_named_skills(names: list[str]) -> int:
     Uninstall is subtractive: the named skills drop out of whatever is installed,
     and every other installed skill stays ticked and thus untouched."""
     catalog: Catalog = load_catalog(_catalog_path())
+    rejection: int | None = _reject_unknown_skills(names, catalog)
+    if rejection is not None:
+        return rejection
     state: State = load_state(STATE_ROOT)
     installed: set[str] = {
         n for n in list_skills(catalog) if skill_unit_id(n) in state.units

--- a/installer/at.py
+++ b/installer/at.py
@@ -205,6 +205,21 @@ def _reject_unknown_skills(names: list[str], catalog: Catalog) -> int | None:
     return 2
 
 
+def _skill_values(argv: list[str]) -> list[str] | None:
+    """Parse the value following each --skill so the dispatch can validate a
+    skills request before acting; returns None when a --skill has no following
+    value (the last token), so a malformed request is a usage error, not a crash."""
+    values: list[str] = []
+    for index, token in enumerate(argv):
+        if token != "--skill":
+            continue
+        value_index: int = index + 1
+        if value_index >= len(argv):
+            return None
+        values.append(argv[value_index])
+    return values
+
+
 def _install_named_skills(names: list[str]) -> int:
     """Install every named skill without the TUI, so `at install --skill <name> ...`
     is a scriptable path that drives the same declarative reconcile the menu does.
@@ -272,17 +287,21 @@ def main(argv: list[str]) -> int:
     if argv and argv[0] == "update":
         return _run_update()
     if argv and argv[0] == "install" and "--skill" in argv:
-        skill_names: list[str] = [
-            argv[i + 1] for i, token in enumerate(argv) if token == "--skill"
-        ]
+        skill_names: list[str] | None = _skill_values(argv)
+        if skill_names is None:
+            print("error: --skill requires a skill name", file=sys.stderr)
+            print("Try 'at --help' for usage.", file=sys.stderr)
+            return 2
         return _install_named_skills(skill_names)
     if argv and argv[0] == "install" and "--all" in argv:
         all_skills: list[str] = list_skills(load_catalog(_catalog_path()))
         return _install_named_skills(all_skills)
-    if argv and argv[0] == "uninstall" and "--skill" in argv:
-        removed_names: list[str] = [
-            argv[i + 1] for i, token in enumerate(argv) if token == "--skill"
-        ]
+    if argv and argv[0] == "uninstall":
+        removed_names: list[str] | None = _skill_values(argv)
+        if "--skill" not in argv or removed_names is None:
+            print("error: uninstall requires --skill <name>", file=sys.stderr)
+            print("Try 'at --help' for usage.", file=sys.stderr)
+            return 2
         return _uninstall_named_skills(removed_names)
     return launch_tui()
 

--- a/installer/at.py
+++ b/installer/at.py
@@ -76,6 +76,14 @@ def _source_root() -> Path:
     return Path(override) if override else REPO_ROOT
 
 
+def _catalog_path() -> Path:
+    """Resolve which catalog the non-interactive CLI loads, honoring AT_CATALOG so a
+    subprocess (e.g. the e2e harness) can point at a fixture catalog; falls back to the
+    repo's CATALOG_PATH when the override is unset."""
+    override: str | None = os.environ.get("AT_CATALOG")
+    return Path(override) if override else CATALOG_PATH
+
+
 def _skill_marker(name: str, installed: frozenset[str]) -> str:
     if skill_unit_id(name) in installed:
         return MARKER_INSTALLED
@@ -187,7 +195,7 @@ def _install_named_skills(names: list[str]) -> int:
     """Install every named skill without the TUI, so `at install --skill <name> ...`
     is a scriptable path that drives the same declarative reconcile the menu does.
     Install is additive: the named skills join whatever is already installed."""
-    catalog: Catalog = load_catalog(CATALOG_PATH)
+    catalog: Catalog = load_catalog(_catalog_path())
     state: State = load_state(STATE_ROOT)
     installed: set[str] = {
         n for n in list_skills(catalog) if skill_unit_id(n) in state.units
@@ -211,7 +219,7 @@ def _uninstall_named_skills(names: list[str]) -> int:
     is a scriptable path that drives the same declarative reconcile the menu does.
     Uninstall is subtractive: the named skills drop out of whatever is installed,
     and every other installed skill stays ticked and thus untouched."""
-    catalog: Catalog = load_catalog(CATALOG_PATH)
+    catalog: Catalog = load_catalog(_catalog_path())
     state: State = load_state(STATE_ROOT)
     installed: set[str] = {
         n for n in list_skills(catalog) if skill_unit_id(n) in state.units
@@ -249,7 +257,7 @@ def main(argv: list[str]) -> int:
         ]
         return _install_named_skills(skill_names)
     if argv and argv[0] == "install" and "--all" in argv:
-        all_skills: list[str] = list_skills(load_catalog(CATALOG_PATH))
+        all_skills: list[str] = list_skills(load_catalog(_catalog_path()))
         return _install_named_skills(all_skills)
     if argv and argv[0] == "uninstall" and "--skill" in argv:
         removed_names: list[str] = [

--- a/installer/at.py
+++ b/installer/at.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.11"
-# dependencies = ["questionary", "rich"]
+# dependencies = ["click", "questionary", "rich"]
 # ///
 import os
 import subprocess
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 from typing import Final
 
+import click
 import questionary
 from prompt_toolkit.key_binding import (
     KeyBindings,
@@ -51,43 +52,27 @@ MENU_CHOICES: Final[tuple[str, ...]] = (
     "Exit",
 )
 
-USAGE: Final[str] = """\
-Usage: at [command] [flags]
 
-Commands:
-  install                      Launch the interactive menu
-  install --skill <name>...    Install the named skills, no menu
-  install --all                Install every catalog skill, no menu
-  uninstall --skill <name>...  Uninstall the named skills, no menu
-  update                       Pull the repo and refresh installed skills
-
-Flags:
-  --skill <name>     Skill to install or uninstall; repeat to act on several
-  --all              With 'install', act on every catalog skill
-  --non-interactive  Accepted with 'install --all' for scripted, non-TTY runs
-  -h, --help         Show this help screen and exit
-  --version          Show the version and exit
-"""
-
-KNOWN_TOKENS: Final[frozenset[str]] = frozenset(
-    {"--version", "-h", "--help", "install", "uninstall", "update"}
-)
+def _env_path(var: str, default: Path) -> Path:
+    """One env-override rule shared by the source-root and catalog seams so they
+    cannot drift: read var, else fall back to default. The e2e harness sets these
+    vars to point the installer at a fixture tree."""
+    override: str | None = os.environ.get(var)
+    return Path(override) if override else default
 
 
 def _source_root() -> Path:
-    """Resolve where skill sources are read from, honoring AT_SOURCE_ROOT so a
-    subprocess (e.g. the e2e harness) can point the installer at a fixture tree;
-    falls back to the repo's REPO_ROOT when the override is unset."""
-    override: str | None = os.environ.get("AT_SOURCE_ROOT")
-    return Path(override) if override else REPO_ROOT
+    """Where skill sources are read from: AT_SOURCE_ROOT points a subprocess at a
+    fixture tree, else the repo root. Reading REPO_ROOT here at call time keeps the
+    seam monkeypatchable by tests."""
+    return _env_path("AT_SOURCE_ROOT", REPO_ROOT)
 
 
 def _catalog_path() -> Path:
-    """Resolve which catalog the non-interactive CLI loads, honoring AT_CATALOG so a
-    subprocess (e.g. the e2e harness) can point at a fixture catalog; falls back to the
-    repo's CATALOG_PATH when the override is unset."""
-    override: str | None = os.environ.get("AT_CATALOG")
-    return Path(override) if override else CATALOG_PATH
+    """Which catalog the non-interactive CLI loads: AT_CATALOG points a subprocess
+    at a fixture catalog, else the repo's. Reading CATALOG_PATH here at call time
+    keeps the seam monkeypatchable by tests."""
+    return _env_path("AT_CATALOG", CATALOG_PATH)
 
 
 def _skill_marker(name: str, installed: frozenset[str]) -> str:
@@ -211,21 +196,6 @@ def _reject_unknown_skills(names: list[str], catalog: Catalog) -> int | None:
     return 2
 
 
-def _skill_values(argv: list[str]) -> list[str] | None:
-    """Parse the value following each --skill so the dispatch can validate a
-    skills request before acting; returns None when a --skill has no following
-    value (the last token), so a malformed request is a usage error, not a crash."""
-    values: list[str] = []
-    for index, token in enumerate(argv):
-        if token != "--skill":
-            continue
-        value_index: int = index + 1
-        if value_index >= len(argv):
-            return None
-        values.append(argv[value_index])
-    return values
-
-
 def _reconcile_to(ticked: frozenset[str], *, catalog: Catalog, state: State) -> int:
     """The one apply path every scriptable install/uninstall shares, so reconcile
     wiring lives in one place."""
@@ -252,7 +222,7 @@ def _install_named_skills(names: list[str]) -> int:
         return rejection
     state: State = load_state(STATE_ROOT)
     installed: set[str] = {
-        n for n in list_skills(catalog) if skill_unit_id(n) in state.units
+        name for name in list_skills(catalog) if skill_unit_id(name) in state.units
     }
     ticked: frozenset[str] = frozenset(installed | set(names))
     return _reconcile_to(ticked, catalog=catalog, state=state)
@@ -269,43 +239,67 @@ def _uninstall_named_skills(names: list[str]) -> int:
         return rejection
     state: State = load_state(STATE_ROOT)
     installed: set[str] = {
-        n for n in list_skills(catalog) if skill_unit_id(n) in state.units
+        name for name in list_skills(catalog) if skill_unit_id(name) in state.units
     }
     ticked: frozenset[str] = frozenset(installed - set(names))
     return _reconcile_to(ticked, catalog=catalog, state=state)
 
 
-def main(argv: list[str]) -> int:
-    if "--version" in argv:
-        print(f"at {AT_VERSION}")
-        return 0
-    if "--help" in argv or "-h" in argv:
-        print(USAGE)
-        return 0
-    if argv and argv[0] not in KNOWN_TOKENS:
-        print(f"error: unknown argument '{argv[0]}'", file=sys.stderr)
-        print("Try 'at --help' for usage.", file=sys.stderr)
-        return 2
-    if argv and argv[0] == "update":
-        return _run_update()
-    if argv and argv[0] == "install" and "--skill" in argv:
-        skill_names: list[str] | None = _skill_values(argv)
-        if skill_names is None:
-            print("error: --skill requires a skill name", file=sys.stderr)
-            print("Try 'at --help' for usage.", file=sys.stderr)
-            return 2
-        return _install_named_skills(skill_names)
-    if argv and argv[0] == "install" and "--all" in argv:
-        all_skills: list[str] = list_skills(load_catalog(_catalog_path()))
-        return _install_named_skills(all_skills)
-    if argv and argv[0] == "uninstall":
-        removed_names: list[str] | None = _skill_values(argv)
-        if "--skill" not in argv or removed_names is None:
-            print("error: uninstall requires --skill <name>", file=sys.stderr)
-            print("Try 'at --help' for usage.", file=sys.stderr)
-            return 2
-        return _uninstall_named_skills(removed_names)
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.version_option(
+    AT_VERSION, "--version", prog_name="at", message="%(prog)s %(version)s"
+)
+def cli() -> None:
+    """Manage agent-template skills from the CLI or an interactive menu."""
+
+
+@cli.command()
+@click.option("--skill", "skills", multiple=True, metavar="<name>")
+@click.option("--all", "install_all", is_flag=True)
+# Accepted so a scripted `install --all` can pass it, but it changes nothing: the
+# --all path never opens the menu, so the flag never needs to reach the callback.
+@click.option("--non-interactive", is_flag=True, expose_value=False)
+def install(skills: tuple[str, ...], install_all: bool) -> int:
+    """Install named skills (--skill/--all) without the menu, else open it."""
+    if skills:
+        return _install_named_skills(list(skills))
+    if install_all:
+        catalog_skills: list[str] = list_skills(load_catalog(_catalog_path()))
+        return _install_named_skills(catalog_skills)
     return launch_tui()
+
+
+@cli.command()
+@click.option("--skill", "skills", multiple=True, metavar="<name>")
+def uninstall(skills: tuple[str, ...]) -> int:
+    """Uninstall the named skills; at least one --skill is required."""
+    if not skills:
+        raise click.UsageError("uninstall requires at least one --skill <name>")
+    return _uninstall_named_skills(list(skills))
+
+
+@cli.command()
+def update() -> int:
+    """Pull the repo, then refresh every installed skill from its updated source."""
+    return _run_update()
+
+
+def main(argv: list[str]) -> int:
+    """The stable int-returning entry every test and the `at` wrapper call: run the
+    click group without its process-exiting shell and translate the outcome to an exit
+    code, so click owns parsing while callers keep a plain function boundary."""
+    try:
+        outcome: int | None = cli.main(args=argv, prog_name="at", standalone_mode=False)
+    except click.exceptions.ClickException as click_error:
+        # Non-standalone click re-raises usage/parse errors instead of exiting; show
+        # the message on stderr ourselves and surface its code (2 for usage errors).
+        click_error.show()
+        return click_error.exit_code
+    except click.exceptions.Exit as click_exit:
+        return click_exit.exit_code
+    except SystemExit as system_exit:
+        return system_exit.code if isinstance(system_exit.code, int) else 0
+    return outcome if isinstance(outcome, int) else 0
 
 
 if __name__ == "__main__":

--- a/installer/at.py
+++ b/installer/at.py
@@ -174,6 +174,29 @@ def _run_update() -> int:
     return 0
 
 
+def _install_named_skill(name: str) -> int:
+    """Install one named skill without the TUI, so `at install --skill <name>` is a
+    scriptable path that drives the same declarative reconcile the menu does. Install
+    is additive: the named skill joins whatever is already installed."""
+    catalog: Catalog = load_catalog(CATALOG_PATH)
+    state: State = load_state(STATE_ROOT)
+    installed: set[str] = {
+        n for n in list_skills(catalog) if skill_unit_id(n) in state.units
+    }
+    ticked: frozenset[str] = frozenset(installed | {name})
+    plan: ReconcilePlan = plan_skill_reconcile(
+        ticked=ticked, catalog=catalog, state=state
+    )
+    apply_skill_reconcile(
+        plan=plan,
+        source_root=REPO_ROOT,
+        state_root=STATE_ROOT,
+        claude_root=CLAUDE_ROOT,
+        state=state,
+    )
+    return 0
+
+
 def main(argv: list[str]) -> int:
     if "--version" in argv:
         print(f"at {AT_VERSION}")
@@ -187,6 +210,9 @@ def main(argv: list[str]) -> int:
         return 2
     if argv and argv[0] == "update":
         return _run_update()
+    if argv and argv[0] == "install" and "--skill" in argv:
+        skill_name: str = argv[argv.index("--skill") + 1]
+        return _install_named_skill(skill_name)
     return launch_tui()
 
 

--- a/installer/at.py
+++ b/installer/at.py
@@ -3,6 +3,7 @@
 # requires-python = ">=3.11"
 # dependencies = ["questionary", "rich"]
 # ///
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -65,6 +66,14 @@ Flags:
 KNOWN_TOKENS: Final[frozenset[str]] = frozenset(
     {"--version", "-h", "--help", "install", "uninstall", "update"}
 )
+
+
+def _source_root() -> Path:
+    """Resolve where skill sources are read from, honoring AT_SOURCE_ROOT so a
+    subprocess (e.g. the e2e harness) can point the installer at a fixture tree;
+    falls back to the repo's REPO_ROOT when the override is unset."""
+    override: str | None = os.environ.get("AT_SOURCE_ROOT")
+    return Path(override) if override else REPO_ROOT
 
 
 def _skill_marker(name: str, installed: frozenset[str]) -> str:
@@ -189,7 +198,7 @@ def _install_named_skills(names: list[str]) -> int:
     )
     apply_skill_reconcile(
         plan=plan,
-        source_root=REPO_ROOT,
+        source_root=_source_root(),
         state_root=STATE_ROOT,
         claude_root=CLAUDE_ROOT,
         state=state,
@@ -213,7 +222,7 @@ def _uninstall_named_skills(names: list[str]) -> int:
     )
     apply_skill_reconcile(
         plan=plan,
-        source_root=REPO_ROOT,
+        source_root=_source_root(),
         state_root=STATE_ROOT,
         claude_root=CLAUDE_ROOT,
         state=state,

--- a/installer/at.py
+++ b/installer/at.py
@@ -174,16 +174,16 @@ def _run_update() -> int:
     return 0
 
 
-def _install_named_skill(name: str) -> int:
-    """Install one named skill without the TUI, so `at install --skill <name>` is a
-    scriptable path that drives the same declarative reconcile the menu does. Install
-    is additive: the named skill joins whatever is already installed."""
+def _install_named_skills(names: list[str]) -> int:
+    """Install every named skill without the TUI, so `at install --skill <name> ...`
+    is a scriptable path that drives the same declarative reconcile the menu does.
+    Install is additive: the named skills join whatever is already installed."""
     catalog: Catalog = load_catalog(CATALOG_PATH)
     state: State = load_state(STATE_ROOT)
     installed: set[str] = {
         n for n in list_skills(catalog) if skill_unit_id(n) in state.units
     }
-    ticked: frozenset[str] = frozenset(installed | {name})
+    ticked: frozenset[str] = frozenset(installed | set(names))
     plan: ReconcilePlan = plan_skill_reconcile(
         ticked=ticked, catalog=catalog, state=state
     )
@@ -211,8 +211,10 @@ def main(argv: list[str]) -> int:
     if argv and argv[0] == "update":
         return _run_update()
     if argv and argv[0] == "install" and "--skill" in argv:
-        skill_name: str = argv[argv.index("--skill") + 1]
-        return _install_named_skill(skill_name)
+        skill_names: list[str] = [
+            argv[i + 1] for i, token in enumerate(argv) if token == "--skill"
+        ]
+        return _install_named_skills(skill_names)
     return launch_tui()
 
 

--- a/installer/at.py
+++ b/installer/at.py
@@ -215,6 +215,9 @@ def main(argv: list[str]) -> int:
             argv[i + 1] for i, token in enumerate(argv) if token == "--skill"
         ]
         return _install_named_skills(skill_names)
+    if argv and argv[0] == "install" and "--all" in argv:
+        all_skills: list[str] = list_skills(load_catalog(CATALOG_PATH))
+        return _install_named_skills(all_skills)
     return launch_tui()
 
 

--- a/installer/at.py
+++ b/installer/at.py
@@ -220,6 +220,22 @@ def _skill_values(argv: list[str]) -> list[str] | None:
     return values
 
 
+def _reconcile_to(ticked: frozenset[str], *, catalog: Catalog, state: State) -> int:
+    """The one apply path every scriptable install/uninstall shares, so reconcile
+    wiring lives in one place."""
+    plan: ReconcilePlan = plan_skill_reconcile(
+        ticked=ticked, catalog=catalog, state=state
+    )
+    apply_skill_reconcile(
+        plan=plan,
+        source_root=_source_root(),
+        state_root=STATE_ROOT,
+        claude_root=CLAUDE_ROOT,
+        state=state,
+    )
+    return 0
+
+
 def _install_named_skills(names: list[str]) -> int:
     """Install every named skill without the TUI, so `at install --skill <name> ...`
     is a scriptable path that drives the same declarative reconcile the menu does.
@@ -233,17 +249,7 @@ def _install_named_skills(names: list[str]) -> int:
         n for n in list_skills(catalog) if skill_unit_id(n) in state.units
     }
     ticked: frozenset[str] = frozenset(installed | set(names))
-    plan: ReconcilePlan = plan_skill_reconcile(
-        ticked=ticked, catalog=catalog, state=state
-    )
-    apply_skill_reconcile(
-        plan=plan,
-        source_root=_source_root(),
-        state_root=STATE_ROOT,
-        claude_root=CLAUDE_ROOT,
-        state=state,
-    )
-    return 0
+    return _reconcile_to(ticked, catalog=catalog, state=state)
 
 
 def _uninstall_named_skills(names: list[str]) -> int:
@@ -260,17 +266,7 @@ def _uninstall_named_skills(names: list[str]) -> int:
         n for n in list_skills(catalog) if skill_unit_id(n) in state.units
     }
     ticked: frozenset[str] = frozenset(installed - set(names))
-    plan: ReconcilePlan = plan_skill_reconcile(
-        ticked=ticked, catalog=catalog, state=state
-    )
-    apply_skill_reconcile(
-        plan=plan,
-        source_root=_source_root(),
-        state_root=STATE_ROOT,
-        claude_root=CLAUDE_ROOT,
-        state=state,
-    )
-    return 0
+    return _reconcile_to(ticked, catalog=catalog, state=state)
 
 
 def main(argv: list[str]) -> int:

--- a/installer/pyproject.toml
+++ b/installer/pyproject.toml
@@ -6,7 +6,11 @@ name = "at-installer"
 version = "0.2.0"
 description = "Interactive installer for agent-templates."
 requires-python = ">=3.11"
-dependencies = ["questionary>=2", "rich>=13"]
+dependencies = [
+    "click>=8.4.1",
+    "questionary>=2",
+    "rich>=13",
+]
 
 [dependency-groups]
 dev = [

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -857,3 +857,66 @@ def test_install_all_flag_installs_every_catalog_skill_non_interactively(
         assert (claude_root / "skills" / name).is_symlink()
         assert (state_root / "staged" / "skill" / name).exists()
         assert skill_unit_id(name) in final_state.units
+
+
+def test_uninstall_skill_flag_removes_named_skill_leaving_others_installed(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # Real sources for both skills exist and both are installed up front, so a
+    # targeted uninstall must drop only demo-a and leave demo-b fully in place.
+    state: State = load_state(state_root)
+    for name in ("demo-a", "demo-b"):
+        source: Path = repo_root / "skills" / name / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(f"# {name}\n", encoding="utf-8")
+        state = install_skill(
+            name=name,
+            source_root=repo_root,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=state,
+        )
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-a"\n\n'
+        '[[units]]\nkind = "skill"\nname = "demo-b"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # Uninstall must remove the skill without ever opening the TUI: route every
+    # questionary prompt to a factory that fails loudly, so a regression that falls
+    # back through launch_tui's select/checkbox/confirm trips this guard, not a prompt.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["uninstall", "--skill", "demo-a"])
+
+    # Today `uninstall` is an unknown subcommand, so main returns 2 and removes
+    # nothing: demo-a's link, staging, and state entry all survive, making the
+    # exit-zero and demo-a-removed assertions the right-reason RED.
+    final_state: State = load_state(state_root)
+    demo_a_link: Path = claude_root / "skills" / "demo-a"
+    demo_a_staging: Path = state_root / "staged" / "skill" / "demo-a"
+    demo_b_link: Path = claude_root / "skills" / "demo-b"
+    demo_b_staging: Path = state_root / "staged" / "skill" / "demo-b"
+    assert exit_code == 0
+    assert not demo_a_link.exists() and not demo_a_link.is_symlink()
+    assert not demo_a_staging.exists()
+    assert skill_unit_id("demo-a") not in final_state.units
+    assert demo_b_link.is_symlink()
+    assert demo_b_staging.exists()
+    assert skill_unit_id("demo-b") in final_state.units

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -1042,3 +1042,47 @@ def test_install_skill_loads_catalog_from_at_catalog_override(
     assert skill_link.is_symlink()
     assert skill_staging.exists()
     assert skill_unit_id("target-skill") in final_state.units
+
+
+def test_install_unknown_skill_errors_with_exit_two_and_installs_nothing(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # The catalog lists a real skill (demo-a) but never 'nonesuch', so the request
+    # names an unknown skill. No source is staged: a correct run installs nothing.
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        'packages = []\nbundles = []\n\n[[units]]\nkind = "skill"\nname = "demo-a"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # The error path must stay non-interactive: route every questionary prompt to a
+    # factory that fails loudly, so a regression that falls back into launch_tui's
+    # select/checkbox/confirm trips this guard instead of silently prompting.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["install", "--skill", "nonesuch"])
+
+    # Today the unknown name builds an empty plan and main returns 0 having done
+    # nothing — a silent success on a typo. The exit-two and stderr checks are the
+    # right-reason RED; the nothing-installed asserts pin the rest of the behavior.
+    captured_err: str = capsys.readouterr().err
+    final_state: State = load_state(state_root)
+    skill_link: Path = claude_root / "skills" / "nonesuch"
+    assert exit_code == 2
+    assert captured_err != ""
+    assert "nonesuch" in captured_err
+    assert not skill_link.exists() and not skill_link.is_symlink()
+    assert skill_unit_id("nonesuch") not in final_state.units

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -795,9 +795,9 @@ def test_multiple_skill_flags_install_all_named_skills_additively(
 
     exit_code: int = main(["install", "--skill", "demo-b", "--skill", "demo-c"])
 
-    # Each --skill flag must install its skill while the pre-installed demo-a survives:
-    # today's parser reads only the first --skill (demo-b), so demo-c is never placed
-    # and its assertions are the right-reason RED; demo-a and demo-b already pass.
+    # Each --skill installs its own skill additively: the two named skills (demo-b,
+    # demo-c) both land, and the pre-installed demo-a survives untouched, so all three
+    # end up linked, staged, and recorded in state.
     final_state: State = load_state(state_root)
     assert exit_code == 0
     for name in ("demo-a", "demo-b", "demo-c"):
@@ -846,9 +846,9 @@ def test_install_all_flag_installs_every_catalog_skill_non_interactively(
     exit_code: int = main(["install", "--all", "--non-interactive"])
 
     # Derive the expected set from the catalog so the check tracks every declared skill,
-    # and pin it non-empty so the per-skill loop can't pass vacuously. Today --all is
-    # unhandled, so main falls through to launch_tui and installs nothing: the first
-    # is_symlink assertion below is the right-reason RED.
+    # and pin it non-empty so the per-skill loop can't pass vacuously. `install --all`
+    # selects every catalog skill and installs each non-interactively, so every one
+    # ends up linked, staged, and recorded in state.
     expected_skills: list[str] = list_skills(load_catalog(catalog_file))
     final_state: State = load_state(state_root)
     assert exit_code == 0
@@ -905,9 +905,9 @@ def test_uninstall_skill_flag_removes_named_skill_leaving_others_installed(
 
     exit_code: int = main(["uninstall", "--skill", "demo-a"])
 
-    # Today `uninstall` is an unknown subcommand, so main returns 2 and removes
-    # nothing: demo-a's link, staging, and state entry all survive, making the
-    # exit-zero and demo-a-removed assertions the right-reason RED.
+    # `uninstall --skill demo-a` is subtractive: it removes only demo-a (its link,
+    # staging, and state entry all go), while demo-b stays linked, staged, and
+    # recorded in state, and the command exits zero.
     final_state: State = load_state(state_root)
     demo_a_link: Path = claude_root / "skills" / "demo-a"
     demo_a_staging: Path = state_root / "staged" / "skill" / "demo-a"
@@ -967,10 +967,10 @@ def test_install_skill_stages_source_from_at_source_root_override(
 
     exit_code: int = main(["install", "--skill", "demo-skill"])
 
-    # Today no AT_SOURCE_ROOT seam exists, so the install still sources from REPO_ROOT
-    # and stages the repo content: the skill installs cleanly (exit 0, live symlink, and
-    # state entry all pass) while the staged SKILL.md holds "# from repo source". The
-    # content equality is the right-reason RED: the source is wrong, not the install.
+    # AT_SOURCE_ROOT wins over REPO_ROOT: the install reads from the fixture tree, so
+    # the staged SKILL.md holds the fixture content, not the repo content. The skill
+    # installs cleanly too (exit 0, live symlink, and state entry), but the staged
+    # content is what pins that the override, not REPO_ROOT, supplied the source.
     final_state: State = load_state(state_root)
     skill_link: Path = claude_root / "skills" / "demo-skill"
     staged_skill_md: Path = state_root / "staged" / "skill" / "demo-skill" / "SKILL.md"
@@ -1030,11 +1030,10 @@ def test_install_skill_loads_catalog_from_at_catalog_override(
 
     exit_code: int = main(["install", "--skill", "target-skill"])
 
-    # Today the CLI always loads CATALOG_PATH (the decoy listing only other-skill), so
-    # target-skill is absent from the catalog, never enters the reconcile plan, and the
-    # empty plan is a clean exit-0 no-op: the is_symlink/staging/state assertions are
-    # the right-reason RED. Once AT_CATALOG is honored, the override catalog lists
-    # target-skill and the install places it.
+    # AT_CATALOG wins over CATALOG_PATH: the install loads the override catalog, which
+    # lists target-skill, so target-skill enters the reconcile plan and is placed
+    # (exit 0, live symlink, staging, and state entry). The decoy default catalog
+    # lists only other-skill, so loading it instead would place nothing.
     final_state: State = load_state(state_root)
     skill_link: Path = claude_root / "skills" / "target-skill"
     skill_staging: Path = state_root / "staged" / "skill" / "target-skill"
@@ -1075,9 +1074,9 @@ def test_install_unknown_skill_errors_with_exit_two_and_installs_nothing(
 
     exit_code: int = main(["install", "--skill", "nonesuch"])
 
-    # Today the unknown name builds an empty plan and main returns 0 having done
-    # nothing — a silent success on a typo. The exit-two and stderr checks are the
-    # right-reason RED; the nothing-installed asserts pin the rest of the behavior.
+    # An unknown --skill name is rejected before any reconcile: main exits 2 and names
+    # the bad skill ('nonesuch') on stderr, and nothing is installed (no link, no
+    # state entry), so a typo fails loudly instead of silently no-opping.
     captured_err: str = capsys.readouterr().err
     final_state: State = load_state(state_root)
     skill_link: Path = claude_root / "skills" / "nonesuch"

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -920,3 +920,61 @@ def test_uninstall_skill_flag_removes_named_skill_leaving_others_installed(
     assert demo_b_link.is_symlink()
     assert demo_b_staging.exists()
     assert skill_unit_id("demo-b") in final_state.units
+
+
+def test_install_skill_stages_source_from_at_source_root_override(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_src: Path = tmp_path / "repo"
+    fixture_src: Path = tmp_path / "fixture"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_src)
+
+    # The same skill name lives under two source roots with deliberately distinct
+    # content, so the staged copy's text alone reveals which root the install read
+    # from. AT_SOURCE_ROOT must win: the e2e harness points it at fixture skills so
+    # the real `at` never sources from the repo's live skills/ tree.
+    fixture_content: str = "# from fixture source\n"
+    repo_content: str = "# from repo source\n"
+    fixture_skill: Path = fixture_src / "skills" / "demo-skill" / "SKILL.md"
+    fixture_skill.parent.mkdir(parents=True)
+    fixture_skill.write_text(fixture_content, encoding="utf-8")
+    repo_skill: Path = repo_src / "skills" / "demo-skill" / "SKILL.md"
+    repo_skill.parent.mkdir(parents=True)
+    repo_skill.write_text(repo_content, encoding="utf-8")
+    monkeypatch.setenv("AT_SOURCE_ROOT", str(fixture_src))
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-skill"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # The override path must place the skill without ever opening the TUI: route every
+    # questionary prompt to a factory that fails loudly, so a regression that falls back
+    # through launch_tui's select/checkbox/confirm trips this guard, not a prompt.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["install", "--skill", "demo-skill"])
+
+    # Today no AT_SOURCE_ROOT seam exists, so the install still sources from REPO_ROOT
+    # and stages the repo content: the skill installs cleanly (exit 0, live symlink, and
+    # state entry all pass) while the staged SKILL.md holds "# from repo source". The
+    # content equality is the right-reason RED: the source is wrong, not the install.
+    final_state: State = load_state(state_root)
+    skill_link: Path = claude_root / "skills" / "demo-skill"
+    staged_skill_md: Path = state_root / "staged" / "skill" / "demo-skill" / "SKILL.md"
+    assert exit_code == 0
+    assert skill_link.is_symlink()
+    assert skill_unit_id("demo-skill") in final_state.units
+    assert staged_skill_md.read_text(encoding="utf-8") == fixture_content

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -1,6 +1,7 @@
 import subprocess
 from collections.abc import Callable, Iterator
 from pathlib import Path
+from typing import NoReturn
 
 import pytest
 import questionary
@@ -701,3 +702,48 @@ def test_update_pulls_repo_then_refreshes_installed_skill(
     assert pull_kwargs["cwd"] == repo_root
     assert final_hash == hash_unit(skill_source)
     assert final_hash != install_hash
+
+
+def test_install_skill_flag_installs_named_skill_non_interactively(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # A real skill source on disk is the only input the non-interactive install needs;
+    # nothing is installed up front, so a clean run must stage, link, and record it.
+    source: Path = repo_root / "skills" / "demo-skill" / "SKILL.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("# demo-skill\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-skill"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # The --skill path must place the skill without ever opening the TUI: route every
+    # questionary prompt to a factory that fails loudly, so a regression that falls back
+    # through launch_tui's select/checkbox/confirm trips this guard, not a prompt.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["install", "--skill", "demo-skill"])
+
+    final_state: State = load_state(state_root)
+    skill_link: Path = claude_root / "skills" / "demo-skill"
+    skill_staging: Path = state_root / "staged" / "skill" / "demo-skill"
+    assert exit_code == 0
+    assert skill_link.is_symlink()
+    assert skill_staging.exists()
+    assert skill_unit_id("demo-skill") in final_state.units

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -978,3 +978,67 @@ def test_install_skill_stages_source_from_at_source_root_override(
     assert skill_link.is_symlink()
     assert skill_unit_id("demo-skill") in final_state.units
     assert staged_skill_md.read_text(encoding="utf-8") == fixture_content
+
+
+def test_install_skill_loads_catalog_from_at_catalog_override(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # A real source for target-skill lives under REPO_ROOT (AT_SOURCE_ROOT stays unset),
+    # so once the override catalog puts target-skill in the plan the install has a tree
+    # to stage from.
+    source: Path = repo_root / "skills" / "target-skill" / "SKILL.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("# target-skill\n", encoding="utf-8")
+
+    # The DEFAULT catalog is a decoy: a valid, non-empty catalog that lists only
+    # other-skill and never target-skill. The e2e harness runs the real `at` against a
+    # fixture catalog, so loading CATALOG_PATH instead of AT_CATALOG must place nothing.
+    default_catalog: Path = tmp_path / "default-catalog.toml"
+    default_catalog.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "other-skill"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", default_catalog)
+
+    # The OVERRIDE catalog lists target-skill; pointing AT_CATALOG at it must be what
+    # makes the reconcile see target-skill at all.
+    override_catalog: Path = tmp_path / "override-catalog.toml"
+    override_catalog.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "target-skill"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AT_CATALOG", str(override_catalog))
+
+    # The override path must place the skill without ever opening the TUI: route every
+    # questionary prompt to a factory that fails loudly, so a regression that falls back
+    # through launch_tui's select/checkbox/confirm trips this guard, not a prompt.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["install", "--skill", "target-skill"])
+
+    # Today the CLI always loads CATALOG_PATH (the decoy listing only other-skill), so
+    # target-skill is absent from the catalog, never enters the reconcile plan, and the
+    # empty plan is a clean exit-0 no-op: the is_symlink/staging/state assertions are
+    # the right-reason RED. Once AT_CATALOG is honored, the override catalog lists
+    # target-skill and the install places it.
+    final_state: State = load_state(state_root)
+    skill_link: Path = claude_root / "skills" / "target-skill"
+    skill_staging: Path = state_root / "staged" / "skill" / "target-skill"
+    assert exit_code == 0
+    assert skill_link.is_symlink()
+    assert skill_staging.exists()
+    assert skill_unit_id("target-skill") in final_state.units

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -18,7 +18,7 @@ from at import (
     main,
     skill_rows,
 )
-from catalog import Catalog, Unit, skill_unit_id
+from catalog import Catalog, Unit, list_skills, load_catalog, skill_unit_id
 from hashing import hash_unit
 from state import State, load_state
 
@@ -801,6 +801,59 @@ def test_multiple_skill_flags_install_all_named_skills_additively(
     final_state: State = load_state(state_root)
     assert exit_code == 0
     for name in ("demo-a", "demo-b", "demo-c"):
+        assert (claude_root / "skills" / name).is_symlink()
+        assert (state_root / "staged" / "skill" / name).exists()
+        assert skill_unit_id(name) in final_state.units
+
+
+def test_install_all_flag_installs_every_catalog_skill_non_interactively(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # Real sources for all three catalog skills exist and nothing is installed up front,
+    # so a clean --all run must stage, link, and record every one of them.
+    for name in ("demo-a", "demo-b", "demo-c"):
+        source: Path = repo_root / "skills" / name / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(f"# {name}\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-a"\n\n'
+        '[[units]]\nkind = "skill"\nname = "demo-b"\n\n'
+        '[[units]]\nkind = "skill"\nname = "demo-c"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # Installing every skill must never open the TUI: route each questionary prompt to a
+    # factory that fails loudly, so a regression that falls back through launch_tui's
+    # select/checkbox/confirm trips this guard instead of waiting on a prompt.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["install", "--all", "--non-interactive"])
+
+    # Derive the expected set from the catalog so the check tracks every declared skill,
+    # and pin it non-empty so the per-skill loop can't pass vacuously. Today --all is
+    # unhandled, so main falls through to launch_tui and installs nothing: the first
+    # is_symlink assertion below is the right-reason RED.
+    expected_skills: list[str] = list_skills(load_catalog(catalog_file))
+    final_state: State = load_state(state_root)
+    assert exit_code == 0
+    assert expected_skills == ["demo-a", "demo-b", "demo-c"]
+    for name in expected_skills:
         assert (claude_root / "skills" / name).is_symlink()
         assert (state_root / "staged" / "skill" / name).exists()
         assert skill_unit_id(name) in final_state.units

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -747,3 +747,60 @@ def test_install_skill_flag_installs_named_skill_non_interactively(
     assert skill_link.is_symlink()
     assert skill_staging.exists()
     assert skill_unit_id("demo-skill") in final_state.units
+
+
+def test_multiple_skill_flags_install_all_named_skills_additively(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # Real sources for all three skills exist, but only demo-a is installed up front,
+    # so an additive multi-flag install must keep demo-a and add both demo-b and demo-c.
+    for name in ("demo-a", "demo-b", "demo-c"):
+        source: Path = repo_root / "skills" / name / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(f"# {name}\n", encoding="utf-8")
+    install_skill(
+        name="demo-a",
+        source_root=repo_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=load_state(state_root),
+    )
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-a"\n\n'
+        '[[units]]\nkind = "skill"\nname = "demo-b"\n\n'
+        '[[units]]\nkind = "skill"\nname = "demo-c"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # Every named skill must be placed without ever opening the TUI: route each
+    # questionary prompt to a factory that fails loudly, so a regression that falls
+    # back through launch_tui's select/checkbox/confirm trips this guard, not a prompt.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["install", "--skill", "demo-b", "--skill", "demo-c"])
+
+    # Each --skill flag must install its skill while the pre-installed demo-a survives:
+    # today's parser reads only the first --skill (demo-b), so demo-c is never placed
+    # and its assertions are the right-reason RED; demo-a and demo-b already pass.
+    final_state: State = load_state(state_root)
+    assert exit_code == 0
+    for name in ("demo-a", "demo-b", "demo-c"):
+        assert (claude_root / "skills" / name).is_symlink()
+        assert (state_root / "staged" / "skill" / name).exists()
+        assert skill_unit_id(name) in final_state.units

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -1112,9 +1112,9 @@ def test_malformed_skill_request_exits_two_without_crash_or_tui(
 
     exit_code: int = main(argv)
 
-    # Today a `--skill` with no value indexes argv past its end and raises IndexError,
-    # while a bare `uninstall` falls through to launch_tui and returns 0: each form is
-    # a crash or a wrong exit code, not the clean exit-2 usage error pinned here.
+    # A malformed skills request is a clean usage error: a `--skill` with no value, or
+    # a bare `uninstall` with no `--skill`, exits 2 with a stderr message. It is never
+    # a crash and never the TUI; a bare `install`, by contrast, still opens the menu.
     captured_err: str = capsys.readouterr().err
     assert exit_code == 2
     assert captured_err.strip() != ""

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -1086,3 +1086,36 @@ def test_install_unknown_skill_errors_with_exit_two_and_installs_nothing(
     assert "nonesuch" in captured_err
     assert not skill_link.exists() and not skill_link.is_symlink()
     assert skill_unit_id("nonesuch") not in final_state.units
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [["install", "--skill"], ["uninstall", "--skill"], ["uninstall"]],
+)
+def test_malformed_skill_request_exits_two_without_crash_or_tui(
+    argv: list[str],
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr("at.STATE_ROOT", tmp_path / "at")
+    monkeypatch.setattr("at.CLAUDE_ROOT", tmp_path / "claude")
+
+    # A malformed skills request must resolve as a usage error, never by opening the
+    # TUI: route every questionary prompt to a factory that fails loudly, so a fall
+    # through into launch_tui's select/checkbox/confirm trips this guard, not a prompt.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(argv)
+
+    # Today a `--skill` with no value indexes argv past its end and raises IndexError,
+    # while a bare `uninstall` falls through to launch_tui and returns 0: each form is
+    # a crash or a wrong exit code, not the clean exit-2 usage error pinned here.
+    captured_err: str = capsys.readouterr().err
+    assert exit_code == 2
+    assert captured_err.strip() != ""

--- a/installer/uv.lock
+++ b/installer/uv.lock
@@ -51,6 +51,7 @@ name = "at-installer"
 version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "click" },
     { name = "questionary" },
     { name = "rich" },
 ]
@@ -65,6 +66,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.4.1" },
     { name = "questionary", specifier = ">=2" },
     { name = "rich", specifier = ">=13" },
 ]
@@ -75,6 +77,18 @@ dev = [
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-cov", specifier = ">=6" },
     { name = "ruff", specifier = ">=0.9" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements **PR 4.5.1** from #74 — the non-interactive skills CLI that unblocks slice 4.5's e2e harness (4.5.2).

## What this adds

A scriptable, non-interactive path through the **existing declarative reconcile** — the same `plan_skill_reconcile`/`apply_skill_reconcile` the TUI uses, not a parallel install path:

- `at install --skill <name> [--skill <name> …]` — install named skills, **additively** over what's already installed (`ticked = installed ∪ named`)
- `at install --all --non-interactive` — install every catalog skill
- `at uninstall --skill <name> …` — uninstall named skills (`ticked = installed − named`), leaving the rest in place
- **Env seams for fixtures:** `AT_SOURCE_ROOT` overrides where skill *sources* are read from; `AT_CATALOG` overrides which *catalog* is loaded — so 4.5.2's subprocess can point the real `at` at frozen fixtures while `$HOME` relocates the install destination
- **Robustness:** an unknown `--skill` name, or a malformed invocation (`--skill` with no value, or a bare `uninstall`), exits **2** with a stderr message — atomic (nothing mutated), never the TUI. A bare `at install` still opens the menu.
- `at --help` now documents the full surface.

## How it was built

Live-RED TDD via the public `main(argv)` interface, one behavior per RED→GREEN cycle (8 behaviors). Reviewer + critic ran on the gate-green diff, followed by one batched fix round: the malformed-input crash fix, a behavior-preserving `_reconcile_to` extraction (de-duplicates the install/uninstall bodies), and documentation (USAGE + reworded test comments). Final reviewer score 90, critic **achieved (94)**.

## Testing

- `installer/` gate green: `ruff format --check .`, `ruff check .`, `mypy --strict .`, `pytest -W error` → **61 passed**
- Env seams proven with **decoy-vs-override** fixtures (the override must win for the skill to install/source correctly)
- Non-interactivity pinned: every CLI test stubs `questionary.select/checkbox/confirm` to fail loudly if the TUI is ever reached

## Follow-up (deferred, non-blocking)

The `error … / Try 'at --help' / return 2` usage-error idiom now appears 4× — a small `_usage_error()` helper would consolidate it (review MINOR, score 38; below the blocker bar).

Part of #74 — slice 4.5, PR 1 of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
