### PR TITLE
test(installer): e2e lifecycle scenarios — uninstall, idempotent re-install, multi-skill (PR 4.5.3)

### DIFF
--- a/installer/tests/e2e/fixtures/catalog.toml
+++ b/installer/tests/e2e/fixtures/catalog.toml
@@ -7,3 +7,7 @@ bundles = []
 [[units]]
 kind = "skill"
 name = "demo-skill"
+
+[[units]]
+kind = "skill"
+name = "demo-skill-two"

--- a/installer/tests/e2e/fixtures/skills/demo-skill-two/SKILL.md
+++ b/installer/tests/e2e/fixtures/skills/demo-skill-two/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: demo-skill-two
+description: Second frozen fixture skill for installer e2e multi-skill scenarios.
+---
+
+# demo-skill-two
+
+A second fixture skill with stable bytes so multi-skill e2e goldens never churn.

--- a/installer/tests/e2e/goldens/install_two_skills.golden
+++ b/installer/tests/e2e/goldens/install_two_skills.golden
@@ -1,0 +1,11 @@
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/skill
+dir .claude/at/staged/skill/demo-skill
+dir .claude/at/staged/skill/demo-skill-two
+file .claude/at/staged/skill/demo-skill-two/SKILL.md ff3436a0c12035b4212dc3a83fa396ab7f1135f50314e0490715d0848bf8b460
+file .claude/at/staged/skill/demo-skill/SKILL.md 25706be2cbf11d3e92d1cadb63751d482723dbcd91b3f32dc9931859308e1674
+json .claude/at/state.json {"units":{"skill/demo-skill":"763e7d2a3620743afe13cecae56bafec01e4346e8aa945bc63262e24b4ff4248","skill/demo-skill-two":"112a14a7446a409b98435238e9dfdc915640e3aa94434ace60644531e0e09bf5"},"version":1}
+dir .claude/skills
+link .claude/skills/demo-skill -> .claude/at/staged/skill/demo-skill
+link .claude/skills/demo-skill-two -> .claude/at/staged/skill/demo-skill-two

--- a/installer/tests/e2e/goldens/uninstall_one_of_two.golden
+++ b/installer/tests/e2e/goldens/uninstall_one_of_two.golden
@@ -1,0 +1,8 @@
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/skill
+dir .claude/at/staged/skill/demo-skill-two
+file .claude/at/staged/skill/demo-skill-two/SKILL.md ff3436a0c12035b4212dc3a83fa396ab7f1135f50314e0490715d0848bf8b460
+json .claude/at/state.json {"units":{"skill/demo-skill-two":"112a14a7446a409b98435238e9dfdc915640e3aa94434ace60644531e0e09bf5"},"version":1}
+dir .claude/skills
+link .claude/skills/demo-skill-two -> .claude/at/staged/skill/demo-skill-two

--- a/installer/tests/e2e/goldens/uninstall_skill.golden
+++ b/installer/tests/e2e/goldens/uninstall_skill.golden
@@ -1,0 +1,5 @@
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/skill
+json .claude/at/state.json {"units":{},"version":1}
+dir .claude/skills

--- a/installer/tests/e2e/test_lifecycle.py
+++ b/installer/tests/e2e/test_lifecycle.py
@@ -1,0 +1,126 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+from harness import FIXTURES_DIR, GOLDENS_DIR, assert_matches_golden, run_at, snapshot
+
+
+@pytest.mark.e2e
+def test_uninstall_skill_leaves_clean_tree(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    install_result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--skill", "demo-skill", "--non-interactive"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    uninstall_result: subprocess.CompletedProcess[str] = run_at(
+        args=["uninstall", "--skill", "demo-skill"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert uninstall_result.returncode == 0, uninstall_result.stderr
+
+    assert_matches_golden(
+        name="uninstall_skill", actual=snapshot(home), goldens_dir=GOLDENS_DIR
+    )
+
+
+@pytest.mark.e2e
+def test_reinstall_is_idempotent(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    first_result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--skill", "demo-skill", "--non-interactive"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert first_result.returncode == 0, first_result.stderr
+    first: str = snapshot(home)
+
+    second_result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--skill", "demo-skill", "--non-interactive"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert second_result.returncode == 0, second_result.stderr
+    second: str = snapshot(home)
+
+    assert first == second
+
+    # Reusing install_one_skill is deliberate: re-installing must reproduce the
+    # single-install tree exactly, so the canonical golden IS the correct golden.
+    # Minting a byte-identical twin would just be a copy that can silently drift.
+    assert_matches_golden(
+        name="install_one_skill", actual=second, goldens_dir=GOLDENS_DIR
+    )
+
+
+@pytest.mark.e2e
+def test_install_two_skills(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    result: subprocess.CompletedProcess[str] = run_at(
+        args=[
+            "install",
+            "--skill",
+            "demo-skill",
+            "--skill",
+            "demo-skill-two",
+            "--non-interactive",
+        ],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert result.returncode == 0, result.stderr
+
+    assert_matches_golden(
+        name="install_two_skills", actual=snapshot(home), goldens_dir=GOLDENS_DIR
+    )
+
+
+@pytest.mark.e2e
+def test_uninstall_one_of_two_leaves_the_other(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    install_result: subprocess.CompletedProcess[str] = run_at(
+        args=[
+            "install",
+            "--skill",
+            "demo-skill",
+            "--skill",
+            "demo-skill-two",
+            "--non-interactive",
+        ],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    uninstall_result: subprocess.CompletedProcess[str] = run_at(
+        args=["uninstall", "--skill", "demo-skill"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert uninstall_result.returncode == 0, uninstall_result.stderr
+
+    assert_matches_golden(
+        name="uninstall_one_of_two", actual=snapshot(home), goldens_dir=GOLDENS_DIR
+    )


### PR DESCRIPTION
## PR 4.5.3 — Lifecycle scenarios I

Part of #74 (slice 4.5). Adds end-to-end lifecycle scenarios on top of the e2e harness landed in #95 (4.5.2). **Test + fixtures only — no production code.** Each scenario drives the real `at` CLI via the harness `run_at` subprocess against a temp `$HOME`, snapshots the installed `~/.claude` tree, and diffs a committed golden.

### Scenarios (`installer/tests/e2e/test_lifecycle.py`)
- **B1 — uninstall leaves a clean tree** (`uninstall_skill.golden`): install then uninstall `demo-skill`; golden shows empty `units:{}`, no `link`, no staged skill `file` — only empty scaffold dirs remain (faithful to the installer's real behavior).
- **B2 — idempotent re-install** (reuses `install_one_skill.golden`): install `demo-skill` twice; asserts `first == second` directly, then pins to the canonical single-install golden. No new golden is minted — a byte-identical twin would only invite drift.
- **B3 — multi-skill install** (`install_two_skills.golden`): installs `demo-skill` + `demo-skill-two` in one invocation; both staged + linked + in state.
- **B4 — selective multi-skill uninstall** (`uninstall_one_of_two.golden`): installs both, uninstalls only `demo-skill`; golden shows just `demo-skill-two` surviving.

### Fixtures
- New frozen fixture skill `demo-skill-two` (stable bytes) + its catalog unit. Adding the unit does **not** churn the existing `install_one_skill.golden` (that scenario installs `demo-skill` explicitly).

### Verification
- `uv run pytest -W error` → **70 passed** (was 66); e2e selection 5 passed; two runs byte-identical (deterministic).
- `ruff format --check` / `ruff check` / `mypy --strict` all clean.
- Goldens independently re-read; B1's golden proven non-vacuous (injecting a stray `link` line makes the test fail with a precise diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)