### PR TITLE
feat(skills): make make-pr + improve-architecture self-contained

### DIFF
--- a/installer/tests/test_skill_bundles.py
+++ b/installer/tests/test_skill_bundles.py
@@ -1,15 +1,33 @@
 from pathlib import Path
 from typing import Final
 
-# installer/tests/ -> installer/ -> repo root, which holds skills/, rules/, gates/.
+# installer/tests/ -> installer/ -> repo root, which holds skills/ plus the canonical
+# rules/, gates/, schemas/, scripts/.
 _REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent.parent
-_SKILL_ROOT: Final[Path] = _REPO_ROOT / "skills" / "make-pr-lite"
-_BUNDLED_ASSET_DIRS: Final[tuple[str, ...]] = ("rules", "gates")
+_SKILLS_ROOT: Final[Path] = _REPO_ROOT / "skills"
+
+# Skills that bundle repo assets inside their own directory so the assets travel with
+# the skill on install (the CLI copies only the skill dir; anything resolved from a repo
+# checkout at runtime would silently go missing elsewhere). Maps skill -> asset dir ->
+# what it mirrors: the full-mirror marker means the bundle equals the whole canonical
+# dir byte-for-byte; a tuple means the bundle holds exactly those files (used when the
+# canonical dir carries more than the skill needs, e.g. scripts/ also has a venv).
+_FULL_MIRROR: Final[str] = "*"
+_BUNDLES: Final[dict[str, dict[str, str | tuple[str, ...]]]] = {
+    "make-pr-lite": {"rules": _FULL_MIRROR, "gates": _FULL_MIRROR},
+    "make-pr": {
+        "rules": _FULL_MIRROR,
+        "gates": _FULL_MIRROR,
+        "schemas": _FULL_MIRROR,
+        "scripts": ("validate_return.py",),
+    },
+    "improve-architecture": {"rules": ("design-principles.md",)},
+}
 
 
 def _files_by_name(root: Path) -> dict[str, bytes]:
-    """Map each file under root to its bytes, keyed by its path relative to root, so
-    two asset trees compare by both filename and content in a single equality check."""
+    """Map each file under root to its bytes, keyed by its path relative to root, so two
+    asset trees compare by both filename and content in a single equality check."""
     return {
         str(path.relative_to(root)): path.read_bytes()
         for path in root.rglob("*")
@@ -17,15 +35,28 @@ def _files_by_name(root: Path) -> dict[str, bytes]:
     }
 
 
-def test_make_pr_lite_bundles_canonical_rules_and_gates() -> None:
-    """make-pr-lite ships its own rules/ and gates/ so they travel with the skill on
-    install — the CLI copies only the skill directory. Guard the bundle against
-    drifting from the repo's canonical copies: a stale bundled rule is exactly the
-    failure this bundle prevents — a language rule never reaching the agents."""
-    for subdir in _BUNDLED_ASSET_DIRS:
-        canonical: dict[str, bytes] = _files_by_name(_REPO_ROOT / subdir)
-        bundled: dict[str, bytes] = _files_by_name(_SKILL_ROOT / subdir)
-        assert bundled == canonical, (
-            f"skills/make-pr-lite/{subdir}/ diverged from {subdir}/ — edit the "
-            f"canonical file, then re-copy the full set into the skill bundle"
-        )
+def test_skill_bundles_match_canonical_assets() -> None:
+    """Skills bundle their assets in-dir so they ship on install (the CLI copies only
+    the skill dir). Guard each bundled file against drifting from its canonical copy:
+    a stale bundled rule reaching the agents is the silent failure this prevents."""
+    for skill, asset_dirs in _BUNDLES.items():
+        for asset_dir, spec in asset_dirs.items():
+            canonical: Path = _REPO_ROOT / asset_dir
+            bundled: Path = _SKILLS_ROOT / skill / asset_dir
+            assert bundled.is_dir(), f"skills/{skill}/{asset_dir}/ is missing"
+            if isinstance(spec, str):
+                assert _files_by_name(bundled) == _files_by_name(canonical), (
+                    f"skills/{skill}/{asset_dir}/ diverged from {asset_dir}/ — "
+                    f"re-copy the full canonical set into the skill bundle"
+                )
+                continue
+            assert set(_files_by_name(bundled)) == set(spec), (
+                f"skills/{skill}/{asset_dir}/ should hold exactly {sorted(spec)}"
+            )
+            for name in spec:
+                assert (bundled / name).read_bytes() == (
+                    canonical / name
+                ).read_bytes(), (
+                    f"skills/{skill}/{asset_dir}/{name} differs from canonical "
+                    f"{asset_dir}/{name} — edit the canonical file, then re-copy it"
+                )

--- a/skills/improve-architecture/SKILL.md
+++ b/skills/improve-architecture/SKILL.md
@@ -10,7 +10,8 @@ killed — by a caller list re-traced blind.
 
 **Proposes, never edits** — `reviewer` and `critic` judge a diff; this audits existing
 code, seeding `/breakdown` or `/make-pr` on approval.
