### PR TITLE
feat(installer): at update fixture seam + e2e lifecycle scenarios II (PR 4.5.4)

### DIFF
--- a/installer/at.py
+++ b/installer/at.py
@@ -169,11 +169,15 @@ def launch_tui() -> int:
 def _run_update() -> int:
     """Fast-forward the repo, then refresh only the installed skills whose upstream
     content changed, so `at update` is a single non-interactive sync."""
-    subprocess.run(["git", "pull", "--ff-only"], cwd=REPO_ROOT, check=True)
-    catalog: Catalog = load_catalog(CATALOG_PATH)
+    source_root: Path = _source_root()
+    # Only pull against the real repo checkout: an AT_SOURCE_ROOT override points the
+    # update at a fixture tree that has no upstream remote to fast-forward.
+    if source_root == REPO_ROOT:
+        subprocess.run(["git", "pull", "--ff-only"], cwd=REPO_ROOT, check=True)
+    catalog: Catalog = load_catalog(_catalog_path())
     state: State = load_state(STATE_ROOT)
     update_installed_skills(
-        source_root=REPO_ROOT,
+        source_root=source_root,
         state_root=STATE_ROOT,
         claude_root=CLAUDE_ROOT,
         catalog=catalog,

--- a/installer/at.py
+++ b/installer/at.py
@@ -167,8 +167,9 @@ def launch_tui() -> int:
 
 
 def _run_update() -> int:
-    """Fast-forward the repo, then refresh only the installed skills whose upstream
-    content changed, so `at update` is a single non-interactive sync."""
+    """Fast-forward the repo when sourcing from the real checkout, then refresh only
+    the installed skills whose upstream content changed, so `at update` is a single
+    non-interactive sync."""
     source_root: Path = _source_root()
     # Only pull against the real repo checkout: an AT_SOURCE_ROOT override points the
     # update at a fixture tree that has no upstream remote to fast-forward.

--- a/installer/tests/e2e/goldens/collision_backup.golden
+++ b/installer/tests/e2e/goldens/collision_backup.golden
@@ -1,0 +1,9 @@
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/skill
+dir .claude/at/staged/skill/demo-skill
+file .claude/at/staged/skill/demo-skill/SKILL.md 25706be2cbf11d3e92d1cadb63751d482723dbcd91b3f32dc9931859308e1674
+json .claude/at/state.json {"units":{"skill/demo-skill":"763e7d2a3620743afe13cecae56bafec01e4346e8aa945bc63262e24b4ff4248"},"version":1}
+dir .claude/skills
+link .claude/skills/demo-skill -> .claude/at/staged/skill/demo-skill
+file .claude/skills/demo-skill.bak bee99ef5c0168550bd69824c01c1b21194da49546240e48354ff1f16c6f61b95

--- a/installer/tests/e2e/goldens/collision_restore.golden
+++ b/installer/tests/e2e/goldens/collision_restore.golden
@@ -1,0 +1,6 @@
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/skill
+json .claude/at/state.json {"units":{},"version":1}
+dir .claude/skills
+file .claude/skills/demo-skill bee99ef5c0168550bd69824c01c1b21194da49546240e48354ff1f16c6f61b95

--- a/installer/tests/e2e/goldens/update_rescues_local_edit.golden
+++ b/installer/tests/e2e/goldens/update_rescues_local_edit.golden
@@ -1,0 +1,10 @@
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/skill
+dir .claude/at/staged/skill/demo-skill
+dir .claude/at/staged/skill/demo-skill.bak
+file .claude/at/staged/skill/demo-skill.bak/SKILL.md 11d91c57ebd2e6bb00143179f043a745217c7bc41947757d42e8029fc6f965e2
+file .claude/at/staged/skill/demo-skill/SKILL.md e6cb6d49688214ac8c404cc20587ebe74c513df17ef9b211adb94073d04418f2
+json .claude/at/state.json {"units":{"skill/demo-skill":"b1a55afd6a4b67a2d99ddb4a949b7c49d5ccb0165967c72e0e9a4ab40a711451"},"version":1}
+dir .claude/skills
+link .claude/skills/demo-skill -> .claude/at/staged/skill/demo-skill

--- a/installer/tests/e2e/goldens/update_restage_on_upstream_bump.golden
+++ b/installer/tests/e2e/goldens/update_restage_on_upstream_bump.golden
@@ -1,0 +1,8 @@
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/skill
+dir .claude/at/staged/skill/demo-skill
+file .claude/at/staged/skill/demo-skill/SKILL.md 472737eb2b385b9628a95e727f43e775281c2488e42dc86727a5e664efcc2c98
+json .claude/at/state.json {"units":{"skill/demo-skill":"01f24f5f7ed336e9818978b3728528f84728ad76be4bf3e36f111a3282c9bf35"},"version":1}
+dir .claude/skills
+link .claude/skills/demo-skill -> .claude/at/staged/skill/demo-skill

--- a/installer/tests/e2e/test_lifecycle_ii.py
+++ b/installer/tests/e2e/test_lifecycle_ii.py
@@ -116,3 +116,85 @@ def test_real_file_collision_is_backed_up_and_restored(tmp_path: Path) -> None:
         actual=snapshot_after_uninstall,
         goldens_dir=GOLDENS_DIR,
     )
