### PR TITLE
test(installer): e2e harness + golden snapshot + first scenario (PR 4.5.2)

### DIFF
--- a/installer/pyproject.toml
+++ b/installer/pyproject.toml
@@ -41,6 +41,7 @@ pythonpath = ["."]  # rootdir is installer/, so tests import the module under te
 # a genuinely untested path; don't write a test solely to colour a line.
 addopts = ["--cov=at", "--cov=state", "--cov=catalog", "--cov=placement", "--cov=reconcile", "--cov-report=term-missing"]
 filterwarnings = ["error"]
+markers = ["e2e: end-to-end tests that drive the real `at` via a uv-run subprocess (deselect with -m 'not e2e')"]
 
 [tool.coverage.run]
 branch = true

--- a/installer/tests/e2e/fixtures/catalog.toml
+++ b/installer/tests/e2e/fixtures/catalog.toml
@@ -1,0 +1,9 @@
+# Frozen fixture catalog for installer e2e scenarios. Deliberately minimal and
+# stable so goldens change only when installer BEHAVIOUR changes, never when a
+# real skill under ../../skills is edited.
+packages = []
+bundles = []
+
+[[units]]
+kind = "skill"
+name = "demo-skill"

--- a/installer/tests/e2e/fixtures/skills/demo-skill/SKILL.md
+++ b/installer/tests/e2e/fixtures/skills/demo-skill/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: demo-skill
+description: Frozen fixture skill for installer e2e snapshot scenarios.
+---
+
+# demo-skill
+
+A fixture skill with stable bytes so the e2e golden never churns.

--- a/installer/tests/e2e/goldens/install_one_skill.golden
+++ b/installer/tests/e2e/goldens/install_one_skill.golden
@@ -1,0 +1,8 @@
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/skill
+dir .claude/at/staged/skill/demo-skill
+file .claude/at/staged/skill/demo-skill/SKILL.md 25706be2cbf11d3e92d1cadb63751d482723dbcd91b3f32dc9931859308e1674
+json .claude/at/state.json {"units":{"skill/demo-skill":"763e7d2a3620743afe13cecae56bafec01e4346e8aa945bc63262e24b4ff4248"},"version":1}
+dir .claude/skills
+link .claude/skills/demo-skill -> .claude/at/staged/skill/demo-skill

--- a/installer/tests/e2e/harness.py
+++ b/installer/tests/e2e/harness.py
@@ -1,6 +1,7 @@
 import difflib
 import hashlib
 import json
+import os
 from pathlib import Path
 from typing import Final
 
@@ -9,6 +10,9 @@ _CLAUDE_DIRNAME: Final[str] = ".claude"
 # separators) so a golden pins the state's meaning rather than the byte order the
 # installer happened to write it in.
 _STATE_RELPATH: Final[str] = ".claude/at/state.json"
+# Setting this env var to any non-empty value flips the golden gate from comparing
+# to regenerating, so a vetted run can re-seed committed goldens without hand-edits.
+_BLESS_ENV: Final[str] = "AT_BLESS"
 
 
 def _descendants(directory: Path) -> list[Path]:
@@ -62,8 +66,16 @@ def snapshot(home: Path) -> str:
 
 def assert_matches_golden(*, name: str, actual: str, goldens_dir: Path) -> None:
     """Gate an e2e scenario's output against its committed golden so drift fails
-    loudly with a diff and a pointer to AT_BLESS, instead of passing silently."""
+    loudly with a diff and a pointer to AT_BLESS, instead of passing silently.
+
+    With AT_BLESS set, the golden is instead regenerated from `actual` (creating
+    `goldens_dir` and its parents) and no comparison runs, re-seeding the committed
+    golden from a vetted run."""
     golden_path: Path = goldens_dir / f"{name}.golden"
+    if os.environ.get(_BLESS_ENV):
+        goldens_dir.mkdir(parents=True, exist_ok=True)
+        golden_path.write_text(actual, encoding="utf-8")
+        return
     golden: str = golden_path.read_text(encoding="utf-8")
     if actual == golden:
         return

--- a/installer/tests/e2e/harness.py
+++ b/installer/tests/e2e/harness.py
@@ -2,6 +2,7 @@ import difflib
 import hashlib
 import json
 import os
+import subprocess
 from pathlib import Path
 from typing import Final
 
@@ -13,6 +14,21 @@ _STATE_RELPATH: Final[str] = ".claude/at/state.json"
 # Setting this env var to any non-empty value flips the golden gate from comparing
 # to regenerating, so a vetted run can re-seed committed goldens without hand-edits.
 _BLESS_ENV: Final[str] = "AT_BLESS"
+# The frozen fixtures (catalog + skill sources) and committed goldens live beside this
+# harness, so scenarios resolve them by file location rather than the process cwd.
+FIXTURES_DIR: Final[Path] = Path(__file__).parent / "fixtures"
+GOLDENS_DIR: Final[Path] = Path(__file__).parent / "goldens"
+# at.py lives in installer/ (two levels up from tests/e2e/), which is also the cwd the
+# real `at` shim runs it from; run_at mirrors that exactly so the subprocess resolves
+# at.py's sibling modules and inline-script deps just as a user's `at` does.
+_INSTALLER_DIR: Final[Path] = Path(__file__).parents[2]
+_AT_SCRIPT: Final[Path] = _INSTALLER_DIR / "at.py"
+# Captured at import, before any per-scenario HOME override, so the subprocess reuses
+# the developer/CI uv cache instead of re-resolving at.py's PEP 723 env under each
+# throwaway temp HOME — keeping e2e runs both fast and deterministic.
+_UV_CACHE_DIR: Final[str] = os.environ.get("UV_CACHE_DIR") or str(
+    Path.home() / ".cache" / "uv"
+)
 
 
 def _descendants(directory: Path) -> list[Path]:
@@ -91,4 +107,27 @@ def assert_matches_golden(*, name: str, actual: str, goldens_dir: Path) -> None:
     raise AssertionError(
         f"snapshot does not match golden {name!r}; "
         f"re-run with AT_BLESS=1 to regenerate it.\n{diff}"
+    )
+
+
+def run_at(
+    *, args: list[str], home: Path, source_root: Path, catalog: Path
+) -> subprocess.CompletedProcess[str]:
+    """Drive the real `at` CLI against an isolated home so e2e scenarios observe an
+    actual install rather than a mocked one, with the env seams pointed at the given
+    fixture source_root and catalog."""
+    env: dict[str, str] = {
+        **os.environ,
+        "HOME": str(home),
+        "AT_SOURCE_ROOT": str(source_root),
+        "AT_CATALOG": str(catalog),
+        "UV_CACHE_DIR": _UV_CACHE_DIR,
+    }
+    return subprocess.run(
+        ["uv", "run", str(_AT_SCRIPT), *args],
+        cwd=_INSTALLER_DIR,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
     )

--- a/installer/tests/e2e/harness.py
+++ b/installer/tests/e2e/harness.py
@@ -92,6 +92,10 @@ def assert_matches_golden(*, name: str, actual: str, goldens_dir: Path) -> None:
         goldens_dir.mkdir(parents=True, exist_ok=True)
         golden_path.write_text(actual, encoding="utf-8")
         return
+    if not golden_path.exists():
+        raise AssertionError(
+            f"no golden {name!r}; re-run with AT_BLESS=1 to create it."
+        )
     golden: str = golden_path.read_text(encoding="utf-8")
     if actual == golden:
         return

--- a/installer/tests/e2e/harness.py
+++ b/installer/tests/e2e/harness.py
@@ -1,0 +1,59 @@
+import hashlib
+import json
+from pathlib import Path
+from typing import Final
+
+_CLAUDE_DIRNAME: Final[str] = ".claude"
+# The install-state file is re-serialized canonically (sorted keys, compact
+# separators) so a golden pins the state's meaning rather than the byte order the
+# installer happened to write it in.
+_STATE_RELPATH: Final[str] = ".claude/at/state.json"
+
+
+def _descendants(directory: Path) -> list[Path]:
+    """Collect every entry beneath a directory while treating a symlink as a leaf,
+    so the snapshot records a link once instead of crossing into the tree it
+    targets (and looping or double-counting staged files)."""
+    found: list[Path] = []
+    for child in directory.iterdir():
+        found.append(child)
+        # is_symlink before is_dir: a symlink to a directory reports is_dir() true,
+        # yet it must stay a leaf so traversal never follows it.
+        if not child.is_symlink() and child.is_dir():
+            found.extend(_descendants(child))
+    return found
+
+
+def _render_entry(*, entry: Path, home: Path) -> str:
+    """Render one tree entry as a single normalized line keyed on its home-relative
+    POSIX path, so a golden stays independent of where home sits on disk."""
+    relpath: str = entry.relative_to(home).as_posix()
+    if entry.is_symlink():
+        target: Path = entry.readlink()
+        # Rewrite a target that lands inside home to a home-relative POSIX path so
+        # it survives relocation; a target pointing elsewhere is shown verbatim.
+        try:
+            shown: str = target.relative_to(home).as_posix()
+        except ValueError:
+            shown = str(target)
+        return f"link {relpath} -> {shown}"
+    if entry.is_dir():
+        return f"dir {relpath}"
+    if relpath == _STATE_RELPATH:
+        parsed: object = json.loads(entry.read_text(encoding="utf-8"))
+        canonical: str = json.dumps(parsed, sort_keys=True, separators=(",", ":"))
+        return f"json {relpath} {canonical}"
+    digest: str = hashlib.sha256(entry.read_bytes()).hexdigest()
+    return f"file {relpath} {digest}"
+
+
+def snapshot(home: Path) -> str:
+    """Exists so e2e scenarios can diff an installed tree against its golden.
+
+    The block is sorted by each entry's home-relative POSIX path and newline-
+    terminated, so an identical tree always renders to identical text regardless of
+    filesystem traversal order or where home lives."""
+    entries: list[Path] = _descendants(home / _CLAUDE_DIRNAME)
+    entries.sort(key=lambda entry: entry.relative_to(home).as_posix())
+    lines: list[str] = [_render_entry(entry=entry, home=home) for entry in entries]
+    return "\n".join(lines) + "\n"

--- a/installer/tests/e2e/harness.py
+++ b/installer/tests/e2e/harness.py
@@ -1,3 +1,4 @@
+import difflib
 import hashlib
 import json
 from pathlib import Path
@@ -57,3 +58,25 @@ def snapshot(home: Path) -> str:
     entries.sort(key=lambda entry: entry.relative_to(home).as_posix())
     lines: list[str] = [_render_entry(entry=entry, home=home) for entry in entries]
     return "\n".join(lines) + "\n"
+
+
+def assert_matches_golden(*, name: str, actual: str, goldens_dir: Path) -> None:
+    """Gate an e2e scenario's output against its committed golden so drift fails
+    loudly with a diff and a pointer to AT_BLESS, instead of passing silently."""
+    golden_path: Path = goldens_dir / f"{name}.golden"
+    golden: str = golden_path.read_text(encoding="utf-8")
+    if actual == golden:
+        return
+    diff: str = "\n".join(
+        difflib.unified_diff(
+            golden.splitlines(),
+            actual.splitlines(),
+            fromfile=f"{name}.golden",
+            tofile="actual",
+            lineterm="",
+        )
+    )
+    raise AssertionError(
+        f"snapshot does not match golden {name!r}; "
+        f"re-run with AT_BLESS=1 to regenerate it.\n{diff}"
+    )

--- a/installer/tests/e2e/test_harness.py
+++ b/installer/tests/e2e/test_harness.py
@@ -2,7 +2,9 @@ import hashlib
 import json
 from pathlib import Path
 
-from harness import snapshot
+import pytest
+from harness import assert_matches_golden, snapshot
+from pytest import MonkeyPatch
 
 
 def test_snapshot_renders_installed_tree_as_sorted_normalized_lines(
@@ -47,3 +49,28 @@ def test_snapshot_renders_installed_tree_as_sorted_normalized_lines(
     expected: str = "\n".join(expected_lines) + "\n"
 
     assert snapshot(home) == expected
+
+
+def test_golden_compare_accepts_match_and_rejects_drift(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # A stray AT_BLESS in the developer's shell must never turn this compare into a
+    # silent bless, so pin the environment to the plain compare regime first.
+    monkeypatch.delenv("AT_BLESS", raising=False)
+
+    golden_text: str = "line-a\nline-b\n"
+    golden_path: Path = tmp_path / "demo.golden"
+    golden_path.write_text(golden_text, encoding="utf-8")
+
+    # An identical snapshot is accepted: the gate completes without raising.
+    assert_matches_golden(name="demo", actual=golden_text, goldens_dir=tmp_path)
+
+    # Drift is rejected with a readable error that names the golden and points at
+    # AT_BLESS as the way to regenerate it.
+    drifted_text: str = "line-a\nDIFFERENT\n"
+    with pytest.raises(AssertionError) as exc_info:
+        assert_matches_golden(name="demo", actual=drifted_text, goldens_dir=tmp_path)
+    message: str = str(exc_info.value)
+    assert "demo" in message
+    assert "AT_BLESS" in message

--- a/installer/tests/e2e/test_harness.py
+++ b/installer/tests/e2e/test_harness.py
@@ -1,0 +1,49 @@
+import hashlib
+import json
+from pathlib import Path
+
+from harness import snapshot
+
+
+def test_snapshot_renders_installed_tree_as_sorted_normalized_lines(
+    tmp_path: Path,
+) -> None:
+    home: Path = tmp_path
+    claude_dir: Path = home / ".claude"
+
+    # A real nested file — its line must carry the sha256 of the file's bytes.
+    skill_bytes: bytes = b"# demo\n"
+    skill_dir: Path = claude_dir / "at" / "staged" / "skill" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_bytes(skill_bytes)
+
+    # The install state file, written with keys in non-canonical order, so the
+    # snapshot is forced to re-serialize it with sorted keys and compact
+    # separators rather than echo the on-disk byte order.
+    state_path: Path = claude_dir / "at" / "state.json"
+    with state_path.open("w", encoding="utf-8") as state_file:
+        json.dump({"version": 1, "units": {"skill/demo": "deadbeef"}}, state_file)
+
+    # A symlink pointing back into the staged tree. It must be recorded as a
+    # leaf (never descended into) and its absolute target rewritten relative to
+    # home, so the staged file appears once, via its real path only.
+    skills_dir: Path = claude_dir / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "demo").symlink_to(skill_dir)
+
+    skill_digest: str = hashlib.sha256(skill_bytes).hexdigest()
+    # Lines are ordered by each entry's home-relative POSIX path, and the block
+    # is newline-terminated so committed goldens stay POSIX text files.
+    expected_lines: list[str] = [
+        "dir .claude/at",
+        "dir .claude/at/staged",
+        "dir .claude/at/staged/skill",
+        "dir .claude/at/staged/skill/demo",
+        f"file .claude/at/staged/skill/demo/SKILL.md {skill_digest}",
+        'json .claude/at/state.json {"units":{"skill/demo":"deadbeef"},"version":1}',
+        "dir .claude/skills",
+        "link .claude/skills/demo -> .claude/at/staged/skill/demo",
+    ]
+    expected: str = "\n".join(expected_lines) + "\n"
+
+    assert snapshot(home) == expected

--- a/installer/tests/e2e/test_harness.py
+++ b/installer/tests/e2e/test_harness.py
@@ -74,3 +74,28 @@ def test_golden_compare_accepts_match_and_rejects_drift(
     message: str = str(exc_info.value)
     assert "demo" in message
     assert "AT_BLESS" in message
+
+
+def test_bless_regenerates_golden_from_actual(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # With AT_BLESS set, the gate must regenerate the golden from the fresh run
+    # instead of comparing, so a clean snapshot can re-seed the committed golden.
+    monkeypatch.setenv("AT_BLESS", "1")
+
+    # A goldens dir that does not exist yet proves bless creates it (and parents)
+    # rather than assuming a golden is already on disk to read and diff against.
+    goldens_dir: Path = tmp_path / "goldens"
+    fresh_content: str = "fresh-content\n"
+
+    assert_matches_golden(name="demo", actual=fresh_content, goldens_dir=goldens_dir)
+
+    blessed_path: Path = goldens_dir / "demo.golden"
+    assert blessed_path.exists()
+    assert blessed_path.read_text(encoding="utf-8") == fresh_content
+
+    # Round-trip: with AT_BLESS cleared, the just-blessed golden compares equal, so
+    # a bless followed by a plain run is a no-op rather than a drift failure.
+    monkeypatch.delenv("AT_BLESS", raising=False)
+    assert_matches_golden(name="demo", actual=fresh_content, goldens_dir=goldens_dir)

--- a/installer/tests/e2e/test_harness.py
+++ b/installer/tests/e2e/test_harness.py
@@ -99,3 +99,22 @@ def test_bless_regenerates_golden_from_actual(
     # a bless followed by a plain run is a no-op rather than a drift failure.
     monkeypatch.delenv("AT_BLESS", raising=False)
     assert_matches_golden(name="demo", actual=fresh_content, goldens_dir=goldens_dir)
+
+
+def test_golden_compare_rejects_missing_golden_with_bless_guidance(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # A stray AT_BLESS in the developer's shell would silently bless the absent
+    # golden instead of comparing, so pin the plain compare regime first.
+    monkeypatch.delenv("AT_BLESS", raising=False)
+
+    # Authoring a brand-new scenario begins with no committed golden on disk — the
+    # most common first-run state. Compare mode must meet that with the same
+    # actionable guidance the drift path gives (naming the golden and pointing at
+    # AT_BLESS), not a raw FileNotFoundError leaking out of read_text.
+    with pytest.raises(AssertionError) as exc_info:
+        assert_matches_golden(name="absent", actual="anything\n", goldens_dir=tmp_path)
+    message: str = str(exc_info.value)
+    assert "absent" in message
+    assert "AT_BLESS" in message

--- a/installer/tests/e2e/test_install_skill.py
+++ b/installer/tests/e2e/test_install_skill.py
@@ -1,0 +1,23 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+from harness import FIXTURES_DIR, GOLDENS_DIR, assert_matches_golden, run_at, snapshot
+
+
+@pytest.mark.e2e
+def test_install_one_skill_matches_golden(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+
+    result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--skill", "demo-skill", "--non-interactive"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=FIXTURES_DIR / "catalog.toml",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert_matches_golden(
+        name="install_one_skill", actual=snapshot(home), goldens_dir=GOLDENS_DIR
+    )


### PR DESCRIPTION
## Slice 4.5 · PR 4.5.2 — E2E harness + golden snapshot + first scenario

Part of #74 (installer epic). Turns "tick a skill and eyeball `~/.claude`" into a scriptable, gated suite that runs the **real** `at` binary against a **frozen** fixture catalog and diffs a committed golden snapshot. This is the harness that slices 4.5.3–4.5.5 and 5–8 each extend.

### What landed (`installer/tests/e2e/`)

- **`snapshot(home)`** — walks `~/.claude` (incl. `~/.claude/at`) into a normalized, sorted, deterministic text block: home-relative POSIX paths, symlink targets rewritten home-relative (symlinks treated as leaves — never descended), file contents as sha256, and `state.json` re-serialized canonically (sorted keys, compact). Independent of tmp-dir location and filesystem traversal order.
- **`assert_matches_golden(name, actual, goldens_dir)`** — diffs `actual` against the committed `<name>.golden`; on drift raises an `AssertionError` with a unified diff and a pointer to `AT_BLESS=1`; a missing golden gets the same actionable message (not a raw `FileNotFoundError`). `AT_BLESS=1` (re)generates the golden.
- **`run_at(args, home, source_root, catalog)`** — drives the real CLI as a `uv run at.py` subprocess (mirroring the `at` shim), pointing the existing `AT_SOURCE_ROOT` / `AT_CATALOG` env seams (from 4.5.1) at fixtures while `$HOME` relocates the install destination. `UV_CACHE_DIR` is pinned to the real cache so the subprocess reuses the cached PEP 723 script env (fast, offline-capable) instead of re-resolving under each temp `$HOME`.
- **Frozen fixtures** — `fixtures/catalog.toml` + `fixtures/skills/demo-skill/SKILL.md`, deliberately minimal and stable so goldens change only when installer **behaviour** changes, never when a real skill is edited.
- **First scenario** (`test_install_one_skill_matches_golden`, `@pytest.mark.e2e`) — installs one skill via the real subprocess into a temp `$HOME` and asserts the full installed tree (staged copy + `state.json` + live symlink) against `goldens/install_one_skill.golden`.
- The `e2e` pytest marker is registered, so CI (4.5.5) can split `pytest -m e2e` from `-m "not e2e"`.

### Verification

- Gates green: `ruff format --check`, `ruff check`, `mypy --strict`, `pytest -W error` → **66 passed**; `-m "not e2e"` → 64 passed + 1 deselected.
- The golden is deterministic and machine-independent — its `SKILL.md` sha256 equals the fixture's bytes and its `state.json` content hash was independently recomputed; an `AT_BLESS=1` re-generation is byte-identical.
- Built test-first (RED→GREEN per behavior) with a reviewer + critic pass; the reviewer's one actionable finding (friendlier missing-golden error) was applied here.

### Deliberately out of scope

- The GitHub Actions CI workflow that gates on golden drift — that's **PR 4.5.5**.
- Two dormant edges the reviewer scoped out under YAGNI (snapshot of an absent `.claude`; a symlink target outside `$HOME`) — neither can occur in the install-one-skill path; they'll be handled if/when a scenario can trigger them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