-**Rubric: `rules/design-principles.md`** — defines *deep* vs *shallow* and every red
+**Rubric: `rules/design-principles.md` bundled beside this `SKILL.md`** (resolve it from the
+skill's own directory, not the audited repo) — defines *deep* vs *shallow* and every red
 flag or principle below.
 
 ```
@@ -64,7 +65,8 @@ A candidate failing its test is dropped in Phase 3.
 (path, package, subsystem); if none, ask. If the inventory below would exceed ~6
 clusters, sub-partition and audit one per run rather than skim.
 
-Read `rules/design-principles.md`, and `docs/adr/` first if present —
+Read `rules/design-principles.md` (bundled beside this `SKILL.md`), and the audited repo's
+`docs/adr/` first if present —
 **never re-propose a decision already rejected there**. `CONTEXT.md`, if present,
 records the team's own names and each boundary's rationale — propose in their
 vocabulary, not yours.

--- a/skills/improve-architecture/rules/design-principles.md
+++ b/skills/improve-architecture/rules/design-principles.md
@@ -1,0 +1,269 @@
+---
+paths: "**/*.py", "**/*.ts", "**/*.tsx", "**/*.rs", "**/*.go", "**/*.java", "**/*.cpp", "**/*.cc", "**/*.h", "**/*.hpp"
+---
+
+# Design Principles
+
+Language-agnostic rules for structure, abstraction, and readability. Language rules
+(`python.md`, `typescript.md`, `rust.md`, …) govern *syntax and idiom*; this file governs *design*.
+Based on Ousterhout's *A Philosophy of Software Design*. Apply the relevant rules to every
+change, but scale the effort to the mode: GREEN stays minimal; REFACTOR is where structural
+improvement usually belongs.
+
+## The one goal: minimize complexity
+
+Complexity is anything about the structure of a system that makes it hard to understand
+or modify. It is the enemy; everything else here serves this goal. Watch for its three
+symptoms and treat any of them as a defect:
+
+- **Change amplification** — a simple change requires edits in many places.
+- **Cognitive load** — a developer must hold a lot in their head to make a change.
+- **Unknown unknowns** — it is not obvious which code must change, or what a change will break.
+
+Complexity is incremental: it accrues one "this'll do" at a time. Reject those individually.
+
+## Deep modules
+
+A module (function, class, file, service) is an interface plus an implementation. The best
+modules are **deep**: a simple interface hiding a powerful implementation. The cost of a
+module is its interface (what every caller must learn); the benefit is its implementation.
+
+- Prefer few deep modules over many shallow ones. A class/function whose interface is as
+  complex as its body (a "shallow module") adds cost without hiding anything.
+- Beware *classitis*: chopping logic into many tiny classes/functions that each do almost
+  nothing but together force the reader to chase the flow across files.
+- A method/function should have a clear, single abstraction. If you cannot state what it
+  does in one short phrase without "and", it is doing too much.
+
+```python
+# SHALLOW — interface as complex as the body; caller learns 3 knobs to save nothing
+def write(path, data, *, mkdirs, encoding, atomic): ...   # caller still owns every decision
+
+# DEEP — one-word interface hiding mkdirs/atomic-rename/encoding decisions
+def save(path: Path, data: str) -> None: ...              # the hard parts live inside
+```
+
+## Information hiding
+
+Each module should encapsulate a few design decisions that nothing outside it depends on.
+That is what makes interfaces simple and change local.
+
+- **Keep each design decision in one place** (no information leakage): a file format, a
+  protocol detail, or a default should live in a single module. If changing one forces a
+  change in another, the knowledge leaked — pull it into one place.
+- **Decompose by responsibility, not execution order** (avoid temporal decomposition):
+  structure around knowledge, not around the order operations happen to run in. "Read, then
+  modify, then write" as three modules usually leaks the format into all three.
+
+```python
+# TEMPORAL — three modules mirror the steps; each must know the file format → leaked 3×
+text = read_yaml(path); patched = bump_version(text); write_yaml(path, patched)
+
+# RESPONSIBILITY — one module owns the format; callers never see it
+config = ConfigFile(path); config.bump_version(); config.save()
+```
+- Expose the *general* capability, hide the *specific* policy. Don't add a config parameter
+  the caller must understand when a sensible internal decision would do.
+
+## Better together or apart
+
+A module should have **one job** and do it fully. Combine two pieces of functionality into one
+module only when that genuinely reduces complexity; otherwise keep them apart.
+
+- **One concern per module.** A datastore and a cache are two concerns: expose a *store*
+  interface and hide caching as an implementation detail *inside* it, or keep them as separate
+  modules — never ship a `StoreAndCache` that does both. If the name needs an "and", or you
+  can't state the job in one phrase, split it.
+
+```python
+# BAD — two concerns in one interface; callers must know the cache exists
+class StoreAndCache:
+    def get(self, k): ...
+    def cache_get(self, k): ...
+    def invalidate(self, k): ...
+
+# GOOD — one Store interface; caching is a hidden implementation decision
+class Store:
+    def get(self, k): ...   # may consult a private cache inside; callers never know
+```
+- **Bring together** when the pieces share information, when one interface is simpler than two
+  (callers learn one abstraction), or when it removes duplication or a shallow go-between.
+- **Keep apart** when the pieces are used independently, when one is general-purpose and the
+  other special-purpose, or when bundling forces callers to learn things they don't need.
+- The test is complexity, not line count: merge if the whole is simpler than the parts; split
+  if the parts are simpler than the whole.
+
+## Layers and abstraction
+
+- **Different layer, different abstraction.** Adjacent layers that share the same
+  abstraction are a smell.
+- **Each method should add abstraction.** A method that only forwards to another with the
+  same signature (a pass-through method) adds interface without value — add value or let the
+  caller go direct.
+
+```python
+def get_user(self, uid):           # BAD — pure forwarder, same signature, no new abstraction
+    return self._repo.get_user(uid)
+
+def get_user(self, uid):           # OK — earns the layer: adds caching + a domain error
+    hit = self._cache.get(uid)
+    return hit if hit is not None else self._fetch_or_raise(uid)
+```
+- **Thread context, not pass-through variables.** When a value would otherwise be threaded
+  through many layers just to reach the bottom, introduce a context object or rethink the
+  boundary.
+- **Pull complexity downward.** It is better for the *module's* implementation to be complex
+  than for its interface — and every caller — to be. Suffer once, inside, so users don't.
+
+## General-purpose interfaces
+
+Do **not** add public options before a behavior requires them. During GREEN, implement only the
+current slice. Once two real slices need the same capability, extract the smallest interface
+that covers both without encoding one caller's special policy. General-purpose means "less
+policy leaked to callers," not "more knobs just in case."
+
+## Avoid flag parameters
+
+A boolean argument that selects between two behaviors is a sign of a module doing two jobs. The
+caller writes `render(doc, true)` and cannot tell what `true` means; the body branches on a flag
+instead of presenting one clear abstraction.
+
+- Split the behaviors into two named functions (`renderDraft` / `renderFinal`) rather than one
+  function with a mode switch — the names document the intent the flag hid.
+
+```python
+def export(data, *, as_csv):        # BAD — caller passes a bare bool; body forks on it
+    if as_csv: ...
+    else: ...
+
+def export_csv(data): ...           # GOOD — two clear abstractions, no flag to decode
+def export_json(data): ...
+```
+- Keep a parameter only when callers genuinely vary it along a continuum, not when it toggles
+  between two code paths that share little.
+
+## Side effects and boundaries
+
+Push I/O and mutation to the edges; keep the core a set of pure functions that map inputs to
+outputs. Pure logic is the part you can read, test, and reuse without standing up the world.
+
+- **Functional core, imperative shell.** Concentrate side effects (network, disk, clock,
+  randomness, global state) in thin boundary layers and keep decision-making logic pure. A
+  function that both computes *and* persists is harder to test and reuse than the two kept apart.
+- **Parse untrusted input at the boundary, once.** Convert external data (request bodies, env
+  vars, file contents, API responses) into trusted domain types at the edge — parse, don't
+  validate — so the interior assumes well-formed values instead of re-checking them. Never trust
+  external input deeper than the boundary that admitted it.
+
+## Define errors out of existence
+
+The best way to handle an error is to design it away.
+
+- Reduce the number of places that must handle errors. Prefer APIs whose normal path also
+  covers the edge (e.g. `unset` on a missing key is a no-op, not an exception).
+
+```python
+def unset(self, key):              # BAD — every caller must wrap in try/except
+    if key not in self._d: raise KeyError(key)
+    del self._d[key]
+
+def unset(self, key):              # GOOD — missing key is a no-op; the error case vanishes
+    self._d.pop(key, None)
+```
+- Use the language's result/exception conventions from the language rules.
+
+## Naming
+
+Names are the densest documentation in the code. A good name is **precise, consistent,
+and obvious**.
+
+- If you cannot find a precise name, the design is probably muddled — the thing does too
+  many things. Treat naming difficulty as a design signal.
+- Name length should scale with scope: loop indices can be `i`; a module-level export
+  cannot.
+- Use the same word for the same concept everywhere, and never the same word for two
+  concepts.
+
+## Comments
+
+Comments exist to capture what the code cannot: the *why*, the abstraction, and the
+non-obvious. They are part of the design, not an afterthought.
+
+- Comment the **interface** (what a caller needs to know to use it) separately from the
+  **implementation** (why it works this way). The interface comment is the abstraction.
+- Write the interface comment *first*, before the body — if it's hard to write, the
+  interface is too complex (design feedback, for free).
+- Never write a comment that just restates the code. Document the things that are *not*
+  obvious from reading it.
+- Comments describe *why*, not *what*. The code already says what.
+- **The interface comment is a complete contract when the signature and names are not enough.**
+  Prefer concise language-rule docstrings, but include any non-obvious preconditions, errors,
+  side effects, or ordering guarantees a caller needs. Do not duplicate obvious parameter or
+  return types just to be exhaustive.
+
+## Consistency
+
+Do similar things in similar ways. Consistency lowers cognitive load and unknown-unknowns: once
+a reader learns a pattern, they can rely on it holding everywhere.
+
+- **Follow the conventions already in the codebase** — naming schemes, file and module layout,
+  error handling, how a common task is wired. A change that invents a new way to do an existing
+  thing adds a pattern every future reader must learn.
+- Keep **parallel cases parallel**: sibling handlers, similar endpoints, and repeated shapes
+  should read the same way, so understanding one means understanding the rest.
+- Diverge from an established pattern only when the pattern is wrong — then fix the pattern,
+  don't add a competing one beside it.
+
+## Code should be obvious
+
+Code is read far more than it is written. Aim for code whose behavior a reader grasps quickly
+and correctly, without surprises. **Non-obvious code is a defect**, even when it is correct.
+
+- If a reader must pause to work out what a piece of code does, or could reasonably read it
+  wrong, that is a problem — fix it with clearer names and structure first.
+- When the *why* still isn't obvious from well-named code, that is what a comment is for (see
+  Comments) — but reach for structure before commentary.
+- Avoid surprises: don't give something a name or signature that implies behavior it lacks, and
+  don't hide a side effect where a reader won't expect it. The obvious reading should be correct.
+
+## Tactical vs strategic
+
+Program **strategically**, not tactically. The goal is a good design, not just working
+code. Invest a little extra continuously (better structure, better names, a comment) rather
+than taking shortcuts that compound. There are no "tactical tornado" exceptions in this
+codebase.
+
+## Design it twice
+
+Your first idea for a non-trivial design is rarely your best. Before committing, sketch **two
+genuinely different approaches** and compare them — the comparison is what reveals the better
+design, and sometimes a third that beats both.
+
+- Spend this effort in proportion to the decision: a throwaway helper doesn't need it; a module
+  boundary, a public interface, or a data shape does (scale to the mode, as the intro says).
+- Compare on the criteria that matter here — which interface is simpler and deeper, which hides
+  more, which has fewer special cases — not which is faster to type.
+
+## Red flags — stop and reconsider if you see these
+
+- **Shallow module** — interface nearly as complex as the implementation.
+- **Information leakage** — the same decision encoded in two places.
+- **Temporal decomposition** — modules mirror execution order, not responsibilities.
+- **Overexposure** — using the common case forces the caller to learn rare options.
+- **Pass-through method / variable** — added layer carries no new abstraction.
+- **Repetition** — the same snippet appears more than twice.
+- **Special-general mixture** — special-purpose code embedded in a general-purpose mechanism.
+- **Multi-concern module** — one module owns two jobs that don't share information; the name needs an "and".
+- **Flag parameter** — a boolean argument selects between two behaviors; split the function instead.
+- **Scattered side effects** — I/O or mutation interleaved through logic that could be a pure core.
+- **Re-validated input** — the same external value checked in many places instead of parsed once at the boundary.
+- **Conjoined methods** — two pieces only understandable by reading both back-to-back.
+- **Comment repeats code** — or, you can't write a comment without restating the body.
+- **Hard to name / hard to describe** — the unit's responsibilities aren't clean.
+- **Inconsistency** — a new pattern for something the codebase already does one established way.
+- **Non-obvious code** — a reader must stop and puzzle out what it does, or could read it wrong.
+
+## Testability is a design property
+
+Code that is hard to test through its public interface is badly factored — design modules so
+behavior is observable at the boundary without reaching inside (see `tdd.md`).

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -35,12 +35,12 @@ give `worker-coder` its **`mode`** (`green` | `refactor` | `non_behavioral`) plu
 `dependencies_allowed` (and any named dependency/version) when the task permits dependencies —
 otherwise the coder blocks on any new dependency. Keep each dispatch
 prompt tight and scoped to one job. Require each agent to return exactly the JSON object defined
-in its prompt, and **validate that return against `<repo_root>/schemas/<role>.schema.json`**
+in its prompt, and **validate that return against `<skill_root>/schemas/<role>.schema.json`**
 (keyed by the `role` field in the return). The validator reads the instance from a **file**, so
 first write the agent's raw return verbatim with `Write` (not `echo`/heredoc — those mangle the
 embedded quotes and newlines) to `<run_root>/<run-id>.<role>.json`, then run:
 
-`uv run --no-project --with jsonschema python <repo_root>/scripts/validate_return.py <repo_root>/schemas/<role>.schema.json <run_root>/<run-id>.<role>.json`
+`uv run --no-project --with jsonschema python <skill_root>/scripts/validate_return.py <skill_root>/schemas/<role>.schema.json <run_root>/<run-id>.<role>.json`
 
 (The validator depends on `jsonschema`; `uv run --no-project --with jsonschema` supplies it on first run and caches it — no separate install step.)
 
@@ -61,27 +61,28 @@ stage it unchanged with your production code. Module boundary: `cart` only. Base
 
 Resolve these values before the first dispatch:
 
-- **repo_root**: the absolute path to the `agent-templates` repo root. Use it for the immutable
-  template assets: `schemas/`, `scripts/`, and `gates/`.
-- **rules_root**: the `rules/` directory at the repo root (`<repo_root>/rules`). Use it for the
-  rule files the agents read.
+- **skill_root**: the directory this `SKILL.md` lives in. It bundles the immutable template
+  assets — `schemas/`, `scripts/`, `gates/`, and `rules/` — so they travel with the skill on
+  install; resolve them here, never from the target repo or a repo checkout.
+- **rules_root**: the bundled `rules/` directory beside this `SKILL.md` (`<skill_root>/rules`). Use
+  it for the rule files the agents read.
 - **target_cwd**: the absolute path to the repository being changed. Run every target-repo
   command there: `git`, verification commands, package-manager setup, and gate runs.
 - **run_root**: a writable directory for logs and transient return JSON, defaulting to
   `<target_cwd>/.v1-runs`. Use this for JSONL logs and `<run-id>.<role>.json`; do not write
-  runtime state into `repo_root`.
+  runtime state into `skill_root`.
 - **Base**: use a base named by the user or task spec. Otherwise use `git merge-base HEAD
   origin/main`; if `origin/main` is unavailable, use `git merge-base HEAD main`. If no base
   can be resolved, stop and ask for one.
 - **Run id**: use the branch name or task id, replacing `/` and whitespace with `_`.
 - **Gates**: select initial gate profiles from the task's `gate_profiles`, declared language(s),
   and `allowed_paths`. After workers change files, expand the selected profiles from
-  `git diff --name-only <base>...HEAD`. Match paths against each `<repo_root>/gates/*.json`
+  `git diff --name-only <base>...HEAD`. Match paths against each `<skill_root>/gates/*.json`
   profile's `triggers` globs; both root and nested paths must match. If a changed language has
   no gate, stop and report the missing gate instead of declaring done.
-- **Rules**: resolve rule files to **absolute** paths (the top-level `rules/` directory of this
-  agent-templates repo, `rules_root`) before passing them — a subagent's working directory is the user's
-  project, not this repo, so bare or repo-relative names will not resolve. Always pass
+- **Rules**: resolve rule files to **absolute** paths (the bundled `rules/` directory beside this
+  `SKILL.md`, `rules_root`) before passing them — a subagent's working directory is the user's
+  project, not this skill's directory, so bare or repo-relative names will not resolve. Always pass
   `design-principles.md`; add `tdd.md` for behavioral RED/GREEN steps; add the matching
   language rule (`python.md`, `typescript.md`, `rust.md`) for each changed file type.
 
@@ -91,7 +92,7 @@ Resolve these values before the first dispatch:
   `<run-id>.<role>.json` return files you write for validation). Do not edit production source, tests,
   rules, or gates directly while acting as architect; route every code or test change to `worker-coder`.
 - Use `Bash` only for `git`, `date`, JSONL validation, the schema validator
-  (`<repo_root>/scripts/validate_return.py`), **re-running a worker's reported verification (e.g. the
+  (`<skill_root>/scripts/validate_return.py`), **re-running a worker's reported verification (e.g. the
   named GREEN test) to confirm its result**, the task-provided baseline command, and the selected
   gate `setup`/`run` commands. Run all target-repo commands in `target_cwd`. Do not run gate
   `fix` commands directly; route fixes to `worker-coder`.
@@ -142,7 +143,7 @@ Resolve these values before the first dispatch:
       with `mode: refactor`; tests must stay green and unchanged.
    Log every dispatch (see JSONL contract).
 5. **Gate (objective — run before any LLM judgment).** Run the selected gates from
-   `<repo_root>/gates/<lang>.json`. Each gate file is
+   `<skill_root>/gates/<lang>.json`. Each gate file is
    `{"setup": <cmd>, "triggers": [<glob>], "gates": [{"name","run","fix"}]}` where `fix` may be
    `null` for checks that need a human/coder change rather than a mechanical command. Run `setup`
    once, then each `gates[].run` in order. If setup fails because the repo does not use the

--- a/skills/make-pr/gates/python.json
+++ b/skills/make-pr/gates/python.json
@@ -1,0 +1,10 @@
+{
+  "setup": "uv sync --frozen",
+  "triggers": ["*.py", "**/*.py", "pyproject.toml", "**/pyproject.toml", "uv.lock", "**/uv.lock"],
+  "gates": [
+    { "name": "format",    "run": "uv run ruff format --check .",  "fix": "uv run ruff format ." },
+    { "name": "lint",      "run": "uv run ruff check .",           "fix": "uv run ruff check --fix ." },
+    { "name": "typecheck", "run": "uv run mypy --strict .",        "fix": null },
+    { "name": "test",      "run": "uv run pytest -W error",        "fix": null }
+  ]
+}