+
+
+# A user's own edit to their installed skill, written into the staged copy that
+# backs the live symlink. Distinct from both the frozen fixture and the upstream
+# bump below, so the rescued ".bak" tree pins this exact edit in the golden.
+_LOCAL_EDIT_SKILL_MD: Final[str] = """\
+---
+name: demo-skill
+description: Frozen fixture skill for installer e2e snapshot scenarios.
+---
+
+# demo-skill
+
+A local edit the user made to their installed skill; update must rescue it.
+"""
+
+# An upstream bump distinct from both the frozen fixture and the local edit, so
+# the staged copy and the source diverge from the recorded hash along independent
+# axes — the only case in which `at update` rescues the edit before re-staging.
+_UPSTREAM_EDIT_SKILL_MD: Final[str] = """\
+---
+name: demo-skill
+description: Upstream-bumped fixture skill body for the rescue e2e scenario.
+---
+
+# demo-skill
+
+Upstream bumped this skill, so `at update` re-stages over the rescued edit.
+"""
+
+
+@pytest.mark.e2e
+def test_update_rescues_locally_edited_staged_copy(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    # A mutable copy of the frozen fixture skill so the test can bump its upstream
+    # source after install, while the catalog stays frozen.
+    source_root: Path = tmp_path / "src"
+    shutil.copytree(
+        FIXTURES_DIR / "skills" / "demo-skill",
+        source_root / "skills" / "demo-skill",
+    )
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    install_result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--skill", "demo-skill", "--non-interactive"],
+        home=home,
+        source_root=source_root,
+        catalog=catalog,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    # Overwrite the staged copy that backs the live symlink: this is where a user's
+    # edit to their installed skill lands, and it now diverges from the recorded hash.
+    staged_skill_file: Path = (
+        home / ".claude" / "at" / "staged" / "skill" / "demo-skill" / "SKILL.md"
+    )
+    staged_skill_file.write_text(_LOCAL_EDIT_SKILL_MD, encoding="utf-8")
+
+    # Bump the upstream source too, so the staged copy AND the source both diverge
+    # from the recorded hash, the condition under which update must rescue first.
+    skill_source_file: Path = source_root / "skills" / "demo-skill" / "SKILL.md"
+    skill_source_file.write_text(_UPSTREAM_EDIT_SKILL_MD, encoding="utf-8")
+
+    update_result: subprocess.CompletedProcess[str] = run_at(
+        args=["update"],
+        home=home,
+        source_root=source_root,
+        catalog=catalog,
+    )
+    assert update_result.returncode == 0, update_result.stderr
+    snapshot_after: str = snapshot(home)
+
+    # Behavioral guard before the golden: a "demo-skill.bak" rescue tree proves the
+    # local edit was moved aside rather than silently overwritten by the re-stage.
+    assert "demo-skill.bak" in snapshot_after
+
+    assert_matches_golden(
+        name="update_rescues_local_edit",
+        actual=snapshot_after,
+        goldens_dir=GOLDENS_DIR,
+    )

--- a/installer/tests/e2e/test_lifecycle_ii.py
+++ b/installer/tests/e2e/test_lifecycle_ii.py
@@ -63,3 +63,56 @@ def test_update_restages_installed_skill_on_upstream_bump(tmp_path: Path) -> Non
         actual=snapshot_after,
         goldens_dir=GOLDENS_DIR,
     )
+
+
+# A user's own real file that happens to occupy the skill's live path before
+# install, kept deterministic so the backup/restore goldens pin its exact bytes.
+_USER_COLLIDING_NOTE: Final[str] = (
+    "My own demo-skill notes, written before the installer ever ran.\n"
+)
+
+
+@pytest.mark.e2e
+def test_real_file_collision_is_backed_up_and_restored(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    # Seed a real (non-symlink) file exactly where demo-skill will link, so install
+    # must move it aside to "<name>.bak" instead of clobbering the user's data.
+    live_skills_dir: Path = home / ".claude" / "skills"
+    live_skills_dir.mkdir(parents=True)
+    colliding_path: Path = live_skills_dir / "demo-skill"
+    colliding_path.write_text(_USER_COLLIDING_NOTE, encoding="utf-8")
+
+    install_result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--skill", "demo-skill", "--non-interactive"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    # Install moved the user's file to demo-skill.bak and put our symlink in place.
+    snapshot_after_install: str = snapshot(home)
+    assert_matches_golden(
+        name="collision_backup",
+        actual=snapshot_after_install,
+        goldens_dir=GOLDENS_DIR,
+    )
+
+    uninstall_result: subprocess.CompletedProcess[str] = run_at(
+        args=["uninstall", "--skill", "demo-skill"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert uninstall_result.returncode == 0, uninstall_result.stderr
+
+    # Uninstall dropped the symlink and restored the user's original file in place.
+    snapshot_after_uninstall: str = snapshot(home)
+    assert_matches_golden(
+        name="collision_restore",
+        actual=snapshot_after_uninstall,
+        goldens_dir=GOLDENS_DIR,
+    )

--- a/installer/tests/e2e/test_lifecycle_ii.py
+++ b/installer/tests/e2e/test_lifecycle_ii.py
@@ -1,0 +1,65 @@
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Final
+
+import pytest
+from harness import FIXTURES_DIR, GOLDENS_DIR, assert_matches_golden, run_at, snapshot
+
+# A deterministic SKILL.md body distinct from the frozen fixture's bytes, so rewriting
+# the mutable source root simulates an upstream bump that `at update` must re-stage.
+_BUMPED_SKILL_MD: Final[str] = """\
+---
+name: demo-skill
+description: Bumped fixture skill body for the update re-stage e2e scenario.
+---
+
+# demo-skill
+
+Upstream bumped this skill so `at update` must re-stage the new bytes.
+"""
+
+
+@pytest.mark.e2e
+def test_update_restages_installed_skill_on_upstream_bump(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    # A mutable copy of the frozen fixture skill so the test can bump its upstream
+    # source between install and update; the catalog stays frozen.
+    source_root: Path = tmp_path / "src"
+    shutil.copytree(
+        FIXTURES_DIR / "skills" / "demo-skill",
+        source_root / "skills" / "demo-skill",
+    )
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    install_result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--skill", "demo-skill", "--non-interactive"],
+        home=home,
+        source_root=source_root,
+        catalog=catalog,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+    snapshot_before: str = snapshot(home)
+
+    skill_source_file: Path = source_root / "skills" / "demo-skill" / "SKILL.md"
+    skill_source_file.write_text(_BUMPED_SKILL_MD, encoding="utf-8")
+
+    update_result: subprocess.CompletedProcess[str] = run_at(
+        args=["update"],
+        home=home,
+        source_root=source_root,
+        catalog=catalog,
+    )
+    assert update_result.returncode == 0, update_result.stderr
+    snapshot_after: str = snapshot(home)
+
+    # Behavioral guard before the golden: the bumped upstream must actually change the
+    # installed tree, proving `at update` re-staged rather than no-opped.
+    assert snapshot_before != snapshot_after
+
+    assert_matches_golden(
+        name="update_restage_on_upstream_bump",
+        actual=snapshot_after,
+        goldens_dir=GOLDENS_DIR,
+    )

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -704,6 +704,85 @@ def test_update_pulls_repo_then_refreshes_installed_skill(
     assert final_hash != install_hash
 
 
+def test_update_restages_from_at_source_root_override_without_pulling(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    override_source: Path = tmp_path / "override"
+    repo_decoy: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_decoy)
+
+    # The same skill lives under the override and the REPO_ROOT decoy with deliberately
+    # distinct content, so the staged copy's text alone reveals which root the update
+    # re-staged from. AT_SOURCE_ROOT must win: the e2e harness points it at a fixture
+    # tree, so `at update` sources from the fixture and has no checkout to `git pull`.
+    original_content: str = "# demo-skill original override\n"
+    decoy_content: str = "# demo-skill decoy repo\n"
+    override_skill: Path = override_source / "skills" / "demo-skill" / "SKILL.md"
+    override_skill.parent.mkdir(parents=True)
+    override_skill.write_text(original_content, encoding="utf-8")
+    decoy_skill: Path = repo_decoy / "skills" / "demo-skill" / "SKILL.md"
+    decoy_skill.parent.mkdir(parents=True)
+    decoy_skill.write_text(decoy_content, encoding="utf-8")
+    monkeypatch.setenv("AT_SOURCE_ROOT", str(override_source))
+
+    # Install demo-skill from the override through the real public action, so state,
+    # staging, and the live symlink all exist — staged from the override — before the
+    # update runs.
+    install_skill(
+        name="demo-skill",
+        source_root=override_source,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=load_state(state_root),
+    )
+
+    # Simulate an upstream bump in the override fixture: rewrite the source to content
+    # distinct from both the original install and the REPO_ROOT decoy, leaving the
+    # installed skill stale against its now-updated override source.
+    new_content: str = "# demo-skill new override\n"
+    override_skill.write_text(new_content, encoding="utf-8")
+
+    # Hold the catalog identical on both seams (module constant and AT_CATALOG env) so
+    # it is never the variable under test: only the source root is.
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-skill"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    monkeypatch.setenv("AT_CATALOG", str(catalog_file))
+
+    # subprocess.run is the one true external boundary (process exec + network):
+    # record each call and hand back a success, so a stray `git pull` is observed here
+    # rather than shelling out.
+    recorded_runs: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        recorded_runs.append((args, kwargs))
+        return subprocess.CompletedProcess(args=[], returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    exit_code: int = main(["update"])
+
+    # AT_SOURCE_ROOT wins over REPO_ROOT: the update re-stages from the override, so the
+    # staged SKILL.md holds the new override content (not the decoy) and state records
+    # the override's hash. With the source root overridden there is no repo to
+    # fast-forward, so `git pull` never runs and no subprocess is spawned at all.
+    override_skill_dir: Path = override_source / "skills" / "demo-skill"
+    staged_skill_md: Path = state_root / "staged" / "skill" / "demo-skill" / "SKILL.md"
+    final_hash: str = load_state(state_root).units[skill_unit_id("demo-skill")]
+    assert exit_code == 0
+    assert recorded_runs == []
+    assert staged_skill_md.read_text(encoding="utf-8") == new_content
+    assert final_hash == hash_unit(override_skill_dir)
+
+
 def test_install_skill_flag_installs_named_skill_non_interactively(
     monkeypatch: MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## PR 4.5.4 — Lifecycle scenarios II

Part of #74 (slice 4.5). Adds e2e coverage for the harder `.bak` / update lifecycle paths, plus the minimal production seam needed to drive `at update` against a fixture.

### Production seam (only production change)
`installer/at.py::_run_update` now resolves the source root via `_source_root()` and the catalog via `_catalog_path()`, and gates `git pull --ff-only` behind `source_root == REPO_ROOT`. When `AT_SOURCE_ROOT` overrides the source to a fixture tree (the e2e seam), the pull is skipped — there is no upstream to fast-forward — and update reconciles from the override. **Production `at update` is unchanged**: with no override `source_root == REPO_ROOT`, so the pull and real catalog/source paths run exactly as before. Pinned by a new unit test mirroring the existing inverse (`test_update_pulls_repo_then_refreshes_installed_skill`, retained as the regression guard).

### E2E scenarios (`installer/tests/e2e/test_lifecycle_ii.py`, driving the real `at` via the harness)
- **`at update` re-stages on an upstream bump** → golden `update_restage_on_upstream_bump` (staged content re-staged to the bumped bytes; guard `snapshot_before != snapshot_after`).
- **Real-file collision round-trip** → goldens `collision_backup` (a user's pre-existing real file is moved to `<name>.bak`, our symlink takes its place) + `collision_restore` (on uninstall the user's original file is restored in place, no `.bak`, empty state). The `.bak` hash equals the restored-file hash — the user's bytes round-trip.
- **Locally-edited staged copy rescue** → golden `update_rescues_local_edit` (when the staged copy was hand-edited *and* upstream changed, `at update` rescues the edit to `<name>.bak` before re-staging the new upstream).

### Verification
- TDD throughout: each behavior a right-reason RED then GREEN. Every committed golden independently re-checked (hashes derived from the test bytes) to confirm it encodes the claimed behavior, not a no-op.
- `uv run pytest -W error` → **74 passed**; ruff format/check + mypy --strict clean.
- Reviewer: no CRITICAL (one MINOR docstring nit, fixed). Critic: goal-fit achieved; non-vacuity confirmed (e2e runs by default, goldens byte-unchanged, `AT_BLESS` unset).

Slice 4.5 now stands at 4/5 — only 4.5.5 (GitHub Actions CI) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)