--- a/skills/make-pr/gates/rust.json
+++ b/skills/make-pr/gates/rust.json
@@ -1,0 +1,10 @@
+{
+  "setup": "cargo fetch --locked",
+  "triggers": ["*.rs", "**/*.rs", "Cargo.toml", "**/Cargo.toml", "Cargo.lock", "**/Cargo.lock"],
+  "gates": [
+    { "name": "format",    "run": "cargo fmt --all --check",                                 "fix": "cargo fmt --all" },
+    { "name": "lint",      "run": "cargo clippy --all-targets --all-features -- -D warnings", "fix": "cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features" },
+    { "name": "typecheck", "run": "cargo check --all-targets --all-features",                 "fix": null },
+    { "name": "test",      "run": "cargo test --all-features",                                "fix": null }
+  ]
+}

--- a/skills/make-pr/gates/typescript.json
+++ b/skills/make-pr/gates/typescript.json
@@ -1,0 +1,10 @@
+{
+  "setup": "pnpm install --frozen-lockfile",
+  "triggers": ["*.ts", "*.tsx", "**/*.ts", "**/*.tsx", "package.json", "**/package.json", "pnpm-lock.yaml", "**/pnpm-lock.yaml", "tsconfig*.json", "**/tsconfig*.json", "biome.json", "**/biome.json"],
+  "gates": [
+    { "name": "format",    "run": "pnpm exec biome format .",                     "fix": "pnpm exec biome format --write ." },
+    { "name": "lint",      "run": "pnpm exec biome check --error-on-warnings .",  "fix": "pnpm exec biome check --fix ." },
+    { "name": "typecheck", "run": "pnpm exec tsc --noEmit",                       "fix": null },
+    { "name": "test",      "run": "pnpm exec vitest run --passWithNoTests=false", "fix": null }
+  ]
+}

--- a/skills/make-pr/rules/cpp.md
+++ b/skills/make-pr/rules/cpp.md
@@ -1,0 +1,104 @@
+---
+paths: "**/*.cpp", "**/*.cc", "**/*.h", "**/*.hpp", "**/CMakeLists.txt"
+---
+
+# C++ Rules
+
+Target C++20 minimum (GCC 13+, Clang 16+, MSVC 17.6+). Use CMake 3.28+ with modern target-based configuration. Prefer modern idioms, strict warnings, and static analysis throughout.
+
+## Tooling
+
+- **Formatter:** clang-format (project `.clang-format` at repo root)
+- **Static analysis:** clang-tidy with checks: `modernize-*`, `bugprone-*`, `performance-*`, `readability-*`, `cppcoreguidelines-*`
+- **Testing:** GoogleTest + GoogleMock
+- **Package manager:** vcpkg (preferred) or Conan 2 for private registries
+- **Build system:** CMake 3.28+ with `CMakePresets.json`
+- **IDE support:** clangd (runs clang-tidy in real-time)
+
+## Ownership and Resource Management
+
+Use RAII for all resource management. Never call `new`/`delete` directly.
+
+- **Default:** `std::unique_ptr<T>` for single ownership
+- **Shared ownership:** `std::shared_ptr<T>` only when ownership is genuinely shared
+- **Breaking cycles:** `std::weak_ptr<T>` to break `shared_ptr` reference cycles
+- Use `std::make_unique` and `std::make_shared` for construction
+- Prefer value types and stack allocation when object lifetime is scoped
+
+## `constexpr` and `const`
+
+Apply `constexpr` and `const` wherever possible. Prefer `constexpr` functions for compile-time evaluation. Use `consteval` for functions that must always run at compile time. Mark variables `const` unless mutation is required.
+
+## C++20 Features
+
+- **Concepts** over SFINAE for template constraints — clearer errors, more readable
+- **`std::format`** over printf/iostream for string formatting
+- **`std::span<T>`** for non-owning buffer/array parameters
+- **`std::string_view`** for non-owning string parameters (do not store — the caller owns the data)
+- **Designated initializers** for aggregate types to improve readability
+- **Three-way comparison (`<=>`)** for custom types instead of writing all six operators
+- **`[[nodiscard("reason")]]`** on functions whose return value must not be silently discarded
+
+## C++23 Features (Where Available)
+
+Use these when the project's minimum compiler version supports them:
+
+- **`std::expected<T, E>`** for error handling that carries error information (preferred over exceptions for expected failure paths)
+- **Monadic `std::optional`** — use `.and_then()`, `.transform()`, `.or_else()` for chaining
+- **`std::print` / `std::println`** over `std::cout` for formatted output
+
+## CMake
+
+Use modern target-based CMake exclusively. Never set global variables for compile settings.
+
+- Set standard per-target: `target_compile_features(mylib PUBLIC cxx_std_20)` — not `CMAKE_CXX_STANDARD`
+- Link per-target: `target_link_libraries(myapp PRIVATE mylib)`
+- Use `CMakePresets.json` for build configurations (debug, release, CI)
+- **Never use `file(GLOB)` for sources** — list source files explicitly so CMake detects additions/removals
+- Export targets with `install(TARGETS ... EXPORT ...)` for library projects
+
+## Compiler Warnings
+
+Enable strict warnings. Treat warnings as errors in CI.
+
+```cmake
+target_compile_options(mylib PRIVATE
+    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall -Wextra -Wpedantic -Werror>
+    $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+)
+```
+
+## Sanitizers
+
+- **Debug builds:** Enable ASan + UBSan together (`-fsanitize=address,undefined`)
+- **Thread safety:** Enable TSan separately (`-fsanitize=thread`) — TSan cannot combine with ASan
+- Configure sanitizer builds in `CMakePresets.json` as dedicated presets
+
+## Ranges
+
+Use `std::ranges` and views for data transformation pipelines where they improve clarity. Not needed for simple `for` loops over a single container — a range-based `for` is fine there.
+
+## Modules
+
+**NOT the default.** Header/source pairs remain the standard approach. Consider C++20 modules only for greenfield projects using CMake 4.0+ where tooling support is confirmed.
+
+## Coroutines
+
+Use coroutines only with established library support (cppcoro, Boost.Asio, libunifex). Do not write custom promise types or awaitables unless building a coroutine library.
+
+## Error Handling
+
+- Use `std::expected<T, E>` (C++23) or a Result type for expected failure paths
+- Reserve exceptions for truly exceptional conditions (programming errors, unrecoverable states)
+- Never throw in destructors
+- Mark functions `noexcept` when they genuinely cannot throw
+
+## Documentation
+
+- Document all public API types and functions with Doxygen-style comments (`///` or `/** */`)
+- Use `@brief`, `@param`, `@return`, `@throws` only when the function is non-trivial
+- Prefer self-documenting names and types over verbose comments
+
+## No `std::cout` in Library Code
+
+Library code must not write to `stdout`/`stderr` directly. Use a logging abstraction (spdlog, fmtlib + custom sink) or accept a callback/sink. Application code initializes the logger and controls output.

--- a/skills/make-pr/rules/design-principles.md
+++ b/skills/make-pr/rules/design-principles.md
@@ -1,0 +1,269 @@
+---
+paths: "**/*.py", "**/*.ts", "**/*.tsx", "**/*.rs", "**/*.go", "**/*.java", "**/*.cpp", "**/*.cc", "**/*.h", "**/*.hpp"
+---
+
+# Design Principles
+
+Language-agnostic rules for structure, abstraction, and readability. Language rules
+(`python.md`, `typescript.md`, `rust.md`, …) govern *syntax and idiom*; this file governs *design*.
+Based on Ousterhout's *A Philosophy of Software Design*. Apply the relevant rules to every
+change, but scale the effort to the mode: GREEN stays minimal; REFACTOR is where structural
+improvement usually belongs.
+
+## The one goal: minimize complexity
+
+Complexity is anything about the structure of a system that makes it hard to understand
+or modify. It is the enemy; everything else here serves this goal. Watch for its three
+symptoms and treat any of them as a defect:
+
+- **Change amplification** — a simple change requires edits in many places.
+- **Cognitive load** — a developer must hold a lot in their head to make a change.
+- **Unknown unknowns** — it is not obvious which code must change, or what a change will break.
+
+Complexity is incremental: it accrues one "this'll do" at a time. Reject those individually.
+
+## Deep modules
+
+A module (function, class, file, service) is an interface plus an implementation. The best
+modules are **deep**: a simple interface hiding a powerful implementation. The cost of a
+module is its interface (what every caller must learn); the benefit is its implementation.
+
+- Prefer few deep modules over many shallow ones. A class/function whose interface is as
+  complex as its body (a "shallow module") adds cost without hiding anything.
+- Beware *classitis*: chopping logic into many tiny classes/functions that each do almost
+  nothing but together force the reader to chase the flow across files.
+- A method/function should have a clear, single abstraction. If you cannot state what it
+  does in one short phrase without "and", it is doing too much.
+
+```python
+# SHALLOW — interface as complex as the body; caller learns 3 knobs to save nothing
+def write(path, data, *, mkdirs, encoding, atomic): ...   # caller still owns every decision
+
+# DEEP — one-word interface hiding mkdirs/atomic-rename/encoding decisions
+def save(path: Path, data: str) -> None: ...              # the hard parts live inside
+```
+
+## Information hiding
+
+Each module should encapsulate a few design decisions that nothing outside it depends on.
+That is what makes interfaces simple and change local.
+
+- **Keep each design decision in one place** (no information leakage): a file format, a
+  protocol detail, or a default should live in a single module. If changing one forces a
+  change in another, the knowledge leaked — pull it into one place.
+- **Decompose by responsibility, not execution order** (avoid temporal decomposition):
+  structure around knowledge, not around the order operations happen to run in. "Read, then
+  modify, then write" as three modules usually leaks the format into all three.
+
+```python
+# TEMPORAL — three modules mirror the steps; each must know the file format → leaked 3×
+text = read_yaml(path); patched = bump_version(text); write_yaml(path, patched)
+
+# RESPONSIBILITY — one module owns the format; callers never see it
+config = ConfigFile(path); config.bump_version(); config.save()
+```
+- Expose the *general* capability, hide the *specific* policy. Don't add a config parameter
+  the caller must understand when a sensible internal decision would do.
+
+## Better together or apart
+
+A module should have **one job** and do it fully. Combine two pieces of functionality into one
+module only when that genuinely reduces complexity; otherwise keep them apart.
+
+- **One concern per module.** A datastore and a cache are two concerns: expose a *store*
+  interface and hide caching as an implementation detail *inside* it, or keep them as separate
+  modules — never ship a `StoreAndCache` that does both. If the name needs an "and", or you
+  can't state the job in one phrase, split it.
+
+```python
+# BAD — two concerns in one interface; callers must know the cache exists
+class StoreAndCache:
+    def get(self, k): ...
+    def cache_get(self, k): ...
+    def invalidate(self, k): ...
+
+# GOOD — one Store interface; caching is a hidden implementation decision
+class Store:
+    def get(self, k): ...   # may consult a private cache inside; callers never know
+```
+- **Bring together** when the pieces share information, when one interface is simpler than two
+  (callers learn one abstraction), or when it removes duplication or a shallow go-between.
+- **Keep apart** when the pieces are used independently, when one is general-purpose and the
+  other special-purpose, or when bundling forces callers to learn things they don't need.
+- The test is complexity, not line count: merge if the whole is simpler than the parts; split
+  if the parts are simpler than the whole.
+
+## Layers and abstraction
+
+- **Different layer, different abstraction.** Adjacent layers that share the same
+  abstraction are a smell.
+- **Each method should add abstraction.** A method that only forwards to another with the
+  same signature (a pass-through method) adds interface without value — add value or let the
+  caller go direct.
+
+```python
+def get_user(self, uid):           # BAD — pure forwarder, same signature, no new abstraction
+    return self._repo.get_user(uid)
+
+def get_user(self, uid):           # OK — earns the layer: adds caching + a domain error
+    hit = self._cache.get(uid)
+    return hit if hit is not None else self._fetch_or_raise(uid)
+```
+- **Thread context, not pass-through variables.** When a value would otherwise be threaded
+  through many layers just to reach the bottom, introduce a context object or rethink the
+  boundary.
+- **Pull complexity downward.** It is better for the *module's* implementation to be complex
+  than for its interface — and every caller — to be. Suffer once, inside, so users don't.
+
+## General-purpose interfaces
+
+Do **not** add public options before a behavior requires them. During GREEN, implement only the
+current slice. Once two real slices need the same capability, extract the smallest interface
+that covers both without encoding one caller's special policy. General-purpose means "less
+policy leaked to callers," not "more knobs just in case."
+
+## Avoid flag parameters
+
+A boolean argument that selects between two behaviors is a sign of a module doing two jobs. The
+caller writes `render(doc, true)` and cannot tell what `true` means; the body branches on a flag
+instead of presenting one clear abstraction.
+
+- Split the behaviors into two named functions (`renderDraft` / `renderFinal`) rather than one
+  function with a mode switch — the names document the intent the flag hid.
+
+```python
+def export(data, *, as_csv):        # BAD — caller passes a bare bool; body forks on it
+    if as_csv: ...
+    else: ...
+
+def export_csv(data): ...           # GOOD — two clear abstractions, no flag to decode
+def export_json(data): ...
+```
+- Keep a parameter only when callers genuinely vary it along a continuum, not when it toggles
+  between two code paths that share little.
+
+## Side effects and boundaries
+
+Push I/O and mutation to the edges; keep the core a set of pure functions that map inputs to
+outputs. Pure logic is the part you can read, test, and reuse without standing up the world.
+
+- **Functional core, imperative shell.** Concentrate side effects (network, disk, clock,
+  randomness, global state) in thin boundary layers and keep decision-making logic pure. A
+  function that both computes *and* persists is harder to test and reuse than the two kept apart.
+- **Parse untrusted input at the boundary, once.** Convert external data (request bodies, env
+  vars, file contents, API responses) into trusted domain types at the edge — parse, don't
+  validate — so the interior assumes well-formed values instead of re-checking them. Never trust
+  external input deeper than the boundary that admitted it.
+
+## Define errors out of existence
+
+The best way to handle an error is to design it away.
+
+- Reduce the number of places that must handle errors. Prefer APIs whose normal path also
+  covers the edge (e.g. `unset` on a missing key is a no-op, not an exception).
+
+```python
+def unset(self, key):              # BAD — every caller must wrap in try/except
+    if key not in self._d: raise KeyError(key)
+    del self._d[key]
+
+def unset(self, key):              # GOOD — missing key is a no-op; the error case vanishes
+    self._d.pop(key, None)
+```
+- Use the language's result/exception conventions from the language rules.
+
+## Naming
+
+Names are the densest documentation in the code. A good name is **precise, consistent,
+and obvious**.
+
+- If you cannot find a precise name, the design is probably muddled — the thing does too
+  many things. Treat naming difficulty as a design signal.
+- Name length should scale with scope: loop indices can be `i`; a module-level export
+  cannot.
+- Use the same word for the same concept everywhere, and never the same word for two
+  concepts.
+
+## Comments
+
+Comments exist to capture what the code cannot: the *why*, the abstraction, and the
+non-obvious. They are part of the design, not an afterthought.
+
+- Comment the **interface** (what a caller needs to know to use it) separately from the
+  **implementation** (why it works this way). The interface comment is the abstraction.
+- Write the interface comment *first*, before the body — if it's hard to write, the
+  interface is too complex (design feedback, for free).
+- Never write a comment that just restates the code. Document the things that are *not*
+  obvious from reading it.
+- Comments describe *why*, not *what*. The code already says what.
+- **The interface comment is a complete contract when the signature and names are not enough.**
+  Prefer concise language-rule docstrings, but include any non-obvious preconditions, errors,
+  side effects, or ordering guarantees a caller needs. Do not duplicate obvious parameter or
+  return types just to be exhaustive.
+
+## Consistency
+
+Do similar things in similar ways. Consistency lowers cognitive load and unknown-unknowns: once
+a reader learns a pattern, they can rely on it holding everywhere.
+
+- **Follow the conventions already in the codebase** — naming schemes, file and module layout,
+  error handling, how a common task is wired. A change that invents a new way to do an existing
+  thing adds a pattern every future reader must learn.
+- Keep **parallel cases parallel**: sibling handlers, similar endpoints, and repeated shapes
+  should read the same way, so understanding one means understanding the rest.
+- Diverge from an established pattern only when the pattern is wrong — then fix the pattern,
+  don't add a competing one beside it.
+
+## Code should be obvious
+
+Code is read far more than it is written. Aim for code whose behavior a reader grasps quickly
+and correctly, without surprises. **Non-obvious code is a defect**, even when it is correct.
+
+- If a reader must pause to work out what a piece of code does, or could reasonably read it
+  wrong, that is a problem — fix it with clearer names and structure first.
+- When the *why* still isn't obvious from well-named code, that is what a comment is for (see
+  Comments) — but reach for structure before commentary.
+- Avoid surprises: don't give something a name or signature that implies behavior it lacks, and
+  don't hide a side effect where a reader won't expect it. The obvious reading should be correct.
+
+## Tactical vs strategic
+
+Program **strategically**, not tactically. The goal is a good design, not just working
+code. Invest a little extra continuously (better structure, better names, a comment) rather
+than taking shortcuts that compound. There are no "tactical tornado" exceptions in this
+codebase.
+
+## Design it twice
+
+Your first idea for a non-trivial design is rarely your best. Before committing, sketch **two
+genuinely different approaches** and compare them — the comparison is what reveals the better
+design, and sometimes a third that beats both.
+
+- Spend this effort in proportion to the decision: a throwaway helper doesn't need it; a module
+  boundary, a public interface, or a data shape does (scale to the mode, as the intro says).
+- Compare on the criteria that matter here — which interface is simpler and deeper, which hides
+  more, which has fewer special cases — not which is faster to type.
+
+## Red flags — stop and reconsider if you see these
+
+- **Shallow module** — interface nearly as complex as the implementation.
+- **Information leakage** — the same decision encoded in two places.
+- **Temporal decomposition** — modules mirror execution order, not responsibilities.
+- **Overexposure** — using the common case forces the caller to learn rare options.
+- **Pass-through method / variable** — added layer carries no new abstraction.
+- **Repetition** — the same snippet appears more than twice.
+- **Special-general mixture** — special-purpose code embedded in a general-purpose mechanism.
+- **Multi-concern module** — one module owns two jobs that don't share information; the name needs an "and".
+- **Flag parameter** — a boolean argument selects between two behaviors; split the function instead.
+- **Scattered side effects** — I/O or mutation interleaved through logic that could be a pure core.
+- **Re-validated input** — the same external value checked in many places instead of parsed once at the boundary.
+- **Conjoined methods** — two pieces only understandable by reading both back-to-back.
+- **Comment repeats code** — or, you can't write a comment without restating the body.
+- **Hard to name / hard to describe** — the unit's responsibilities aren't clean.
+- **Inconsistency** — a new pattern for something the codebase already does one established way.
+- **Non-obvious code** — a reader must stop and puzzle out what it does, or could read it wrong.
+
+## Testability is a design property
+
+Code that is hard to test through its public interface is badly factored — design modules so
+behavior is observable at the boundary without reaching inside (see `tdd.md`).

--- a/skills/make-pr/rules/python.md
+++ b/skills/make-pr/rules/python.md
@@ -1,0 +1,126 @@
+---
+paths: "**/*.py", "**/pyproject.toml"
+---
+
+# Python Rules
+
+Target Python 3.12+. Use modern syntax and tooling throughout.
+
+## Tooling
+
+- **Linter/Formatter:** ruff (`select = ["E", "F", "I", "B", "C4", "UP", "SIM", "PIE", "RUF", "DTZ", "PTH", "ASYNC"]` — `DTZ`/`PTH`/`ASYNC` enforce the tz-aware-datetime, pathlib, and async rules below)
+- **Type checker:** mypy with `strict = true`
+- **Package manager:** uv (manages packages, virtual envs, and Python versions)
+- **Tests:** pytest + hypothesis (property-based) + pytest-asyncio + pytest-cov (branch coverage)
+- **Logging:** structlog with JSON output
+- **Config:** All tool configuration in `pyproject.toml` only. No `setup.cfg`, `tox.ini`, or `.flake8`.
+  The gate runs config-backed commands; put Ruff selection, mypy strictness, warnings-as-errors,
+  and coverage policy in `pyproject.toml`.
+
+## Type Hints
+
+Type hints required on all function signatures and on **every variable binding** —
+module-level, class-level, and **local** — wherever the syntax allows an annotation. Annotate
+each `x = ...` assignment, including locals inside functions (this also pins the `Any` that
+`json.loads`/`re`/external calls leak, forcing a deliberate narrowing). The only exempt targets
+are those that *cannot* carry an annotation — `for`/comprehension loop variables, walrus (`:=`)
+targets, exception-handler (`except … as`) bindings, and tuple-unpacking targets; split a tuple
+unpack into single annotated assignments when the types matter.
+
+- Use modern syntax: `list[T]`, `dict[K, V]`, `T | None` (not `Optional[T]`)
+- Use the `type` statement for type aliases: `type Vector = list[float]`
+- Use `TypeIs` over `TypeGuard` for type narrowing — it narrows the `else` branch too (import
+  from `typing_extensions` on 3.12): `def is_str(x: object) -> TypeIs[str]: return isinstance(x, str)`
+- Use `Self` for methods that return `self`
+- Use `Protocol` for structural subtyping; prefer over ABC unless sharing implementation
+- Use `ParamSpec` for decorators that wrap callables
+- Use `@override` on every method that overrides a parent
+- Use `Final[T]` for constants
+
+## Naming
+
+- snake_case for functions, variables, and modules; PascalCase for classes; `UPPER_SNAKE` for
+  constants; a single leading underscore for private names (Ruff's `N` rules are off by default)
+
+## Function and Parameter Design
+
+Prefer functions over classes unless state is needed. If a method doesn't use `self`, prefer a module-level function; use `@staticmethod` only when it must conceptually live on the class.
+
+- Use keyword-only arguments for public functions and helpers when named arguments improve
+  call-site clarity. Exceptions: `self`/`cls`, dunder methods, protocol/callback signatures,
+  pytest fixture injection, framework-required signatures, and tiny private helpers where
+  positional use is clearer.
+- Never use mutable defaults (`list`, `dict`, `set`). Use `None` sentinel with `if arg is None: arg = []`
+- Sensible immutable defaults (strings, numbers, booleans, `None`, tuples) are fine
+- Return frozen dataclasses for multi-value returns, never bare tuples — return a
+  `@dataclass(frozen=True)` result with named fields instead of `-> tuple[int, str]`
+- `@property` for cheap computed access only — no side effects, no I/O. Never `@cache`/`@lru_cache`
+  a method: it pins `self` for the process lifetime and leaks memory
+
+## Control Flow and Idioms
+
+- Use `is None` / `is not None` for identity; only fall back to a truthiness check when `None`
+  and empty should behave identically
+- Use `with` for every resource (files, locks, sessions, connections), not just files
+- Never mutate a collection while iterating it; build a new one with a comprehension
+- Timezone-aware datetimes always: `datetime.now(tz=UTC)`, never naive `now()`/`utcnow()`
+- Comprehension over a manual append loop; switch to a generator (`yield` or `(...)`) when the
+  data is large or consumed once
+- `set`/`frozenset` for membership tests; `dict.get(key, default)` over `in`-then-index
+- Prefer EAFP over LBYL; keep the one statement that can raise as the entire `try` body
+- Watch the aliasing footgun: `[[]] * n` shares one inner list — use `[[] for _ in range(n)]`
+
+## Project Structure
+
+- Keep `__init__.py` files empty — they are namespace markers, not code. The one exception:
+  re-exporting the package's public API (e.g. `from .core import Thing`). A module docstring alone
+  is never a reason to add content; an empty `__init__.py` is correct, not a file to "fix"
+- Place shared types in `types.py` modules
+- Place constants in `constants.py` using `Final[T]`
+- Use `pathlib.Path` over `os.path`
+- Use `asyncio` over threading for concurrent I/O
+- Always use top-level imports. Never import inside functions.
+- Avoid `if TYPE_CHECKING:` for ordinary imports — a circular import usually means the architecture
+  is wrong, so fix that first. Use it only for a genuinely unavoidable type-only cycle (or to keep a
+  heavy/optional dependency out of the runtime import graph); pair it with `from __future__ import
+  annotations`, since 3.12 still evaluates annotations eagerly without it
+- Convert `defaultdict` to plain `dict` before returning from functions
+- Executable modules define `main()` and call it under `if __name__ == "__main__":`; no work at import time
+- No mutable module-level state; module-level values are `Final`
+- Lift magic literals into named `Final` constants (in `constants.py`)
+
+## Data Modeling
+
+- Use `dataclasses` or Pydantic models for structured data
+- Prefer frozen dataclasses (`frozen=True`) when mutability is not needed
+- Model closed sets of values with `enum.Enum` (`StrEnum`/`IntEnum` when serialized). This
+  intentionally diverges from `typescript.md`'s enum ban — Python enums carry no runtime-emit cost
+
+## Error Handling
+
+- Define project-specific exception hierarchies inheriting from a base project exception
+- Catch the narrowest exception type; never `except Exception` unless you log and re-raise
+- Re-raise with bare `raise`, never `raise e` — it preserves the original traceback
+- Use built-in exceptions for precondition violations (`ValueError`, `TypeError`)
+- Always chain exceptions: `raise ProjectError("msg") from original_error`
+- Use `except*` and `ExceptionGroup` for concurrent error handling
+
+## Logging
+
+- Use structlog with JSON output to stdout
+- Bind context (request ID, user ID, operation) at entry points
+- Never log to files directly; let the runtime collect stdout
+
+## Docstrings
+
+Single sentence explaining WHY the function exists, not WHAT it does. Do not include `Args:`, `Returns:`, or `Raises:` sections -- type hints and names should be self-documenting. Only write a module-level docstring if it adds info beyond the filename. Non-obvious preconditions, error modes, and side effects belong in a prose interface comment (see `design-principles.md`), not in structured docstring sections.
+
+## Testing
+
+Test discipline (pytest, hypothesis, pytest-asyncio) lives in `tdd.md`. Python-specific config:
+- Set `filterwarnings = ["error"]` to catch deprecation warnings (the default gate also runs
+  pytest with `-W error`).
+- Measure **branch** coverage as a **diagnostic**, never a gate target — read it to find a
+  genuinely untested path, but do not set a `--cov-fail-under` mandate. A 100% target just
+  manufactures tests that color branches green instead of asserting behavior. Configure the
+  coverage report (not a threshold) in `pyproject.toml`; do not hardcode repository layout in the gate.

--- a/skills/make-pr/rules/rust.md
+++ b/skills/make-pr/rules/rust.md
@@ -1,0 +1,175 @@
+---
+paths: "**/*.rs", "**/Cargo.toml"
+---
+
+# Rust Rules
+
+Target Edition 2024 (Rust 1.85+). Pin `rust-version` in `Cargo.toml`, commit `Cargo.lock`, and
+keep modern idioms with strict linting throughout. Follow the
+[Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) and the official
+[Rust Style Guide](https://doc.rust-lang.org/style-guide/) — both are what `rustfmt`/`clippy`
+encode.
+
+## Tooling
+
+- **Formatter:** rustfmt via `cargo fmt`. The official style is non-negotiable: 4-space indent,
+  100-column width, block (not visual) indent, trailing commas in multi-line lists, line comments
+  (`//`) over block, one combined `#[derive(...)]` per item. Put any overrides in `rustfmt.toml`.
+- **Linter:** clippy. `cargo clippy --all-targets --all-features -- -D warnings` is clean before
+  every commit. **Fix warnings, never silence them** — reach for `#[allow(...)]` only with a
+  comment justifying it (lint levels live in `[workspace.lints]` — see Workspace Lints).
+- **Async runtime:** Tokio (async-std is discontinued).
+- **Error handling:** thiserror (libraries) + anyhow (applications); eyre is an acceptable
+  alternative for rich application error reports.
+- **Tests:** `cargo test` (unit + integration + doc tests). Use **cargo-nextest** as the local
+  runner (faster parallelism, better output) — it does **not** run doc tests, so keep
+  `cargo test --doc` alongside it. **proptest** for property-based tests (per-value shrinking).
+- **CI checks:** `cargo doc --no-deps`, `cargo audit`, `cargo deny` (known vulnerabilities + license violations).
+
+## Naming
+
+Follow the Rust API Guidelines casing: `UpperCamelCase` for types/traits/enum variants,
+`snake_case` for functions/methods/variables/modules, `SCREAMING_SNAKE_CASE` for consts/statics.
+
+- Names say what they mean (`is_in(haystack, needle)`, not `is_in(a, b)`); keep a consistent word
+  order (`verb_noun`); omit the type from the name unless it disambiguates.
+- Generic parameters are short, conventionally a single uppercase letter (`T`, `K`, `V`).
+- Lifetimes get short descriptive lowercase names (`'heap`); use `'a` only for trivial single-use
+  lifetimes, and never numbered lifetimes.
+- Suffix error types with `Error`; bind pattern variables to the source name or its first letter
+  (`if let Some(response) = event.response`), not an inconsistent rename.
+
+## Error Handling
+
+Use `Result<T, E>` in all public APIs. **Never panic in library code** (assertions guarding
+genuine invariants excepted). No `unwrap()`/`expect()` on production paths.
+
+- **Libraries:** define concrete error enums with `#[derive(thiserror::Error)]` so callers can
+  match variants. Add a crate-level `type Result<T> = std::result::Result<T, Error>;` alias and
+  `From` impls so `?` converts cleanly.
+- **Applications:** use `anyhow::Result` (or `eyre::Result`) for top-level propagation.
+- Propagate with `?`; add context (`.context("failed to open config")?`). Discard an error
+  deliberately with `.ok()`, never a `|_| ()` closure.
+- Tests must exercise the error paths, not just the happy path.
+
+## Ownership and Idioms
+
+- **Borrow over clone**, and avoid redundant clones on hot paths. Pass `&T`; take `T` by value
+  only for `Copy` types or when you genuinely consume it.
+- Bind a value, then borrow the binding — `let foo = make(); use(&foo);`, not `let foo = &make();`.
+  Start a `let` with `&` only when indexing or slicing.
+- **Iterators over manual loops:** `items.iter().filter(..).map(..).collect()` reads top-to-bottom
+  and optimizes as zero-cost abstraction; prefer `.collect()` to `FromIterator::from_iter`.
+- Allocate late: `Vec::with_capacity(n)` when the size is known, `Vec::new()` for an empty
+  collection.
+- Use `Self` inside impls to refer to the type; never shadow a type name, and keep value shadowing
+  to one level or a single type-changing conversion. Lowercase hex literals (`0xab5c`).
+
+## Generics and Dispatch
+
+- Prefer **static dispatch** (`impl Trait`, `<T: Trait>`); reach for `dyn Trait` only when runtime
+  polymorphism is actually required.
+- Move bounds to a `where` clause once they need a compound constraint or would push the
+  angle-bracket header past ~30 characters.
+- Every generic parameter must be used in the signature — an unused one signals a modeling mistake.
+
+## Imports
+
+Three groups, blank-line separated, in order: `std`/`core`/`alloc`; third-party crates; local
+(`crate`/`super`/`self`).
+
+- No glob imports (`use foo::*`) except `use super::*;` inside a `#[cfg(test)]` module. Don't glob
+  enum variants — rename locally (`use SomeLongEnum as Se;`) if needed.
+- Group same-path imports with nested braces (`use a::b::{C, D};`).
+
+The std/external/local grouping and same-path brace-merging are produced only by the *unstable*
+rustfmt options `group_imports`/`imports_granularity`. Stable `cargo fmt` (the gate) only sorts within
+existing groups, so on stable these two are reviewer-enforced conventions; to automate them, set
+`group_imports = "StdExternalCrate"` and `imports_granularity = "Crate"` in `rustfmt.toml` and run
+`cargo +nightly fmt`.
+
+## Documentation
+
+Doc comments (`///`) required on all public items, written as complete sentences. Include these
+sections where applicable:
+
+- `# Errors` — when the function returns `Result`, list the error conditions.
+- `# Panics` — document any conditions under which the function panics.
+- `# Safety` — required on every `unsafe fn`; document the invariants the caller must uphold.
+
+Apply `#[must_use]` on constructors, builders, and fallible operations whose return value should
+not be silently dropped (the `must_use_candidate` clippy lint catches misses). Comments explain
+*why*, not *what*; promote a lingering `TODO` into a tracked issue rather than leaving it in code.
+
+## Unsafe Discipline
+
+- Set `unsafe_code = "deny"` in `[workspace.lints.rust]`; use `#![forbid(unsafe_code)]` at the
+  crate root for crates that must stay pure-safe.
+- Every `unsafe` block carries a `// SAFETY:` comment explaining why the invariants hold.
+- Minimize the unsafe surface: wrap it in safe abstractions with documented preconditions.
+
+## Workspace Lints
+
+Configure lints via `[workspace.lints]` in the workspace `Cargo.toml`; member crates inherit with
+`[lints] workspace = true`. Do not use inline `#![allow(...)]`/`#![warn(...)]` at the crate level.
+
+```toml
+[workspace.lints.rust]
+unsafe_code = "deny"
+missing_docs = "warn"
+unreachable_pub = "warn"
+
+[workspace.lints.clippy]
+# Cherry-pick from pedantic — do NOT enable the whole pedantic group
+doc_markdown = "warn"
+manual_let_else = "warn"
+match_same_arms = "warn"
+redundant_closure_for_method_calls = "warn"
+semicolon_if_nothing_returned = "warn"
+must_use_candidate = "warn"
+needless_pass_by_value = "warn"
+uninlined_format_args = "warn"
+```
+
+## Async
+
+Native `async fn` in traits is stable — use it directly. But it cannot express a `Send` bound on the
+returned future, so a future obtained through a generic or `dyn` bound will not satisfy `tokio::spawn`
+on the multithreaded runtime; when you must spawn the result, return `-> impl Future<Output = …> +
+Send` explicitly, annotate the trait with `#[trait_variant::make(Send)]`, or fall back to
+`#[async_trait]` (which boxes a `Send` future). Reach for `#[async_trait]` for dyn-compatibility **or**
+when you need that `Send` bound for spawning.
+
+- `tokio::select!` to multiplex futures; `tokio::sync::mpsc` for async channels.
+- Offload CPU-bound or blocking work to `tokio::task::spawn_blocking`; never block the async
+  executor with synchronous I/O.
+
+## Serde
+
+- `#[serde(rename_all = "camelCase")]` for JSON API types.
+- `#[serde(deny_unknown_fields)]` on configuration structs to catch typos — but **not** combined
+  with `#[serde(flatten)]` (they conflict and produce confusing errors).
+
+## Project Structure
+
+- Organize modules by **capability/domain**, not by language feature — no `types.rs` / `impl.rs`
+  split. Keep a struct and its `impl` blocks in the same file. Apply the "could this be a separate
+  crate?" test to find module boundaries.
+- Workspace: a virtual manifest (no `[package]`, only `[workspace]`) with a flat `crates/` layout
+  (`core/`, `api/`, `cli/`). Declare shared deps in `[workspace.dependencies]` and reference them
+  with `dep.workspace = true` so versions stay consistent.
+- **No `println!`/`eprintln!`/`dbg!` in library code** — emit structured events through `tracing`
+  (or `log`); binaries initialize the subscriber, libraries only emit.
+
+## Testing
+
+Test discipline (red → green → refactor, behavior through the public interface) lives in `tdd.md`.
+Rust specifics:
+
+- Unit tests in a `#[cfg(test)] mod tests { use super::*; }` block beside the code; integration
+  tests in `tests/`; doc tests double as living, compiled usage examples.
+- **proptest** for property-based tests of pure functions; prefer a property over a handful of
+  examples when the rule is general.
+- The default gate runs `cargo test --all-features` (swap in `cargo nextest run` for projects that
+  adopt it, keeping doc tests). Configure features, lint levels, and `rust-version` in committed
+  config, not on the gate command line.

--- a/skills/make-pr/rules/tdd.md
+++ b/skills/make-pr/rules/tdd.md
@@ -1,0 +1,116 @@
+---
+paths: "**/*_test.py", "**/test_*.py", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/tests/**"
+---
+
+# TDD Rules
+
+How tests get written in this codebase: red → green → refactor, in vertical slices.
+Adapted from the test-first discipline of *Growing Object-Oriented Software* and Matt
+Pocock's TDD skill. The `coder` and `tdd-runner` agents follow this; the `architect`
+enforces the loop.
+
+## Core principle
+
+**Tests verify behavior through public interfaces, never implementation details.**
+
+A good test reads like a specification of what the system does for a user. It survives any
+internal refactor that preserves behavior. The defining smell of a bad test: it breaks when
+you refactor even though behavior did not change.
+
+- Do **not** mock internal collaborators, test private methods, or assert on internal state.
+- Mock only true external boundaries (network, clock, filesystem, third-party APIs).
+- If a behavior is only reachable by poking internals, the design is wrong — fix the design,
+  not the test (see `design-principles.md`).
+- Write the **fewest** tests that pin the behavior. Prefer one test through the real public
+  interface over many that re-check the same path from different angles. Never add a test solely
+  to cover a line or branch, and never test a dormant or unreachable path — coverage is a
+  diagnostic, not a target. A suite that grows faster than the behavior it describes is slop.
+
+## Anti-pattern: horizontal slices
+
+Never write all the tests up front and then all the implementation. Tests written against
+imagined behavior assert the shape of data structures rather than user-facing capability,
+and go stale the moment the implementation teaches you something. **Always vertical slices:
+one test → one implementation → repeat (tracer bullets).**
+
+## The loop
+
+For each behavior, in order:
+
+1. **RED** — Write exactly one test for one behavior. Run it. Watch it fail **for the right
+   reason** — an assertion failure, or a missing symbol the GREEN step will add that exactly
+   matches the target public interface, not an import typo, syntax error, or fixture mistake. A
+   test that has never failed proves nothing.
+2. **GREEN** — Write the *minimum* code to make that test pass. No speculative features, no
+   handling of cases no test demands yet.
+3. **REFACTOR** — Only once green. Remove duplication, improve names, deepen modules per
+   `design-principles.md`. Re-run tests; they must stay green. **Never refactor while red.**
+
+## Planning a change (before the first RED)
+
+- Confirm the public interface from the task spec.
+- List the **behaviors** to cover (user-facing outcomes), not implementation steps.
+- Order them so each slice is a thin end-to-end path.
+- The task spec must include explicit acceptance criteria or a behavior list. If it does not,
+  stop for re-scope. If it does, proceed and log the chosen behavior list; ask the human only
+  when multiple materially different interfaces or behavior lists are plausible.
+
+## When TDD is mandatory
+
+TDD is required for any change with **behavior or logic**: new functions, branching,
+parsing, state changes, and bug fixes.
+
+It may be **skipped** only for changes with no behavior to assert: pure config, dependency
+bumps, docs, comments, formatting, and mechanical renames. When skipped, the `architect`
+logs the skip with a reason in the run log. When in doubt, do TDD.
+
+A bug fix **always** starts with a failing test that reproduces the bug.
+
+## Per-cycle checklist
+
+- [ ] Test names a behavior, not a method (`returns_empty_cart_total_as_zero`, not `test_total`).
+- [ ] Test uses only the public interface.
+- [ ] Test was seen to fail for the right reason before any production code.
+- [ ] Production code is minimal for the current test.
+- [ ] No speculative feature was added.
+- [ ] After refactor, all tests still green.
+
+## Tooling
+
+- Prefer a **property-based** test (hypothesis / proptest) over a handful of examples when the rule
+  is general, and measure **branch** coverage, not just line.
+- The test runner, async support, and where tests live are language-specific — see the language
+  rule (`python.md`, `typescript.md`, `rust.md`) for the runner and layout.
+
+## What a good test looks like
+
+```python
+# GOOD — behavior through the public interface
+def test_discount_applies_to_subtotal():
+    cart = Cart(items=[Item(price=100), Item(price=50)])
+    assert cart.total(discount=Percent(10)) == 135
+
+# BAD — couples to implementation; breaks on harmless refactor
+def test_discount_calls_internal_multiplier():
+    cart = Cart(items=[Item(price=100)])
+    cart._apply_discount = Mock()
+    cart.total(discount=Percent(10))
+    cart._apply_discount.assert_called_once()
+```
+
+```typescript
+// GOOD (vitest) — same lesson: assert the public result, not an internal call
+test("discount applies to subtotal", () => {
+  const cart = new Cart([item(100), item(50)]);
+  expect(cart.total({ discount: percent(10) })).toBe(135);
+});
+```
+
+```rust
+// GOOD (cargo test) — same lesson: assert the public result, not an internal call
+#[test]
+fn discount_applies_to_subtotal() {
+    let cart = Cart::new(vec![item(100), item(50)]);
+    assert_eq!(cart.total(Percent(10)), Money(135));
+}
+```

--- a/skills/make-pr/rules/typescript.md
+++ b/skills/make-pr/rules/typescript.md
@@ -1,0 +1,162 @@
+---
+paths: "**/*.ts", "**/*.tsx", "**/package.json"
+---
+
+# TypeScript Rules
+
+Target TypeScript 5.8+. Use strict mode, modern ESM, and current tooling throughout.
+
+## Compiler Configuration
+
+Use `module: "nodenext"` (Node.js — it sets `moduleResolution` automatically) or, for bundled apps, `module: "preserve"` (TS 5.4+, which implies `moduleResolution: "bundler"`). If you instead use `module: "esnext"`, you must also set `moduleResolution: "bundler"` explicitly — alone it falls back to the legacy `classic` resolver, which cannot read package `exports` maps. Always enable strict mode plus additional flags:
+
+```json
+{
+  "strict": true,
+  "noUncheckedIndexedAccess": true,
+  "exactOptionalPropertyTypes": true,
+  "noPropertyAccessFromIndexSignature": true
+}
+```
+
+No CommonJS for new code. All files use ESM (`import`/`export`).
+
+## Tooling
+
+- **Linter/Formatter:** Biome for the default v1 TypeScript gate. Repos using ESLint + Prettier
+  must provide an explicit TypeScript gate override before running v1.
+- **Package manager:** pnpm (strict deps — no phantom dependencies)
+- **Tests:** vitest (native TS/ESM support) + @vitest/coverage-v8 (branch coverage)
+- **Validation:** Zod (or Valibot for bundle-sensitive apps). Prefer Standard Schema v1 compliant validators.
+- **Monorepo:** Turborepo for multi-package TypeScript repos
+
+## No Enums
+
+Never use TypeScript `enum`. Use `as const` objects with derived union types instead:
+
+```typescript
+const Status = { Active: "active", Inactive: "inactive" } as const;
+type Status = (typeof Status)[keyof typeof Status];
+```
+
+Rationale: enums emit runtime helper code and conflict with erasable-types (Node's native TS).
+`as const` keeps runtime values as plain objects only when you actually need values, and derived
+union types erase cleanly when you only need types.
+
+## No Barrel Exports
+
+Do not create `index.ts` barrel files that re-export from other modules. Import directly from the source file:
+
+```typescript
+// BAD
+import { UserService } from "./services";
+
+// GOOD
+import { UserService } from "./services/user-service.ts";
+```
+
+Barrel files are acceptable only at package public API boundaries (the main `index.ts` of a published package). Removing barrels speeds builds and avoids circular imports.
+
+## Type Safety
+
+- **`unknown` over `any`:** When a dynamic type is needed, use `unknown` with type narrowing (type guards, `instanceof`, `typeof`, or Zod parsing). Never use `any`. If a third-party API lacks types and no `@types/` package exists, write a `.d.ts` declaration file instead.
+- **`const` over `let`**, never `var`. Reassignment should be rare; prefer deriving new values.
+- **Explicit return types** on exported functions and public methods. Inferred return types are fine for local/private functions.
+- **Discriminated unions** for modeling state:
+
+```typescript
+type Result<T, E = Error> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+```
+
+- **Exhaustiveness checking:** in every `switch` over a discriminated union, assign the
+  default case to a `never` binding so adding a variant without handling it fails to compile:
+
+```typescript
+function area(s: Shape): number {
+  switch (s.kind) {
+    case "circle": return Math.PI * s.r ** 2;
+    case "square": return s.side ** 2;
+    default: { const _exhaustive: never = s; return _exhaustive; }
+  }
+}
+```
+
+- **Derive types with built-in utility types** (`Partial`, `Pick`, `Omit`, `Readonly`,
+  `Record`, `ReturnType`, `Awaited`) instead of hand-maintaining parallel shapes that drift
+  from their source of truth.
+- **Every generic parameter must be used.** A type parameter that never appears in the
+  parameters or return type breaks inference and signals a modeling mistake — drop it.
+
+## Error Handling
+
+Use result types for expected/recoverable errors. Use neverthrow or a custom discriminated union (shown above). Reserve `throw` for truly exceptional, unrecoverable situations (programmer errors, invariant violations).
+
+```typescript
+// neverthrow style
+import { ok, err, Result } from "neverthrow";
+
+function parseConfig(raw: string): Result<Config, ParseError> {
+  // ...
+  return ok(config);
+}
+```
+
+## Project Structure
+
+- Keep `package.json` `type: "module"` for ESM
+- Place shared types in dedicated `types.ts` files
+- Place constants in `constants.ts` using `as const`
+- Co-locate tests next to source files (`foo.ts` / `foo.test.ts`) or in a parallel `__tests__/` directory
+- Use path aliases sparingly; prefer relative imports within a package
+
+## Functions and Parameters
+
+- Prefer functions over classes unless state management or lifecycle is needed
+- Use object parameters for functions with 3+ arguments:
+
+```typescript
+function createUser(opts: { name: string; email: string; role: Role }): User {
+  // ...
+}
+```
+
+- Use `readonly` on array and object parameters that should not be mutated
+- Prefer `satisfies` over type assertions (`as`) to validate types without widening
+
+## Overloads and Callbacks
+
+- **Prefer union-typed or optional parameters over function overloads.** Overloads hide bugs
+  and interact badly with strict null checks; `fn(x: number | string)` and
+  `fn(x: string, y?: string)` are clearer than multiple signatures. When overloads are genuinely
+  unavoidable, order them specific-to-general — TypeScript resolves to the first matching signature.
+- **Type an ignored callback return as `void`**, never `any`; `void` stops callers from
+  consuming a value that was never meant to be used.
+- **Don't make callback parameters optional.** A callback may legally accept fewer arguments,
+  so `(data: Data, count: number) => void` is correct even when some callers ignore `count`.
+- **Hand-written `.d.ts` declarations use primitive types** (`string`, `number`, `boolean`,
+  `object`), never boxed wrappers (`String`, `Number`, `Boolean`, `Object`).
+
+## Async Patterns
+
+- Always `await` promises; never leave floating promises (use `void` prefix if intentionally fire-and-forget)
+- Use `AbortSignal` for cancellation
+- Prefer `using` (explicit resource management) for cleanup when targeting environments that support it
+
+## Testing
+
+Test discipline (vitest, behavior through the public interface) lives in `tdd.md`. The gate runs
+`vitest` with `--passWithNoTests=false` so a test-less change cannot pass green. Configure
+coverage provider, branch thresholds, strict compiler flags, enum/barrel restrictions, and Biome
+rules in committed project config (`vitest.config.*`, `tsconfig*.json`, `biome.json`) rather than
+only on the gate command line.
+
+## Logging
+
+- Use a structured logger (pino) emitting JSON to stdout; never log to files directly.
+- Bind context (request ID, user ID, operation) at entry points and pass child loggers down.
+
+## Documentation
+
+Single-sentence JSDoc explaining WHY the function exists, not WHAT it does. Parameter types and return types are in the signature; do not duplicate them in JSDoc `@param`/`@returns` tags.

--- a/skills/make-pr/schemas/_defs.schema.json
+++ b/skills/make-pr/schemas/_defs.schema.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "_defs.schema.json",
+  "title": "v1 agent return — shared definitions",
+  "$defs": {
+    "schema_version": {
+      "const": "v1"
+    }
+  }
+}

--- a/skills/make-pr/schemas/coder-lite.schema.json
+++ b/skills/make-pr/schemas/coder-lite.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "coder-lite.schema.json",
+  "title": "Coder-lite agent return",
+  "$comment": "The make-pr-lite coder. Unlike coder.schema.json this is NOT validated at orchestration time (the lite loop reads returns directly); it exists so the prompt example stays honest under the anti-drift check and documents the whole-PR self-TDD return shape.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "role",
+    "mode",
+    "status",
+    "commit",
+    "behaviors",
+    "files_changed",
+    "commands",
+    "new_dependencies",
+    "scope_notes",
+    "blocked_reason"
+  ],
+  "properties": {
+    "role": { "const": "coder-lite" },
+    "mode": { "enum": ["build", "fix"] },
+    "status": { "enum": ["done", "blocked"] },
+    "commit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha", "subject"],
+      "properties": {
+        "sha": { "type": "string" },
+        "subject": { "type": "string" }
+      }
+    },
+    "behaviors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "test", "files", "red", "green"],
+        "properties": {
+          "name": { "type": "string" },
+          "test": { "type": ["string", "null"] },
+          "files": { "type": "array", "items": { "type": "string" } },
+          "red": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "required": ["cmd", "exit_code", "key_output"],
+            "properties": {
+              "cmd": { "type": "string" },
+              "exit_code": { "type": "integer" },
+              "key_output": { "type": "string" }
+            }
+          },
+          "green": { "type": "boolean" }
+        }
+      }
+    },
+    "files_changed": { "type": "array", "items": { "type": "string" } },
+    "commands": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["cmd", "exit_code", "outcome", "key_output"],
+        "properties": {
+          "cmd": { "type": "string" },
+          "exit_code": { "type": "integer" },
+          "outcome": { "type": "string", "enum": ["pass", "fail"] },
+          "key_output": { "type": "string" }
+        }
+      }
+    },
+    "new_dependencies": { "type": "array", "items": { "type": "string" } },
+    "scope_notes": { "type": "string" },
+    "blocked_reason": { "type": "string" }
+  },
+  "allOf": [
+    {
+      "$comment": "A done return records a real commit.",
+      "if": { "required": ["status"], "properties": { "status": { "const": "done" } } },
+      "then": {
+        "properties": {
+          "commit": {
+            "properties": {
+              "sha": { "minLength": 1 },
+              "subject": { "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "A blocked return must explain why.",
+      "if": { "required": ["status"], "properties": { "status": { "const": "blocked" } } },
+      "then": { "properties": { "blocked_reason": { "minLength": 1 } } }
+    }
+  ]
+}

--- a/skills/make-pr/schemas/coder.schema.json
+++ b/skills/make-pr/schemas/coder.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "coder.schema.json",
+  "title": "Coder agent return",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "role",
+    "mode",
+    "status",
+    "commit",
+    "files_changed",
+    "files_staged",
+    "commands",
+    "scope_notes",
+    "new_dependencies",
+    "blocked_reason"
+  ],
+  "properties": {
+    "schema_version": { "$ref": "_defs.schema.json#/$defs/schema_version" },
+    "role": { "const": "coder" },
+    "mode": { "enum": ["green", "refactor", "non_behavioral"] },
+    "status": { "enum": ["done", "blocked"] },
+    "commit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha", "subject"],
+      "properties": {
+        "sha": { "type": "string" },
+        "subject": { "type": "string" }
+      }
+    },
+    "files_changed": { "type": "array", "items": { "type": "string" } },
+    "files_staged": { "type": "array", "items": { "type": "string" } },
+    "commands": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["cmd", "exit_code", "outcome", "key_output"],
+        "properties": {
+          "cmd": { "type": "string" },
+          "exit_code": { "type": "integer" },
+          "outcome": { "type": "string", "enum": ["pass", "fail"] },
+          "key_output": { "type": "string" }
+        }
+      }
+    },
+    "scope_notes": { "type": "string" },
+    "new_dependencies": { "type": "array", "items": { "type": "string" } },
+    "blocked_reason": { "type": "string" }
+  },
+  "allOf": [
+    {
+      "$comment": "A done return records a real commit.",
+      "if": { "required": ["status"], "properties": { "status": { "const": "done" } } },
+      "then": {
+        "properties": {
+          "commit": {
+            "properties": {
+              "sha": { "minLength": 1 },
+              "subject": { "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "A done GREEN must carry the auditable RED->GREEN transition: a failing run and a passing run.",
+      "if": { "required": ["status", "mode"], "properties": { "status": { "const": "done" }, "mode": { "const": "green" } } },
+      "then": {
+        "properties": {
+          "commands": {
+            "allOf": [
+              { "contains": { "required": ["outcome"], "properties": { "outcome": { "const": "fail" } } } },
+              { "contains": { "required": ["outcome"], "properties": { "outcome": { "const": "pass" } } } }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "$comment": "A done REFACTOR keeps tests green: at least one passing run. (non_behavioral may have no runnable check.)",
+      "if": { "required": ["status", "mode"], "properties": { "status": { "const": "done" }, "mode": { "const": "refactor" } } },
+      "then": {
+        "properties": {
+          "commands": {
+            "contains": { "required": ["outcome"], "properties": { "outcome": { "const": "pass" } } }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "A blocked return must explain why.",
+      "if": { "required": ["status"], "properties": { "status": { "const": "blocked" } } },
+      "then": { "properties": { "blocked_reason": { "minLength": 1 } } }
+    }
+  ]
+}

--- a/skills/make-pr/schemas/critic.schema.json
+++ b/skills/make-pr/schemas/critic.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "critic.schema.json",
+  "title": "Critic agent return",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "role",
+    "score",
+    "verdict",
+    "task_restated",
+    "covered",
+    "gaps"
+  ],
+  "properties": {
+    "schema_version": { "$ref": "_defs.schema.json#/$defs/schema_version" },
+    "role": { "const": "critic" },
+    "score": { "type": "integer", "minimum": 1, "maximum": 100 },
+    "verdict": { "enum": ["achieved", "partial", "not_achieved"] },
+    "task_restated": { "type": "string" },
+    "covered": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["task_part", "evidence"],
+        "properties": {
+          "task_part": { "type": "string" },
+          "evidence": { "type": "string" }
+        }
+      }
+    },
+    "gaps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["task_part", "reason"],
+        "properties": {
+          "task_part": { "type": "string" },
+          "reason": { "type": "string" }
+        }
+      }
+    },
+    "note": { "type": "string" }
+  },
+  "allOf": [
+    {
+      "$comment": "verdict must follow from score: achieved >=85, partial 50-84, not_achieved <=49.",
+      "if": { "required": ["verdict"], "properties": { "verdict": { "const": "achieved" } } },
+      "then": { "properties": { "score": { "minimum": 85 } } }
+    },
+    {
+      "if": { "required": ["verdict"], "properties": { "verdict": { "const": "partial" } } },
+      "then": { "properties": { "score": { "minimum": 50, "maximum": 84 } } }
+    },
+    {
+      "if": { "required": ["verdict"], "properties": { "verdict": { "const": "not_achieved" } } },
+      "then": { "properties": { "score": { "maximum": 49 } } }
+    }
+  ]
+}

--- a/skills/make-pr/schemas/reviewer.schema.json
+++ b/skills/make-pr/schemas/reviewer.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "reviewer.schema.json",
+  "title": "Reviewer agent return",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "role", "summary", "summary_score", "has_critical", "findings"],
+  "properties": {
+    "schema_version": { "$ref": "_defs.schema.json#/$defs/schema_version" },
+    "role": { "const": "reviewer" },
+    "summary": { "type": "string" },
+    "summary_score": { "type": "integer", "minimum": 1, "maximum": 100 },
+    "has_critical": { "type": "boolean" },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["severity", "score", "lens", "location", "issue", "fix"],
+        "properties": {
+          "severity": { "enum": ["CRITICAL", "MAJOR", "MINOR"] },
+          "score": { "type": "integer", "minimum": 1, "maximum": 100 },
+          "lens": { "enum": ["quality", "bug", "security", "readability", "test"] },
+          "location": { "type": "string" },
+          "issue": { "type": "string" },
+          "fix": { "type": "string" }
+        },
+        "allOf": [
+          { "if": { "required": ["severity"], "properties": { "severity": { "const": "CRITICAL" } } },
+            "then": { "properties": { "score": { "minimum": 85 } } } },
+          { "if": { "required": ["severity"], "properties": { "severity": { "const": "MAJOR" } } },
+            "then": { "properties": { "score": { "minimum": 50, "maximum": 84 } } } },
+          { "if": { "required": ["severity"], "properties": { "severity": { "const": "MINOR" } } },
+            "then": { "properties": { "score": { "maximum": 49 } } } }
+        ]
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "has_critical must equal 'at least one finding is CRITICAL'.",
+      "if": { "properties": { "findings": { "contains": { "required": ["severity"], "properties": { "severity": { "const": "CRITICAL" } } } } } },
+      "then": { "properties": { "has_critical": { "const": true } } },
+      "else": { "properties": { "has_critical": { "const": false } } }
+    }
+  ]
+}

--- a/skills/make-pr/schemas/tdd-runner.schema.json
+++ b/skills/make-pr/schemas/tdd-runner.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "tdd-runner.schema.json",
+  "title": "TDD-runner agent return",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "role",
+    "status",
+    "behavior",
+    "test_file",
+    "test_name",
+    "commands",
+    "right_reason",
+    "right_reason_note",
+    "notes"
+  ],
+  "properties": {
+    "schema_version": { "$ref": "_defs.schema.json#/$defs/schema_version" },
+    "role": { "const": "tdd-runner" },
+    "status": { "enum": ["red", "error"] },
+    "behavior": { "type": "string" },
+    "test_file": { "type": "string" },
+    "test_name": { "type": "string" },
+    "commands": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["cmd", "exit_code", "outcome", "key_output"],
+        "properties": {
+          "cmd": { "type": "string" },
+          "exit_code": { "type": "integer" },
+          "outcome": { "type": "string", "enum": ["red", "error"] },
+          "key_output": { "type": "string" }
+        }
+      }
+    },
+    "right_reason": { "type": "boolean" },
+    "right_reason_note": { "type": "string" },
+    "notes": { "type": "string" }
+  },
+  "allOf": [
+    {
+      "$comment": "A red status is a witnessed right-reason RED: right_reason true and a command observed red.",
+      "if": { "required": ["status"], "properties": { "status": { "const": "red" } } },
+      "then": {
+        "properties": {
+          "right_reason": { "const": true },
+          "commands": { "contains": { "required": ["outcome"], "properties": { "outcome": { "const": "red" } } } }
+        }
+      }
+    },
+    {
+      "$comment": "An error status did not reach a meaningful RED.",
+      "if": { "required": ["status"], "properties": { "status": { "const": "error" } } },
+      "then": { "properties": { "right_reason": { "const": false } } }
+    }
+  ]
+}

--- a/skills/make-pr/scripts/validate_return.py
+++ b/skills/make-pr/scripts/validate_return.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Validate an agent return against its v1 JSON-Schema contract.
+
+A thin wrapper over jsonschema (the reference validator) so the architect can reject a
+malformed return (exit 0/1/2). Run under uv so the dependency is present:
+    uv run --no-project --with jsonschema python validate_return.py <schema> <instance>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+
+
+def _validator(*, schema_path: Path) -> Draft202012Validator:
+    """A validator registered with the sibling schemas, so cross-file $refs resolve."""
+    registry: Registry = Registry().with_resources(
+        (path.name, Resource.from_contents(json.loads(path.read_text())))
+        for path in schema_path.parent.glob("*.schema.json")
+    )
+    return Draft202012Validator(json.loads(schema_path.read_text()), registry=registry)
+
+
+def errors_against(*, instance: object, schema_path: Path) -> list[str]:
+    """Every way an in-memory instance violates the schema (empty list = valid)."""
+    validator: Draft202012Validator = _validator(schema_path=schema_path)
+    messages: list[str] = [
+        f"{error.json_path}: {error.message}"
+        for error in validator.iter_errors(instance)
+    ]
+    return sorted(messages)
+
+
+def validate(*, schema_path: Path, instance_path: Path) -> list[str]:
+    """Every way the instance file violates the schema file (empty list means valid)."""
+    instance: object = json.loads(instance_path.read_text())
+    return errors_against(instance=instance, schema_path=schema_path)
+
+
+def main(*, argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(
+            "usage: validate_return.py <schema.json> <instance.json>", file=sys.stderr
+        )
+        return 2
+    schema_path: Path = Path(argv[1])
+    instance_path: Path = Path(argv[2])
+    try:
+        errors: list[str] = validate(
+            schema_path=schema_path, instance_path=instance_path
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if errors:
+        print(f"INVALID: {instance_path.name} does not match {schema_path.name}")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+    print(f"OK: {instance_path.name} matches {schema_path.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(argv=sys.argv))


### PR DESCRIPTION
## Why

Follow-up to #99. An audit of all 13 skills found two more that read assets from `<repo_root>` and so **silently degrade when run outside the `agent-templates` clone** (another repo, or a machine without the checkout):

- **`make-pr`** (and its aliases `pr-make`, `pr-make-till-merge`) — reads `rules/`, `gates/`, `schemas/`, and `scripts/validate_return.py` from `<repo_root>`.
- **`improve-architecture`** — reads its core rubric `rules/design-principles.md` via a *bare relative path* that resolves to nothing outside the clone.

They worked day-to-day only because the orchestrator resolved `<repo_root>` to the local clone and handed agents absolute paths into it (confirmed in `.v1-runs/` logs). That's implicit and fragile — when a session doesn't resolve to the clone, rules are silently dropped.

## Changes

- **`make-pr`**: bundle `rules/` + `gates/` + `schemas/` + `validate_return.py` inside the skill dir; resolve everything from `skill_root` (beside `SKILL.md`), not `<repo_root>`. The CLI copies the whole skill dir, so the assets now travel on install.
- **`improve-architecture`**: bundle `rules/design-principles.md`; resolve it from the skill dir.
- **Drift guard**: generalized `installer/tests/test_skill_bundles.py` to a data-driven spec covering all three bundling skills (`make-pr-lite`, `make-pr`, `improve-architecture`), with full-mirror vs named-subset checks. Verified it fails on drift in both modes.

## Verification

Full `gates/python.json` profile green: `ruff format --check`, `ruff check`, `mypy --strict`, **75 tests** (`pytest -W error`).

## Scope / context

- Interim, mirroring #99. **Slice 7** (issue #74) replaces these in-skill bundles with installer-composed deps from a single canonical source.
- The audit's *widest* gap — sub-agent install — is **not** code here: 9/13 skills dispatch `reviewer`/`critic`/etc., which the new installer doesn't yet manage (Slice 5). They currently work only via the old bash installer's global copies (and `reviewer`/`critic` had drifted — re-synced locally, outside this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)