### PR TITLE
feat(installer): Agents tab — generalize engine + agent install/uninstall (slice 5.1)

### DIFF
--- a/installer/actions.py
+++ b/installer/actions.py
@@ -96,3 +96,31 @@ def uninstall_skill(
     )
     save_state(new_state, state_root)
     return new_state
+
+
+def uninstall_agent(
+    *,
+    name: str,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Take an agent back off disk by dropping its live symlink then its staged
+    file, so neither a dangling link nor an orphaned staging area survives — the
+    inverse of install_agent.
+
+    Persists the updated state to state_root (via save_state) and returns a brand-new
+    immutable State without the agent's unit; the passed-in state is never mutated."""
+    unlink_unit(link_path=claude_root / AGENTS_DIRNAME / f"{name}.md")
+    unstage_unit(unit=agent_unit(name), staged_root=state_root / STAGED_DIRNAME)
+    removed_id: str = agent_unit_id(name)
+    new_state: State = State(
+        version=state.version,
+        units={
+            unit_id: content
+            for unit_id, content in state.units.items()
+            if unit_id != removed_id
+        },
+    )
+    save_state(new_state, state_root)
+    return new_state

--- a/installer/actions.py
+++ b/installer/actions.py
@@ -3,8 +3,8 @@
 
 from pathlib import Path
 
-from catalog import skill_unit, skill_unit_id
-from constants import SKILLS_DIRNAME, STAGED_DIRNAME
+from catalog import agent_unit, agent_unit_id, skill_unit, skill_unit_id
+from constants import AGENTS_DIRNAME, SKILLS_DIRNAME, STAGED_DIRNAME
 from hashing import hash_unit
 from placement import link_unit, stage_unit, unlink_unit, unstage_unit
 from state import State, save_state
@@ -32,6 +32,39 @@ def install_skill(
     new_state: State = State(
         version=state.version,
         units={**state.units, skill_unit_id(name): content_hash},
+    )
+    save_state(new_state, state_root)
+    return new_state
+
+
+def install_agent(
+    *,
+    name: str,
+    source_root: Path,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Place an agent on disk by staging its single Markdown source then linking
+    the staged file live, so the staged copy stays the single source of truth
+    behind the symlink. The staged copy drops the ".md" suffix (keyed by bare
+    "<kind>/<name>"), while the live symlink keeps it so ~/.claude/agents/ holds
+    a "<name>.md" entry.
+
+    Persists the updated state to state_root (via save_state) and returns a brand-new
+    immutable State; the passed-in state is never mutated."""
+    source: Path = source_root / AGENTS_DIRNAME / f"{name}.md"
+    staged_path: Path = stage_unit(
+        unit=agent_unit(name), source=source, staged_root=state_root / STAGED_DIRNAME
+    )
+    link_unit(
+        staged_path=staged_path,
+        link_path=claude_root / AGENTS_DIRNAME / f"{name}.md",
+    )
+    content_hash: str = hash_unit(staged_path)
+    new_state: State = State(
+        version=state.version,
+        units={**state.units, agent_unit_id(name): content_hash},
     )
     save_state(new_state, state_root)
     return new_state

--- a/installer/actions.py
+++ b/installer/actions.py
@@ -3,11 +3,66 @@
 
 from pathlib import Path
 
-from catalog import agent_unit, agent_unit_id, skill_unit, skill_unit_id
+from catalog import Unit, agent_unit, skill_unit, unit_id
 from constants import AGENTS_DIRNAME, SKILLS_DIRNAME, STAGED_DIRNAME
 from hashing import hash_unit
 from placement import link_unit, stage_unit, unlink_unit, unstage_unit
 from state import State, save_state
+
+
+def _install_unit(
+    *,
+    unit: Unit,
+    source: Path,
+    link_path: Path,
+    state_root: Path,
+    state: State,
+) -> State:
+    """Place one unit on disk by staging its source then linking the staged copy
+    live, so the staged tree stays the single source of truth behind the symlink.
+
+    Persists the updated state to state_root (via save_state) and returns a brand-new
+    immutable State recording the unit's content hash; the passed-in state is never
+    mutated."""
+    staged_path: Path = stage_unit(
+        unit=unit, source=source, staged_root=state_root / STAGED_DIRNAME
+    )
+    link_unit(staged_path=staged_path, link_path=link_path)
+    content_hash: str = hash_unit(staged_path)
+    new_state: State = State(
+        version=state.version,
+        units={**state.units, unit_id(unit): content_hash},
+    )
+    save_state(new_state, state_root)
+    return new_state
+
+
+def _uninstall_unit(
+    *,
+    unit: Unit,
+    link_path: Path,
+    state_root: Path,
+    state: State,
+) -> State:
+    """Take one unit back off disk by dropping its live symlink then its staged
+    copy, so neither a dangling link nor an orphaned staging area survives — the
+    inverse of _install_unit.
+
+    Persists the updated state to state_root (via save_state) and returns a brand-new
+    immutable State without the unit; the passed-in state is never mutated."""
+    unlink_unit(link_path=link_path)
+    unstage_unit(unit=unit, staged_root=state_root / STAGED_DIRNAME)
+    removed_id: str = unit_id(unit)
+    new_state: State = State(
+        version=state.version,
+        units={
+            existing_id: content
+            for existing_id, content in state.units.items()
+            if existing_id != removed_id
+        },
+    )
+    save_state(new_state, state_root)
+    return new_state
 
 
 def install_skill(
@@ -18,23 +73,15 @@ def install_skill(
     claude_root: Path,
     state: State,
 ) -> State:
-    """Place a skill on disk by staging its source then linking the staged tree
-    live, so the staged copy stays the single source of truth behind the symlink.
-
-    Persists the updated state to state_root (via save_state) and returns a brand-new
-    immutable State; the passed-in state is never mutated."""
-    source: Path = source_root / SKILLS_DIRNAME / name
-    staged_path: Path = stage_unit(
-        unit=skill_unit(name), source=source, staged_root=state_root / STAGED_DIRNAME
+    """Install the named skill, staging its source tree and linking it live under
+    ~/.claude/skills/<name>."""
+    return _install_unit(
+        unit=skill_unit(name),
+        source=source_root / SKILLS_DIRNAME / name,
+        link_path=claude_root / SKILLS_DIRNAME / name,
+        state_root=state_root,
+        state=state,
     )
-    link_unit(staged_path=staged_path, link_path=claude_root / SKILLS_DIRNAME / name)
-    content_hash: str = hash_unit(staged_path)
-    new_state: State = State(
-        version=state.version,
-        units={**state.units, skill_unit_id(name): content_hash},
-    )
-    save_state(new_state, state_root)
-    return new_state
 
 
 def install_agent(
@@ -45,29 +92,16 @@ def install_agent(
     claude_root: Path,
     state: State,
 ) -> State:
-    """Place an agent on disk by staging its single Markdown source then linking
-    the staged file live, so the staged copy stays the single source of truth
-    behind the symlink. The staged copy drops the ".md" suffix (keyed by bare
-    "<kind>/<name>"), while the live symlink keeps it so ~/.claude/agents/ holds
-    a "<name>.md" entry.
-
-    Persists the updated state to state_root (via save_state) and returns a brand-new
-    immutable State; the passed-in state is never mutated."""
-    source: Path = source_root / AGENTS_DIRNAME / f"{name}.md"
-    staged_path: Path = stage_unit(
-        unit=agent_unit(name), source=source, staged_root=state_root / STAGED_DIRNAME
-    )
-    link_unit(
-        staged_path=staged_path,
+    """Install the named agent, staging its single "<name>.md" source and linking
+    it live under ~/.claude/agents/. The staged copy is keyed by bare
+    "<kind>/<name>" (no ".md"), while the live symlink keeps the ".md" suffix."""
+    return _install_unit(
+        unit=agent_unit(name),
+        source=source_root / AGENTS_DIRNAME / f"{name}.md",
         link_path=claude_root / AGENTS_DIRNAME / f"{name}.md",
+        state_root=state_root,
+        state=state,
     )
-    content_hash: str = hash_unit(staged_path)
-    new_state: State = State(
-        version=state.version,
-        units={**state.units, agent_unit_id(name): content_hash},
-    )
-    save_state(new_state, state_root)
-    return new_state
 
 
 def uninstall_skill(
@@ -77,25 +111,14 @@ def uninstall_skill(
     claude_root: Path,
     state: State,
 ) -> State:
-    """Take a skill back off disk by dropping its live symlink then its staged
-    tree, so neither a dangling link nor an orphaned staging area survives — the
-    inverse of install_skill.
-
-    Persists the updated state to state_root (via save_state) and returns a brand-new
-    immutable State without the skill's unit; the passed-in state is never mutated."""
-    unlink_unit(link_path=claude_root / SKILLS_DIRNAME / name)
-    unstage_unit(unit=skill_unit(name), staged_root=state_root / STAGED_DIRNAME)
-    removed_id: str = skill_unit_id(name)
-    new_state: State = State(
-        version=state.version,
-        units={
-            unit_id: content
-            for unit_id, content in state.units.items()
-            if unit_id != removed_id
-        },
+    """Uninstall the named skill, the inverse of install_skill: drop its live
+    symlink then its staged tree."""
+    return _uninstall_unit(
+        unit=skill_unit(name),
+        link_path=claude_root / SKILLS_DIRNAME / name,
+        state_root=state_root,
+        state=state,
     )
-    save_state(new_state, state_root)
-    return new_state
 
 
 def uninstall_agent(
@@ -105,22 +128,11 @@ def uninstall_agent(
     claude_root: Path,
     state: State,
 ) -> State:
-    """Take an agent back off disk by dropping its live symlink then its staged
-    file, so neither a dangling link nor an orphaned staging area survives — the
-    inverse of install_agent.
-
-    Persists the updated state to state_root (via save_state) and returns a brand-new
-    immutable State without the agent's unit; the passed-in state is never mutated."""
-    unlink_unit(link_path=claude_root / AGENTS_DIRNAME / f"{name}.md")
-    unstage_unit(unit=agent_unit(name), staged_root=state_root / STAGED_DIRNAME)
-    removed_id: str = agent_unit_id(name)
-    new_state: State = State(
-        version=state.version,
-        units={
-            unit_id: content
-            for unit_id, content in state.units.items()
-            if unit_id != removed_id
-        },
+    """Uninstall the named agent, the inverse of install_agent: drop its live
+    symlink then its staged file."""
+    return _uninstall_unit(
+        unit=agent_unit(name),
+        link_path=claude_root / AGENTS_DIRNAME / f"{name}.md",
+        state_root=state_root,
+        state=state,
     )
-    save_state(new_state, state_root)
-    return new_state

--- a/installer/at.py
+++ b/installer/at.py
@@ -90,36 +90,38 @@ def _catalog_path() -> Path:
     return _env_path("AT_CATALOG", CATALOG_PATH)
 
 
-def _skill_marker(name: str, installed: frozenset[str]) -> str:
-    if skill_unit_id(name) in installed:
-        return MARKER_INSTALLED
-    return MARKER_NOT_INSTALLED
+def _unit_rows(
+    *,
+    names: Callable[[Catalog], list[str]],
+    unit_id_of: Callable[[str], str],
+    catalog: Catalog,
+    state: State,
+) -> list[str]:
+    """Pair each catalog unit with its on-disk install marker, the one row-rendering
+    the Skills and Agents tabs share, keying install state by the unit id catalog.py
+    owns."""
+    installed: frozenset[str] = frozenset(state.units)
+    return [
+        (MARKER_INSTALLED if unit_id_of(name) in installed else MARKER_NOT_INSTALLED)
+        + f" {name}"
+        for name in names(catalog)
+    ]
 
 
 def skill_rows(*, catalog: Catalog, state: State) -> list[str]:
     """Pair each catalog skill with its on-disk install marker so the Skills tab
     renders status, keying install state by the unit id catalog.py owns."""
-    installed: frozenset[str] = frozenset(state.units)
-    return [f"{_skill_marker(name, installed)} {name}" for name in list_skills(catalog)]
-
-
-def _agent_marker(name: str, installed: frozenset[str]) -> str:
-    if agent_unit_id(name) in installed:
-        return MARKER_INSTALLED
-    return MARKER_NOT_INSTALLED
+    return _unit_rows(
+        names=list_skills, unit_id_of=skill_unit_id, catalog=catalog, state=state
+    )
 
 
 def agent_rows(*, catalog: Catalog, state: State) -> list[str]:
     """Pair each catalog agent with its on-disk install marker so the Agents tab
     renders status, keying install state by the unit id catalog.py owns."""
-    installed: frozenset[str] = frozenset(state.units)
-    return [f"{_agent_marker(name, installed)} {name}" for name in list_agents(catalog)]
-
-
-class _RowsFn(Protocol):
-    """One unit kind's status renderer: catalog rows with install markers."""
-
-    def __call__(self, *, catalog: Catalog, state: State) -> list[str]: ...
+    return _unit_rows(
+        names=list_agents, unit_id_of=agent_unit_id, catalog=catalog, state=state
+    )
 
 
 class _PlanFn(Protocol):
@@ -149,7 +151,6 @@ class _UnitTab:
     """The per-kind pieces the Skills and Agents tabs vary over, so one generic
     runner drives both from data instead of two parallel branches."""
 
-    rows: _RowsFn
     names: Callable[[Catalog], list[str]]
     unit_id_of: Callable[[str], str]
     plan: _PlanFn
@@ -159,7 +160,6 @@ class _UnitTab:
 
 
 _SKILLS_TAB: Final[_UnitTab] = _UnitTab(
-    rows=skill_rows,
     names=list_skills,
     unit_id_of=skill_unit_id,
     plan=plan_skill_reconcile,
@@ -169,7 +169,6 @@ _SKILLS_TAB: Final[_UnitTab] = _UnitTab(
 )
 
 _AGENTS_TAB: Final[_UnitTab] = _UnitTab(
-    rows=agent_rows,
     names=list_agents,
     unit_id_of=agent_unit_id,
     plan=plan_agent_reconcile,
@@ -213,7 +212,9 @@ def _run_unit_tab(*, tab: _UnitTab, console: Console) -> None:
     and Agents tabs share, differing only by the functions and prompts in `tab`."""
     catalog: Catalog = load_catalog(CATALOG_PATH)
     state: State = load_state(STATE_ROOT)
-    for row in tab.rows(catalog=catalog, state=state):
+    for row in _unit_rows(
+        names=tab.names, unit_id_of=tab.unit_id_of, catalog=catalog, state=state
+    ):
         console.print(row, markup=False)
     installed: frozenset[str] = frozenset(state.units)
     choices: list[questionary.Choice] = [
@@ -240,7 +241,9 @@ def _run_unit_tab(*, tab: _UnitTab, console: Console) -> None:
         claude_root=CLAUDE_ROOT,
         state=state,
     )
-    for row in tab.rows(catalog=catalog, state=state):
+    for row in _unit_rows(
+        names=tab.names, unit_id_of=tab.unit_id_of, catalog=catalog, state=state
+    ):
         console.print(row, markup=False)
 
 

--- a/installer/at.py
+++ b/installer/at.py
@@ -6,8 +6,10 @@
 import os
 import subprocess
 import sys
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Final
+from typing import Final, Protocol
 
 import click
 import questionary
@@ -114,6 +116,74 @@ def agent_rows(*, catalog: Catalog, state: State) -> list[str]:
     return [f"{_agent_marker(name, installed)} {name}" for name in list_agents(catalog)]
 
 
+class _RowsFn(Protocol):
+    """One unit kind's status renderer: catalog rows with install markers."""
+
+    def __call__(self, *, catalog: Catalog, state: State) -> list[str]: ...
+
+
+class _PlanFn(Protocol):
+    """One unit kind's planner: diff a ticked selection into a reconcile plan."""
+
+    def __call__(
+        self, *, ticked: frozenset[str], catalog: Catalog, state: State
+    ) -> ReconcilePlan: ...
+
+
+class _ApplyFn(Protocol):
+    """One unit kind's applier: carry out a reconcile plan and return new state."""
+
+    def __call__(
+        self,
+        *,
+        plan: ReconcilePlan,
+        source_root: Path,
+        state_root: Path,
+        claude_root: Path,
+        state: State,
+    ) -> State: ...
+
+
+@dataclass(frozen=True)
+class _UnitTab:
+    """The per-kind pieces the Skills and Agents tabs vary over, so one generic
+    runner drives both from data instead of two parallel branches."""
+
+    rows: _RowsFn
+    names: Callable[[Catalog], list[str]]
+    unit_id_of: Callable[[str], str]
+    plan: _PlanFn
+    apply: _ApplyFn
+    select_prompt: str
+    confirm_prompt: str
+
+
+_SKILLS_TAB: Final[_UnitTab] = _UnitTab(
+    rows=skill_rows,
+    names=list_skills,
+    unit_id_of=skill_unit_id,
+    plan=plan_skill_reconcile,
+    apply=apply_skill_reconcile,
+    select_prompt="Select installed skills",
+    confirm_prompt="Apply skill changes?",
+)
+
+_AGENTS_TAB: Final[_UnitTab] = _UnitTab(
+    rows=agent_rows,
+    names=list_agents,
+    unit_id_of=agent_unit_id,
+    plan=plan_agent_reconcile,
+    apply=apply_agent_reconcile,
+    select_prompt="Select installed agents",
+    confirm_prompt="Apply agent changes?",
+)
+
+_UNIT_TABS: Final[dict[str, _UnitTab]] = {
+    "Skills": _SKILLS_TAB,
+    "Agents": _AGENTS_TAB,
+}
+
+
 def abort_on_esc(question: questionary.Question) -> questionary.Question:
     """Let Esc abort a prompt exactly like Ctrl-C, so a user can back out with the
     key they reach for first; returns the question for chaining."""
@@ -137,6 +207,43 @@ def abort_on_esc(question: questionary.Question) -> questionary.Question:
     return question
 
 
+def _run_unit_tab(*, tab: _UnitTab, console: Console) -> None:
+    """Drive one installed-units tab end to end — render status, take the ticked
+    selection, plan the diff, confirm, apply, then re-render — the body the Skills
+    and Agents tabs share, differing only by the functions and prompts in `tab`."""
+    catalog: Catalog = load_catalog(CATALOG_PATH)
+    state: State = load_state(STATE_ROOT)
+    for row in tab.rows(catalog=catalog, state=state):
+        console.print(row, markup=False)
+    installed: frozenset[str] = frozenset(state.units)
+    choices: list[questionary.Choice] = [
+        questionary.Choice(name, checked=tab.unit_id_of(name) in installed)
+        for name in tab.names(catalog)
+    ]
+    ticked: list[str] | None = abort_on_esc(
+        questionary.checkbox(tab.select_prompt, choices=choices)
+    ).ask()
+    if ticked is None:
+        return
+    plan: ReconcilePlan = tab.plan(
+        ticked=frozenset(ticked), catalog=catalog, state=state
+    )
+    if plan.is_empty:
+        return
+    confirmed: bool | None = abort_on_esc(questionary.confirm(tab.confirm_prompt)).ask()
+    if not confirmed:
+        return
+    state = tab.apply(
+        plan=plan,
+        source_root=REPO_ROOT,
+        state_root=STATE_ROOT,
+        claude_root=CLAUDE_ROOT,
+        state=state,
+    )
+    for row in tab.rows(catalog=catalog, state=state):
+        console.print(row, markup=False)
+
+
 def launch_tui() -> int:
     """Bail out on non-interactive stdin: questionary's prompt would otherwise
     block forever waiting on input no CI session can supply."""
@@ -152,75 +259,9 @@ def launch_tui() -> int:
             ).ask()
             if choice is None or choice == "Exit":
                 return 0
-            if choice == "Skills":
-                catalog: Catalog = load_catalog(CATALOG_PATH)
-                state: State = load_state(STATE_ROOT)
-                for row in skill_rows(catalog=catalog, state=state):
-                    console.print(row, markup=False)
-                installed: frozenset[str] = frozenset(state.units)
-                choices: list[questionary.Choice] = [
-                    questionary.Choice(name, checked=skill_unit_id(name) in installed)
-                    for name in list_skills(catalog)
-                ]
-                ticked: list[str] | None = abort_on_esc(
-                    questionary.checkbox("Select installed skills", choices=choices)
-                ).ask()
-                if ticked is None:
-                    continue
-                plan: ReconcilePlan = plan_skill_reconcile(
-                    ticked=frozenset(ticked), catalog=catalog, state=state
-                )
-                if plan.is_empty:
-                    continue
-                confirmed: bool | None = abort_on_esc(
-                    questionary.confirm("Apply skill changes?")
-                ).ask()
-                if not confirmed:
-                    continue
-                state = apply_skill_reconcile(
-                    plan=plan,
-                    source_root=REPO_ROOT,
-                    state_root=STATE_ROOT,
-                    claude_root=CLAUDE_ROOT,
-                    state=state,
-                )
-                for row in skill_rows(catalog=catalog, state=state):
-                    console.print(row, markup=False)
-                continue
-            if choice == "Agents":
-                catalog = load_catalog(CATALOG_PATH)
-                state = load_state(STATE_ROOT)
-                for row in agent_rows(catalog=catalog, state=state):
-                    console.print(row, markup=False)
-                installed = frozenset(state.units)
-                choices = [
-                    questionary.Choice(name, checked=agent_unit_id(name) in installed)
-                    for name in list_agents(catalog)
-                ]
-                ticked = abort_on_esc(
-                    questionary.checkbox("Select installed agents", choices=choices)
-                ).ask()
-                if ticked is None:
-                    continue
-                plan = plan_agent_reconcile(
-                    ticked=frozenset(ticked), catalog=catalog, state=state
-                )
-                if plan.is_empty:
-                    continue
-                confirmed = abort_on_esc(
-                    questionary.confirm("Apply agent changes?")
-                ).ask()
-                if not confirmed:
-                    continue
-                state = apply_agent_reconcile(
-                    plan=plan,
-                    source_root=REPO_ROOT,
-                    state_root=STATE_ROOT,
-                    claude_root=CLAUDE_ROOT,
-                    state=state,
-                )
-                for row in agent_rows(catalog=catalog, state=state):
-                    console.print(row, markup=False)
+            tab: _UnitTab | None = _UNIT_TABS.get(choice)
+            if tab is not None:
+                _run_unit_tab(tab=tab, console=console)
                 continue
             console.print(TAB_PLACEHOLDER)
     except KeyboardInterrupt:

--- a/installer/at.py
+++ b/installer/at.py
@@ -6,66 +6,19 @@
 import os
 import subprocess
 import sys
-from collections.abc import Callable
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Final, Protocol
+from typing import Final
 
 import click
-import questionary
-from prompt_toolkit.key_binding import (
-    KeyBindings,
-    KeyBindingsBase,
-    KeyPressEvent,
-    merge_key_bindings,
-)
-from prompt_toolkit.keys import Keys
-from rich.console import Console
-from rich.panel import Panel
 
-from catalog import (
-    Catalog,
-    agent_unit_id,
-    list_agents,
-    list_skills,
-    load_catalog,
-    skill_unit_id,
-)
-from reconcile import (
-    ReconcilePlan,
-    apply_agent_reconcile,
-    apply_skill_reconcile,
-    plan_agent_reconcile,
-    plan_skill_reconcile,
-)
+from catalog import Catalog, list_skills, load_catalog, skill_unit_id
+from paths import CATALOG_PATH, CLAUDE_ROOT, REPO_ROOT, STATE_ROOT
+from reconcile import ReconcilePlan, apply_skill_reconcile, plan_skill_reconcile
 from state import State, load_state
+from tui import launch_tui
 from update import update_installed_skills
 
 AT_VERSION: Final[str] = "0.2.0"
-
-CATALOG_PATH: Final[Path] = Path(__file__).parent / "catalog.toml"
-STATE_ROOT: Final[Path] = Path.home() / ".claude" / "at"
-# at.py lives in installer/; the repo root one level up holds skills/<name>/ sources.
-REPO_ROOT: Final[Path] = Path(__file__).parent.parent
-# Live link root where installs go; kept separate from STATE_ROOT so tests can pin each.
-CLAUDE_ROOT: Final[Path] = Path.home() / ".claude"
-
-MARKER_INSTALLED: Final[str] = "✅"
-MARKER_NOT_INSTALLED: Final[str] = "❌"
-
-HEADER_TEXT: Final[str] = "Agent Templates Installer"
-NON_TTY_NOTICE: Final[str] = (
-    "The interactive menu needs a terminal; run 'at install' in one to use it."
-)
-TAB_PLACEHOLDER: Final[str] = "(empty — populated in a later PR)"
-MENU_CHOICES: Final[tuple[str, ...]] = (
-    "Bundles",
-    "Skills",
-    "Agents",
-    "Rules",
-    "Hooks",
-    "Exit",
-)
 
 
 def _env_path(var: str, default: Path) -> Path:
@@ -88,187 +41,6 @@ def _catalog_path() -> Path:
     at a fixture catalog, else the repo's. Reading CATALOG_PATH here at call time
     keeps the seam monkeypatchable by tests."""
     return _env_path("AT_CATALOG", CATALOG_PATH)
-
-
-def _unit_rows(
-    *,
-    names: Callable[[Catalog], list[str]],
-    unit_id_of: Callable[[str], str],
-    catalog: Catalog,
-    state: State,
-) -> list[str]:
-    """Pair each catalog unit with its on-disk install marker, the one row-rendering
-    the Skills and Agents tabs share, keying install state by the unit id catalog.py
-    owns."""
-    installed: frozenset[str] = frozenset(state.units)
-    return [
-        (MARKER_INSTALLED if unit_id_of(name) in installed else MARKER_NOT_INSTALLED)
-        + f" {name}"
-        for name in names(catalog)
-    ]
-
-
-def skill_rows(*, catalog: Catalog, state: State) -> list[str]:
-    """Pair each catalog skill with its on-disk install marker so the Skills tab
-    renders status, keying install state by the unit id catalog.py owns."""
-    return _unit_rows(
-        names=list_skills, unit_id_of=skill_unit_id, catalog=catalog, state=state
-    )
-
-
-def agent_rows(*, catalog: Catalog, state: State) -> list[str]:
-    """Pair each catalog agent with its on-disk install marker so the Agents tab
-    renders status, keying install state by the unit id catalog.py owns."""
-    return _unit_rows(
-        names=list_agents, unit_id_of=agent_unit_id, catalog=catalog, state=state
-    )
-
-
-class _PlanFn(Protocol):
-    """One unit kind's planner: diff a ticked selection into a reconcile plan."""
-
-    def __call__(
-        self, *, ticked: frozenset[str], catalog: Catalog, state: State
-    ) -> ReconcilePlan: ...
-
-
-class _ApplyFn(Protocol):
-    """One unit kind's applier: carry out a reconcile plan and return new state."""
-
-    def __call__(
-        self,
-        *,
-        plan: ReconcilePlan,
-        source_root: Path,
-        state_root: Path,
-        claude_root: Path,
-        state: State,
-    ) -> State: ...
-
-
-@dataclass(frozen=True)
-class _UnitTab:
-    """The per-kind pieces the Skills and Agents tabs vary over, so one generic
-    runner drives both from data instead of two parallel branches."""
-
-    names: Callable[[Catalog], list[str]]
-    unit_id_of: Callable[[str], str]
-    plan: _PlanFn
-    apply: _ApplyFn
-    select_prompt: str
-    confirm_prompt: str
-
-
-_SKILLS_TAB: Final[_UnitTab] = _UnitTab(
-    names=list_skills,
-    unit_id_of=skill_unit_id,
-    plan=plan_skill_reconcile,
-    apply=apply_skill_reconcile,
-    select_prompt="Select installed skills",
-    confirm_prompt="Apply skill changes?",
-)
-
-_AGENTS_TAB: Final[_UnitTab] = _UnitTab(
-    names=list_agents,
-    unit_id_of=agent_unit_id,
-    plan=plan_agent_reconcile,
-    apply=apply_agent_reconcile,
-    select_prompt="Select installed agents",
-    confirm_prompt="Apply agent changes?",
-)
-
-_UNIT_TABS: Final[dict[str, _UnitTab]] = {
-    "Skills": _SKILLS_TAB,
-    "Agents": _AGENTS_TAB,
-}
-
-
-def abort_on_esc(question: questionary.Question) -> questionary.Question:
-    """Let Esc abort a prompt exactly like Ctrl-C, so a user can back out with the
-    key they reach for first; returns the question for chaining."""
-    # Both real questionary Questions and the test doubles that stub only .ask() cross
-    # this seam; a double carries no prompt_toolkit Application, so there is no binding
-    # to register — hand it straight back rather than blow up on the missing attribute.
-    if getattr(question, "application", None) is None:
-        return question
-    # A confirm's existing bindings are a _MergedKeyBindings with no .add, unlike a
-    # checkbox/select's concrete KeyBindings — so register Escape on a fresh KeyBindings
-    # and merge it ahead of whatever the prompt already had, leaving those intact.
-    escape: KeyBindings = KeyBindings()
-
-    @escape.add(Keys.Escape, eager=True)
-    def _(event: KeyPressEvent) -> None:
-        event.app.exit(exception=KeyboardInterrupt, style="class:aborting")
-
-    existing: KeyBindingsBase | None = question.application.key_bindings
-    merged: list[KeyBindingsBase] = [escape] if existing is None else [existing, escape]
-    question.application.key_bindings = merge_key_bindings(merged)
-    return question
-
-
-def _run_unit_tab(*, tab: _UnitTab, console: Console) -> None:
-    """Drive one installed-units tab end to end — render status, take the ticked
-    selection, plan the diff, confirm, apply, then re-render — the body the Skills
-    and Agents tabs share, differing only by the functions and prompts in `tab`."""
-    catalog: Catalog = load_catalog(CATALOG_PATH)
-    state: State = load_state(STATE_ROOT)
-    for row in _unit_rows(
-        names=tab.names, unit_id_of=tab.unit_id_of, catalog=catalog, state=state
-    ):
-        console.print(row, markup=False)
-    installed: frozenset[str] = frozenset(state.units)
-    choices: list[questionary.Choice] = [
-        questionary.Choice(name, checked=tab.unit_id_of(name) in installed)
-        for name in tab.names(catalog)
-    ]
-    ticked: list[str] | None = abort_on_esc(
-        questionary.checkbox(tab.select_prompt, choices=choices)
-    ).ask()
-    if ticked is None:
-        return
-    plan: ReconcilePlan = tab.plan(
-        ticked=frozenset(ticked), catalog=catalog, state=state
-    )
-    if plan.is_empty:
-        return
-    confirmed: bool | None = abort_on_esc(questionary.confirm(tab.confirm_prompt)).ask()
-    if not confirmed:
-        return
-    state = tab.apply(
-        plan=plan,
-        source_root=REPO_ROOT,
-        state_root=STATE_ROOT,
-        claude_root=CLAUDE_ROOT,
-        state=state,
-    )
-    for row in _unit_rows(
-        names=tab.names, unit_id_of=tab.unit_id_of, catalog=catalog, state=state
-    ):
-        console.print(row, markup=False)
-
-
-def launch_tui() -> int:
-    """Bail out on non-interactive stdin: questionary's prompt would otherwise
-    block forever waiting on input no CI session can supply."""
-    console: Console = Console()
-    console.print(Panel(HEADER_TEXT, expand=False))
-    if not sys.stdin.isatty():
-        console.print(NON_TTY_NOTICE)
-        return 0
-    try:
-        while True:
-            choice: str | None = abort_on_esc(
-                questionary.select("Select a tab", choices=list(MENU_CHOICES))
-            ).ask()
-            if choice is None or choice == "Exit":
-                return 0
-            tab: _UnitTab | None = _UNIT_TABS.get(choice)
-            if tab is not None:
-                _run_unit_tab(tab=tab, console=console)
-                continue
-            console.print(TAB_PLACEHOLDER)
-    except KeyboardInterrupt:
-        return 0
 
 
 def _run_update() -> int:

--- a/installer/at.py
+++ b/installer/at.py
@@ -29,7 +29,13 @@ from catalog import (
     load_catalog,
     skill_unit_id,
 )
-from reconcile import ReconcilePlan, apply_skill_reconcile, plan_skill_reconcile
+from reconcile import (
+    ReconcilePlan,
+    apply_agent_reconcile,
+    apply_skill_reconcile,
+    plan_agent_reconcile,
+    plan_skill_reconcile,
+)
 from state import State, load_state
 from update import update_installed_skills
 
@@ -179,6 +185,41 @@ def launch_tui() -> int:
                     state=state,
                 )
                 for row in skill_rows(catalog=catalog, state=state):
+                    console.print(row, markup=False)
+                continue
+            if choice == "Agents":
+                catalog = load_catalog(CATALOG_PATH)
+                state = load_state(STATE_ROOT)
+                for row in agent_rows(catalog=catalog, state=state):
+                    console.print(row, markup=False)
+                installed = frozenset(state.units)
+                choices = [
+                    questionary.Choice(name, checked=agent_unit_id(name) in installed)
+                    for name in list_agents(catalog)
+                ]
+                ticked = abort_on_esc(
+                    questionary.checkbox("Select installed agents", choices=choices)
+                ).ask()
+                if ticked is None:
+                    continue
+                plan = plan_agent_reconcile(
+                    ticked=frozenset(ticked), catalog=catalog, state=state
+                )
+                if plan.is_empty:
+                    continue
+                confirmed = abort_on_esc(
+                    questionary.confirm("Apply agent changes?")
+                ).ask()
+                if not confirmed:
+                    continue
+                state = apply_agent_reconcile(
+                    plan=plan,
+                    source_root=REPO_ROOT,
+                    state_root=STATE_ROOT,
+                    claude_root=CLAUDE_ROOT,
+                    state=state,
+                )
+                for row in agent_rows(catalog=catalog, state=state):
                     console.print(row, markup=False)
                 continue
             console.print(TAB_PLACEHOLDER)

--- a/installer/at.py
+++ b/installer/at.py
@@ -21,7 +21,14 @@ from prompt_toolkit.keys import Keys
 from rich.console import Console
 from rich.panel import Panel
 
-from catalog import Catalog, list_skills, load_catalog, skill_unit_id
+from catalog import (
+    Catalog,
+    agent_unit_id,
+    list_agents,
+    list_skills,
+    load_catalog,
+    skill_unit_id,
+)
 from reconcile import ReconcilePlan, apply_skill_reconcile, plan_skill_reconcile
 from state import State, load_state
 from update import update_installed_skills
@@ -86,6 +93,19 @@ def skill_rows(*, catalog: Catalog, state: State) -> list[str]:
     renders status, keying install state by the unit id catalog.py owns."""
     installed: frozenset[str] = frozenset(state.units)
     return [f"{_skill_marker(name, installed)} {name}" for name in list_skills(catalog)]
+
+
+def _agent_marker(name: str, installed: frozenset[str]) -> str:
+    if agent_unit_id(name) in installed:
+        return MARKER_INSTALLED
+    return MARKER_NOT_INSTALLED
+
+
+def agent_rows(*, catalog: Catalog, state: State) -> list[str]:
+    """Pair each catalog agent with its on-disk install marker so the Agents tab
+    renders status, keying install state by the unit id catalog.py owns."""
+    installed: frozenset[str] = frozenset(state.units)
+    return [f"{_agent_marker(name, installed)} {name}" for name in list_agents(catalog)]
 
 
 def abort_on_esc(question: questionary.Question) -> questionary.Question:

--- a/installer/catalog.py
+++ b/installer/catalog.py
@@ -50,7 +50,9 @@ _SKILL_KIND: Final[str] = "skill"
 _AGENT_KIND: Final[str] = "agent"
 
 
-def _unit_id(unit: Unit) -> str:
+def unit_id(unit: Unit) -> str:
+    """Own the "<kind>/<name>" join key in one place, so callers key state and
+    resolve packages without re-encoding the id format this module defines."""
     return f"{unit.kind}{_REF_SEP}{unit.name}"
 
 
@@ -63,7 +65,7 @@ def skill_unit(name: str) -> Unit:
 def skill_unit_id(name: str) -> str:
     """Expose the id a skill unit is keyed by, so callers render install status
     without re-encoding the "<kind>/<name>" join this module owns."""
-    return _unit_id(skill_unit(name))
+    return unit_id(skill_unit(name))
 
 
 def agent_unit(name: str) -> Unit:
@@ -75,7 +77,7 @@ def agent_unit(name: str) -> Unit:
 def agent_unit_id(name: str) -> str:
     """Expose the id an agent unit is keyed by, so callers render install status
     without re-encoding the "<kind>/<name>" join this module owns."""
-    return _unit_id(agent_unit(name))
+    return unit_id(agent_unit(name))
 
 
 def list_skills(catalog: Catalog) -> list[str]:
@@ -117,7 +119,7 @@ def load_catalog(path: Path) -> Catalog:
         Unit(kind=cast("str", row["kind"]), name=cast("str", row["name"]))
         for row in cast("list[dict[str, object]]", raw["units"])
     )
-    by_id: dict[str, Unit] = {_unit_id(unit): unit for unit in units}
+    by_id: dict[str, Unit] = {unit_id(unit): unit for unit in units}
 
     packages: tuple[Package, ...] = tuple(
         _build_package(row, by_id)

--- a/installer/catalog.py
+++ b/installer/catalog.py
@@ -66,6 +66,18 @@ def skill_unit_id(name: str) -> str:
     return _unit_id(skill_unit(name))
 
 
+def agent_unit(name: str) -> Unit:
+    """Own the agent-kind decision here, so callers stage agents without
+    re-encoding the "agent" kind token this module is the source of truth for."""
+    return Unit(kind=_AGENT_KIND, name=name)
+
+
+def agent_unit_id(name: str) -> str:
+    """Expose the id an agent unit is keyed by, so callers render install status
+    without re-encoding the "<kind>/<name>" join this module owns."""
+    return _unit_id(agent_unit(name))
+
+
 def list_skills(catalog: Catalog) -> list[str]:
     """Surface the installable skills by name in a stable order, so a UI listing
     doesn't depend on declaration order in the toml."""

--- a/installer/catalog.py
+++ b/installer/catalog.py
@@ -47,6 +47,7 @@ class Catalog:
 
 
 _SKILL_KIND: Final[str] = "skill"
+_AGENT_KIND: Final[str] = "agent"
 
 
 def _unit_id(unit: Unit) -> str:
@@ -69,6 +70,12 @@ def list_skills(catalog: Catalog) -> list[str]:
     """Surface the installable skills by name in a stable order, so a UI listing
     doesn't depend on declaration order in the toml."""
     return sorted(unit.name for unit in catalog.units if unit.kind == _SKILL_KIND)
+
+
+def list_agents(catalog: Catalog) -> list[str]:
+    """Surface the installable agents by name in a stable order, so a UI listing
+    doesn't depend on declaration order in the toml."""
+    return sorted(unit.name for unit in catalog.units if unit.kind == _AGENT_KIND)
 
 
 def _resolve(ref: str, by_id: dict[str, Unit], package: str) -> Unit:

--- a/installer/constants.py
+++ b/installer/constants.py
@@ -5,3 +5,4 @@ from typing import Final
 # sources live in the repo (~/.claude's per-kind dirs and the repo's skills/ tree).
 STAGED_DIRNAME: Final[str] = "staged"
 SKILLS_DIRNAME: Final[str] = "skills"
+AGENTS_DIRNAME: Final[str] = "agents"

--- a/installer/paths.py
+++ b/installer/paths.py
@@ -1,0 +1,13 @@
+"""The install-root paths both the CLI (at.py) and the TUI (tui.py) read, kept in
+one module so the two entry points resolve them identically and tests pin each in
+a single place."""
+
+from pathlib import Path
+from typing import Final
+
+CATALOG_PATH: Final[Path] = Path(__file__).parent / "catalog.toml"
+STATE_ROOT: Final[Path] = Path.home() / ".claude" / "at"
+# Live link root where installs go; kept separate from STATE_ROOT so tests can pin each.
+CLAUDE_ROOT: Final[Path] = Path.home() / ".claude"
+# paths.py lives in installer/; the repo root one level up holds skills/<name>/ sources.
+REPO_ROOT: Final[Path] = Path(__file__).parent.parent

--- a/installer/reconcile.py
+++ b/installer/reconcile.py
@@ -2,7 +2,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from actions import install_skill, uninstall_skill
-from catalog import Catalog, list_skills, skill_unit_id
+from catalog import (
+    Catalog,
+    agent_unit_id,
+    list_agents,
+    list_skills,
+    skill_unit_id,
+)
 from state import State
 
 
@@ -34,6 +40,24 @@ def plan_skill_reconcile(
     )
     to_remove: tuple[str, ...] = tuple(
         name for name in skills if name in installed and name not in ticked
+    )
+    return ReconcilePlan(to_install=to_install, to_remove=to_remove)
+
+
+def plan_agent_reconcile(
+    *, ticked: frozenset[str], catalog: Catalog, state: State
+) -> ReconcilePlan:
+    """Diff the ticked selection against installed state over the catalog's agents,
+    so the apply step works from a decided plan instead of re-deriving the diff."""
+    agents: list[str] = list_agents(catalog)
+    installed: set[str] = {
+        name for name in agents if agent_unit_id(name) in state.units
+    }
+    to_install: tuple[str, ...] = tuple(
+        name for name in agents if name in ticked and name not in installed
+    )
+    to_remove: tuple[str, ...] = tuple(
+        name for name in agents if name in installed and name not in ticked
     )
     return ReconcilePlan(to_install=to_install, to_remove=to_remove)
 

--- a/installer/reconcile.py
+++ b/installer/reconcile.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from pathlib import Path
 
-from actions import install_skill, uninstall_skill
+from actions import install_agent, install_skill, uninstall_agent, uninstall_skill
 from catalog import (
     Catalog,
     agent_unit_id,
@@ -83,6 +83,35 @@ def apply_skill_reconcile(
         )
     for name in plan.to_remove:
         current = uninstall_skill(
+            name=name,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=current,
+        )
+    return current
+
+
+def apply_agent_reconcile(
+    *,
+    plan: ReconcilePlan,
+    source_root: Path,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Carry out a planned diff by installing then uninstalling each named agent,
+    threading the persisted State through so the final return reflects every action."""
+    current: State = state
+    for name in plan.to_install:
+        current = install_agent(
+            name=name,
+            source_root=source_root,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=current,
+        )
+    for name in plan.to_remove:
+        current = uninstall_agent(
             name=name,
             state_root=state_root,
             claude_root=claude_root,

--- a/installer/reconcile.py
+++ b/installer/reconcile.py
@@ -1,5 +1,7 @@
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Protocol
 
 from actions import install_agent, install_skill, uninstall_agent, uninstall_skill
 from catalog import (
@@ -26,22 +28,36 @@ class ReconcilePlan:
         return not self.to_install and not self.to_remove
 
 
+def _plan_reconcile(
+    *,
+    ticked: frozenset[str],
+    names: list[str],
+    unit_id_of: Callable[[str], str],
+    state: State,
+) -> ReconcilePlan:
+    """Diff the ticked selection against installed state over one kind's units, so
+    both public plan wrappers share one diff instead of re-deriving it per kind."""
+    installed: set[str] = {name for name in names if unit_id_of(name) in state.units}
+    to_install: tuple[str, ...] = tuple(
+        name for name in names if name in ticked and name not in installed
+    )
+    to_remove: tuple[str, ...] = tuple(
+        name for name in names if name in installed and name not in ticked
+    )
+    return ReconcilePlan(to_install=to_install, to_remove=to_remove)
+
+
 def plan_skill_reconcile(
     *, ticked: frozenset[str], catalog: Catalog, state: State
 ) -> ReconcilePlan:
     """Diff the ticked selection against installed state over the catalog's skills,
     so the apply step works from a decided plan instead of re-deriving the diff."""
-    skills: list[str] = list_skills(catalog)
-    installed: set[str] = {
-        name for name in skills if skill_unit_id(name) in state.units
-    }
-    to_install: tuple[str, ...] = tuple(
-        name for name in skills if name in ticked and name not in installed
+    return _plan_reconcile(
+        ticked=ticked,
+        names=list_skills(catalog),
+        unit_id_of=skill_unit_id,
+        state=state,
     )
-    to_remove: tuple[str, ...] = tuple(
-        name for name in skills if name in installed and name not in ticked
-    )
-    return ReconcilePlan(to_install=to_install, to_remove=to_remove)
 
 
 def plan_agent_reconcile(
@@ -49,17 +65,70 @@ def plan_agent_reconcile(
 ) -> ReconcilePlan:
     """Diff the ticked selection against installed state over the catalog's agents,
     so the apply step works from a decided plan instead of re-deriving the diff."""
-    agents: list[str] = list_agents(catalog)
-    installed: set[str] = {
-        name for name in agents if agent_unit_id(name) in state.units
-    }
-    to_install: tuple[str, ...] = tuple(
-        name for name in agents if name in ticked and name not in installed
+    return _plan_reconcile(
+        ticked=ticked,
+        names=list_agents(catalog),
+        unit_id_of=agent_unit_id,
+        state=state,
     )
-    to_remove: tuple[str, ...] = tuple(
-        name for name in agents if name in installed and name not in ticked
-    )
-    return ReconcilePlan(to_install=to_install, to_remove=to_remove)
+
+
+class _InstallAction(Protocol):
+    """One kind's install primitive: stage the named unit's source and link it live."""
+
+    def __call__(
+        self,
+        *,
+        name: str,
+        source_root: Path,
+        state_root: Path,
+        claude_root: Path,
+        state: State,
+    ) -> State: ...
+
+
+class _UninstallAction(Protocol):
+    """One kind's uninstall primitive: drop the named unit's link and staged copy."""
+
+    def __call__(
+        self,
+        *,
+        name: str,
+        state_root: Path,
+        claude_root: Path,
+        state: State,
+    ) -> State: ...
+
+
+def _apply_reconcile(
+    *,
+    plan: ReconcilePlan,
+    install: _InstallAction,
+    uninstall: _UninstallAction,
+    source_root: Path,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Carry out a planned diff by installing then uninstalling each named unit,
+    threading the persisted State through so the final return reflects every action."""
+    current: State = state
+    for name in plan.to_install:
+        current = install(
+            name=name,
+            source_root=source_root,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=current,
+        )
+    for name in plan.to_remove:
+        current = uninstall(
+            name=name,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=current,
+        )
+    return current
 
 
 def apply_skill_reconcile(
@@ -72,23 +141,15 @@ def apply_skill_reconcile(
 ) -> State:
     """Carry out a planned diff by installing then uninstalling each named skill,
     threading the persisted State through so the final return reflects every action."""
-    current: State = state
-    for name in plan.to_install:
-        current = install_skill(
-            name=name,
-            source_root=source_root,
-            state_root=state_root,
-            claude_root=claude_root,
-            state=current,
-        )
-    for name in plan.to_remove:
-        current = uninstall_skill(
-            name=name,
-            state_root=state_root,
-            claude_root=claude_root,
-            state=current,
-        )
-    return current
+    return _apply_reconcile(
+        plan=plan,
+        install=install_skill,
+        uninstall=uninstall_skill,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state,
+    )
 
 
 def apply_agent_reconcile(
@@ -101,20 +162,12 @@ def apply_agent_reconcile(
 ) -> State:
     """Carry out a planned diff by installing then uninstalling each named agent,
     threading the persisted State through so the final return reflects every action."""
-    current: State = state
-    for name in plan.to_install:
-        current = install_agent(
-            name=name,
-            source_root=source_root,
-            state_root=state_root,
-            claude_root=claude_root,
-            state=current,
-        )
-    for name in plan.to_remove:
-        current = uninstall_agent(
-            name=name,
-            state_root=state_root,
-            claude_root=claude_root,
-            state=current,
-        )
-    return current
+    return _apply_reconcile(
+        plan=plan,
+        install=install_agent,
+        uninstall=uninstall_agent,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state,
+    )

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from actions import install_skill, uninstall_skill
-from catalog import skill_unit_id
+from actions import install_agent, install_skill, uninstall_skill
+from catalog import agent_unit_id, skill_unit_id
 from hashing import hash_unit
 from state import State, load_state
 
@@ -121,3 +121,36 @@ def test_uninstall_skill_undoes_install_and_forgets_unit(tmp_path: Path) -> None
     assert unit_id not in result.units
     assert unit_id not in load_state(state_root).units
     assert unit_id in installed_state.units
+
+
+def test_install_agent_stages_md_file_and_links_into_claude_agents(
+    tmp_path: Path,
+) -> None:
+    agent_content: str = "# Demo Agent\n\nDemonstrates installation.\n"
+    name: str = "demo-agent"
+    source_root: Path = tmp_path / "repo"
+    agent_source: Path = source_root / "agents" / f"{name}.md"
+    agent_source.parent.mkdir(parents=True)
+    agent_source.write_text(agent_content, encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    result: State = install_agent(
+        name=name,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    staged_path: Path = state_root / "staged" / "agent" / name
+    assert staged_path.is_file()
+    assert staged_path.read_text(encoding="utf-8") == agent_content
+
+    link_path: Path = claude_root / "agents" / f"{name}.md"
+    assert link_path.is_symlink()
+    assert link_path.resolve() == staged_path.resolve()
+    assert link_path.read_text(encoding="utf-8") == agent_content
+
+    assert agent_unit_id(name) in result.units

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from actions import install_agent, install_skill, uninstall_skill
+from actions import install_agent, install_skill, uninstall_agent, uninstall_skill
 from catalog import agent_unit_id, skill_unit_id
 from hashing import hash_unit
 from state import State, load_state
@@ -154,3 +154,36 @@ def test_install_agent_stages_md_file_and_links_into_claude_agents(
     assert link_path.read_text(encoding="utf-8") == agent_content
 
     assert agent_unit_id(name) in result.units
+
+
+def test_uninstall_agent_undoes_install_and_forgets_unit(tmp_path: Path) -> None:
+    agent_content: str = "# Demo Agent\n\nDemonstrates installation.\n"
+    name: str = "demo-agent"
+    source_root: Path = tmp_path / "repo"
+    agent_source: Path = source_root / "agents" / f"{name}.md"
+    agent_source.parent.mkdir(parents=True)
+    agent_source.write_text(agent_content, encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    installed_state: State = install_agent(
+        name=name,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    result: State = uninstall_agent(
+        name=name,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=installed_state,
+    )
+
+    unit_id: str = agent_unit_id(name)
+    assert not (claude_root / "agents" / f"{name}.md").is_symlink()
+    assert not (state_root / "staged" / "agent" / name).exists()
+    assert unit_id not in result.units
+    assert unit_id not in load_state(state_root).units
+    assert unit_id in installed_state.units

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -15,10 +15,18 @@ from at import (
     MARKER_NOT_INSTALLED,
     TAB_PLACEHOLDER,
     abort_on_esc,
+    agent_rows,
     main,
     skill_rows,
 )
-from catalog import Catalog, Unit, list_skills, load_catalog, skill_unit_id
+from catalog import (
+    Catalog,
+    Unit,
+    agent_unit_id,
+    list_skills,
+    load_catalog,
+    skill_unit_id,
+)
 from hashing import hash_unit
 from state import State, load_state
 
@@ -99,6 +107,23 @@ def test_skill_rows_lists_every_skill_sorted_and_excludes_non_skills() -> None:
     rows: list[str] = skill_rows(catalog=catalog, state=state)
 
     assert rows == [f"{MARKER_NOT_INSTALLED} alpha", f"{MARKER_NOT_INSTALLED} zeta"]
+
+
+def test_agent_rows_marks_installed_sorted_and_excludes_non_agents() -> None:
+    catalog: Catalog = Catalog(
+        units=(
+            Unit(kind="agent", name="zeta"),
+            Unit(kind="agent", name="alpha"),
+            Unit(kind="skill", name="some-skill"),
+        ),
+        packages=(),
+        bundles=(),
+    )
+    state: State = State(version=1, units={agent_unit_id("alpha"): "hash"})
+
+    rows: list[str] = agent_rows(catalog=catalog, state=state)
+
+    assert rows == [f"{MARKER_INSTALLED} alpha", f"{MARKER_NOT_INSTALLED} zeta"]
 
 
 def test_skills_tab_renders_skill_rows_instead_of_placeholder(

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -166,6 +166,67 @@ def test_skills_tab_renders_skill_rows_instead_of_placeholder(
     assert TAB_PLACEHOLDER not in captured
 
 
+def test_agents_tab_installs_ticked_agent_through_reconcile(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # A real agent source on disk is the only input the install needs; nothing is
+    # installed up front, so ticking demo-agent through the Agents tab must stage,
+    # link, and record it — mirroring how the Skills tab installs a ticked skill.
+    agent_source: Path = repo_root / "agents" / "demo-agent.md"
+    agent_source.parent.mkdir(parents=True)
+    agent_source.write_text("# demo-agent\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "agent"\nname = "demo-agent"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    # The tab menu opens the Agents tab, then closes it after the reconcile applies.
+    select_answers: Iterator[str] = iter(["Agents", "Exit"])
+
+    class FakeSelect:
+        def ask(self) -> str:
+            return next(select_answers)
+
+    # Tick the lone catalog agent so the desired set installs demo-agent.
+    class FakeCheckbox:
+        def ask(self) -> list[str]:
+            return ["demo-agent"]
+
+    class ConfirmPrompt:
+        def ask(self) -> bool:
+            return True
+
+    monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakeSelect())
+    monkeypatch.setattr("questionary.checkbox", lambda *args, **kwargs: FakeCheckbox())
+    monkeypatch.setattr("questionary.confirm", lambda *args, **kwargs: ConfirmPrompt())
+
+    exit_code: int = main(["install"])
+
+    # Ticking demo-agent applies plan_agent_reconcile then apply_agent_reconcile, so
+    # the agent ends up linked live and recorded in state, and the rows re-render with
+    # the installed marker. Today the Agents branch is a TAB_PLACEHOLDER that installs
+    # nothing, so the symlink/state/marker assertions fail.
+    captured: str = capsys.readouterr().out
+    final_state: State = load_state(state_root)
+    agent_link: Path = claude_root / "agents" / "demo-agent.md"
+    assert exit_code == 0
+    assert agent_link.is_symlink()
+    assert agent_unit_id("demo-agent") in final_state.units
+    assert f"{MARKER_INSTALLED} demo-agent" in captured
+    assert TAB_PLACEHOLDER not in captured
+
+
 def test_skills_tab_unticking_skill_removes_it_while_ticked_stays_installed(
     monkeypatch: MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -10,15 +10,7 @@ from prompt_toolkit.output import DummyOutput
 from pytest import CaptureFixture, MonkeyPatch
 
 from actions import install_skill
-from at import (
-    MARKER_INSTALLED,
-    MARKER_NOT_INSTALLED,
-    TAB_PLACEHOLDER,
-    abort_on_esc,
-    agent_rows,
-    main,
-    skill_rows,
-)
+from at import main
 from catalog import (
     Catalog,
     Unit,
@@ -29,6 +21,14 @@ from catalog import (
 )
 from hashing import hash_unit
 from state import State, load_state
+from tui import (
+    MARKER_INSTALLED,
+    MARKER_NOT_INSTALLED,
+    TAB_PLACEHOLDER,
+    abort_on_esc,
+    agent_rows,
+    skill_rows,
+)
 
 
 def test_version_flag_prints_version_and_exits_zero(
@@ -130,14 +130,14 @@ def test_skills_tab_renders_skill_rows_instead_of_placeholder(
     monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
 ) -> None:
     monkeypatch.setattr("sys.stdin.isatty", lambda: True)
-    monkeypatch.setattr("at.STATE_ROOT", tmp_path)
+    monkeypatch.setattr("tui.STATE_ROOT", tmp_path)
     catalog_file: Path = tmp_path / "catalog.toml"
     catalog_file.write_text(
         "packages = []\nbundles = []\n\n"
         '[[units]]\nkind = "skill"\nname = "demo-skill"\n',
         encoding="utf-8",
     )
-    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    monkeypatch.setattr("tui.CATALOG_PATH", catalog_file)
     # Enter the Skills tab, then close it; the empty tick set is an unchanged
     # selection, so this read-only test installs nothing and falls through.
     answers: Iterator[str] = iter(["Skills", "Exit"])
@@ -173,9 +173,9 @@ def test_agents_tab_installs_ticked_agent_through_reconcile(
     state_root: Path = tmp_path / "at"
     claude_root: Path = tmp_path / "claude"
     repo_root: Path = tmp_path / "repo"
-    monkeypatch.setattr("at.STATE_ROOT", state_root)
-    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
-    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+    monkeypatch.setattr("tui.STATE_ROOT", state_root)
+    monkeypatch.setattr("tui.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("tui.REPO_ROOT", repo_root)
 
     # A real agent source on disk is the only input the install needs; nothing is
     # installed up front, so ticking demo-agent through the Agents tab must stage,
@@ -190,7 +190,7 @@ def test_agents_tab_installs_ticked_agent_through_reconcile(
         '[[units]]\nkind = "agent"\nname = "demo-agent"\n',
         encoding="utf-8",
     )
-    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    monkeypatch.setattr("tui.CATALOG_PATH", catalog_file)
     # The tab menu opens the Agents tab, then closes it after the reconcile applies.
     select_answers: Iterator[str] = iter(["Agents", "Exit"])
 
@@ -233,9 +233,9 @@ def test_skills_tab_unticking_skill_removes_it_while_ticked_stays_installed(
     state_root: Path = tmp_path / "at"
     claude_root: Path = tmp_path / "claude"
     repo_root: Path = tmp_path / "repo"
-    monkeypatch.setattr("at.STATE_ROOT", state_root)
-    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
-    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+    monkeypatch.setattr("tui.STATE_ROOT", state_root)
+    monkeypatch.setattr("tui.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("tui.REPO_ROOT", repo_root)
 
     # Pre-install both skills through the real public install action, so on-disk
     # state, staging, and live symlinks all exist before the reconcile runs.
@@ -259,7 +259,7 @@ def test_skills_tab_unticking_skill_removes_it_while_ticked_stays_installed(
         '[[units]]\nkind = "skill"\nname = "demo-b"\n',
         encoding="utf-8",
     )
-    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    monkeypatch.setattr("tui.CATALOG_PATH", catalog_file)
     # The tab menu opens the Skills tab, then closes it after the reconcile.
     select_answers: Iterator[str] = iter(["Skills", "Exit"])
 
@@ -301,9 +301,9 @@ def test_skills_tab_declining_confirm_leaves_install_state_untouched(
     state_root: Path = tmp_path / "at"
     claude_root: Path = tmp_path / "claude"
     repo_root: Path = tmp_path / "repo"
-    monkeypatch.setattr("at.STATE_ROOT", state_root)
-    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
-    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+    monkeypatch.setattr("tui.STATE_ROOT", state_root)
+    monkeypatch.setattr("tui.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("tui.REPO_ROOT", repo_root)
 
     # Real sources for both skills exist, but only demo-a is installed up front, so
     # the declined reconcile must neither remove demo-a nor add demo-b.
@@ -326,7 +326,7 @@ def test_skills_tab_declining_confirm_leaves_install_state_untouched(
         '[[units]]\nkind = "skill"\nname = "demo-b"\n',
         encoding="utf-8",
     )
-    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    monkeypatch.setattr("tui.CATALOG_PATH", catalog_file)
     # The tab menu opens the Skills tab, then closes it after the declined reconcile.
     select_answers: Iterator[str] = iter(["Skills", "Exit"])
 
@@ -371,9 +371,9 @@ def test_esc_at_apply_confirm_discards_selection_change(
     state_root: Path = tmp_path / "at"
     claude_root: Path = tmp_path / "claude"
     repo_root: Path = tmp_path / "repo"
-    monkeypatch.setattr("at.STATE_ROOT", state_root)
-    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
-    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+    monkeypatch.setattr("tui.STATE_ROOT", state_root)
+    monkeypatch.setattr("tui.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("tui.REPO_ROOT", repo_root)
 
     # Real sources for both skills exist, but only demo-a is installed up front, so an
     # Esc-cancelled confirm must neither remove demo-a nor add demo-b.
@@ -396,7 +396,7 @@ def test_esc_at_apply_confirm_discards_selection_change(
         '[[units]]\nkind = "skill"\nname = "demo-b"\n',
         encoding="utf-8",
     )
-    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    monkeypatch.setattr("tui.CATALOG_PATH", catalog_file)
     # The tab menu opens the Skills tab, then closes it after the cancelled confirm.
     select_answers: Iterator[str] = iter(["Skills", "Exit"])
 
@@ -455,9 +455,9 @@ def test_skills_tab_unchanged_selection_asks_no_confirm_and_changes_nothing(
     state_root: Path = tmp_path / "at"
     claude_root: Path = tmp_path / "claude"
     repo_root: Path = tmp_path / "repo"
-    monkeypatch.setattr("at.STATE_ROOT", state_root)
-    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
-    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+    monkeypatch.setattr("tui.STATE_ROOT", state_root)
+    monkeypatch.setattr("tui.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("tui.REPO_ROOT", repo_root)
 
     # Real sources for both skills exist, but only demo-a is installed up front.
     for name in ("demo-a", "demo-b"):
@@ -479,7 +479,7 @@ def test_skills_tab_unchanged_selection_asks_no_confirm_and_changes_nothing(
         '[[units]]\nkind = "skill"\nname = "demo-b"\n',
         encoding="utf-8",
     )
-    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    monkeypatch.setattr("tui.CATALOG_PATH", catalog_file)
     # The tab menu opens the Skills tab, then closes it after the no-op reconcile.
     select_answers: Iterator[str] = iter(["Skills", "Exit"])
 
@@ -529,9 +529,9 @@ def test_skills_tab_checkbox_pre_ticks_installed_skills_and_cancel_is_noop(
     state_root: Path = tmp_path / "at"
     claude_root: Path = tmp_path / "claude"
     repo_root: Path = tmp_path / "repo"
-    monkeypatch.setattr("at.STATE_ROOT", state_root)
-    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
-    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+    monkeypatch.setattr("tui.STATE_ROOT", state_root)
+    monkeypatch.setattr("tui.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("tui.REPO_ROOT", repo_root)
 
     # Real sources for both skills exist, but only demo-a is installed up front, so
     # the checkbox must offer demo-a pre-ticked and demo-b unticked.
@@ -554,7 +554,7 @@ def test_skills_tab_checkbox_pre_ticks_installed_skills_and_cancel_is_noop(
         '[[units]]\nkind = "skill"\nname = "demo-b"\n',
         encoding="utf-8",
     )
-    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    monkeypatch.setattr("tui.CATALOG_PATH", catalog_file)
     # The tab menu opens the Skills tab, then closes it after the cancelled prompt.
     select_answers: Iterator[str] = iter(["Skills", "Exit"])
 
@@ -604,9 +604,9 @@ def test_skills_tab_esc_in_checkbox_cancels_reconcile_without_confirm(
     state_root: Path = tmp_path / "at"
     claude_root: Path = tmp_path / "claude"
     repo_root: Path = tmp_path / "repo"
-    monkeypatch.setattr("at.STATE_ROOT", state_root)
-    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
-    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+    monkeypatch.setattr("tui.STATE_ROOT", state_root)
+    monkeypatch.setattr("tui.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("tui.REPO_ROOT", repo_root)
 
     # Real sources for both skills exist, but only demo-a is installed up front, so
     # an Esc-cancelled reconcile must leave that install exactly as it stands.
@@ -629,7 +629,7 @@ def test_skills_tab_esc_in_checkbox_cancels_reconcile_without_confirm(
         '[[units]]\nkind = "skill"\nname = "demo-b"\n',
         encoding="utf-8",
     )
-    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+    monkeypatch.setattr("tui.CATALOG_PATH", catalog_file)
     # The tab menu opens the Skills tab, then closes it after the cancelled reconcile.
     select_answers: Iterator[str] = iter(["Skills", "Exit"])
 

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -215,8 +215,7 @@ def test_agents_tab_installs_ticked_agent_through_reconcile(
 
     # Ticking demo-agent applies plan_agent_reconcile then apply_agent_reconcile, so
     # the agent ends up linked live and recorded in state, and the rows re-render with
-    # the installed marker. Today the Agents branch is a TAB_PLACEHOLDER that installs
-    # nothing, so the symlink/state/marker assertions fail.
+    # the installed marker.
     captured: str = capsys.readouterr().out
     final_state: State = load_state(state_root)
     agent_link: Path = claude_root / "agents" / "demo-agent.md"

--- a/installer/tests/test_catalog.py
+++ b/installer/tests/test_catalog.py
@@ -8,6 +8,7 @@ from catalog import (
     Catalog,
     Package,
     Unit,
+    list_agents,
     list_skills,
     load_catalog,
     skill_unit_id,
@@ -33,6 +34,35 @@ name = "helper"
 [[packages]]
 name = "pack"
 units = ["skill/alpha", "agent/helper"]
+
+[[bundles]]
+name = "everything"
+packages = ["pack"]
+"""
+
+
+# Two agent units declared out of order (zeta before alpha) plus a skill and a
+# rule, so a single catalog pins both the sort and the non-agent exclusion.
+_AGENTS_FIXTURE: Final[str] = """
+[[units]]
+kind = "agent"
+name = "zeta"
+
+[[units]]
+kind = "agent"
+name = "alpha"
+
+[[units]]
+kind = "skill"
+name = "beta"
+
+[[units]]
+kind = "rule"
+name = "python"
+
+[[packages]]
+name = "pack"
+units = ["agent/alpha"]
 
 [[bundles]]
 name = "everything"
@@ -70,6 +100,14 @@ def test_list_skills_returns_only_skill_names_sorted(tmp_path: Path) -> None:
 
     # Only skill-kind units, and sorted (declaration order is beta, alpha).
     assert list_skills(catalog) == ["alpha", "beta"]
+
+
+def test_list_agents_returns_only_agent_names_sorted(tmp_path: Path) -> None:
+    catalog: Catalog = load_catalog(_write(tmp_path, _AGENTS_FIXTURE))
+
+    # Only agent-kind units, and sorted (declaration order is zeta, alpha); the
+    # skill and rule units must not leak into the agent listing.
+    assert list_agents(catalog) == ["alpha", "zeta"]
 
 
 def test_skill_unit_id_joins_kind_and_name() -> None:

--- a/installer/tests/test_reconcile.py
+++ b/installer/tests/test_reconcile.py
@@ -2,7 +2,12 @@ from pathlib import Path
 
 from actions import install_skill
 from catalog import Catalog, Unit, skill_unit_id
-from reconcile import ReconcilePlan, apply_skill_reconcile, plan_skill_reconcile
+from reconcile import (
+    ReconcilePlan,
+    apply_skill_reconcile,
+    plan_agent_reconcile,
+    plan_skill_reconcile,
+)
 from state import State, load_state
 
 
@@ -20,6 +25,27 @@ def test_plan_classifies_skills_by_tick_against_installed_state() -> None:
     ticked: frozenset[str] = frozenset({"alpha", "gamma"})
 
     plan: ReconcilePlan = plan_skill_reconcile(
+        ticked=ticked, catalog=catalog, state=state
+    )
+
+    assert plan.to_install == ("alpha",)
+    assert plan.to_remove == ("beta",)
+
+
+def test_plan_classifies_agents_by_tick_against_installed_state() -> None:
+    catalog: Catalog = Catalog(
+        units=(
+            Unit(kind="agent", name="alpha"),
+            Unit(kind="agent", name="beta"),
+            Unit(kind="agent", name="gamma"),
+        ),
+        packages=(),
+        bundles=(),
+    )
+    state: State = State(version=1, units={"agent/beta": "hash", "agent/gamma": "hash"})
+    ticked: frozenset[str] = frozenset({"alpha", "gamma"})
+
+    plan: ReconcilePlan = plan_agent_reconcile(
         ticked=ticked, catalog=catalog, state=state
     )
 

--- a/installer/tests/test_reconcile.py
+++ b/installer/tests/test_reconcile.py
@@ -1,9 +1,10 @@
 from pathlib import Path
 
-from actions import install_skill
-from catalog import Catalog, Unit, skill_unit_id
+from actions import install_agent, install_skill
+from catalog import Catalog, Unit, agent_unit_id, skill_unit_id
 from reconcile import (
     ReconcilePlan,
+    apply_agent_reconcile,
     apply_skill_reconcile,
     plan_agent_reconcile,
     plan_skill_reconcile,
@@ -94,5 +95,50 @@ def test_apply_installs_planned_skills_and_uninstalls_removed_ones(
 
     assert not (claude_root / "skills" / "old-skill").is_symlink()
     assert not (state_root / "staged" / "skill" / "old-skill").exists()
+    assert old_id not in result.units
+    assert old_id not in persisted.units
+
+
+def test_apply_installs_planned_agents_and_uninstalls_removed_ones(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    agents_source: Path = source_root / "agents"
+    agents_source.mkdir(parents=True)
+    for name in ("old-agent", "new-agent"):
+        (agents_source / f"{name}.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    installed_state: State = install_agent(
+        name="old-agent",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    plan: ReconcilePlan = ReconcilePlan(
+        to_install=("new-agent",), to_remove=("old-agent",)
+    )
+    result: State = apply_agent_reconcile(
+        plan=plan,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=installed_state,
+    )
+
+    persisted: State = load_state(state_root)
+    new_id: str = agent_unit_id("new-agent")
+    old_id: str = agent_unit_id("old-agent")
+
+    assert (claude_root / "agents" / "new-agent.md").is_symlink()
+    assert (state_root / "staged" / "agent" / "new-agent").is_file()
+    assert new_id in result.units
+    assert new_id in persisted.units
+
+    assert not (claude_root / "agents" / "old-agent.md").is_symlink()
+    assert not (state_root / "staged" / "agent" / "old-agent").exists()
     assert old_id not in result.units
     assert old_id not in persisted.units

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -1,0 +1,264 @@
+"""The interactive installer menu: the whole TUI concern (tab rendering, the
+checkbox/confirm reconcile loop, and Esc handling) lives here so at.py stays the
+CLI/entry dispatcher."""
+
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, Protocol
+
+import questionary
+from prompt_toolkit.key_binding import (
+    KeyBindings,
+    KeyBindingsBase,
+    KeyPressEvent,
+    merge_key_bindings,
+)
+from prompt_toolkit.keys import Keys
+from rich.console import Console
+from rich.panel import Panel
+
+from catalog import (
+    Catalog,
+    agent_unit_id,
+    list_agents,
+    list_skills,
+    load_catalog,
+    skill_unit_id,
+)
+from paths import CATALOG_PATH, CLAUDE_ROOT, REPO_ROOT, STATE_ROOT
+from reconcile import (
+    ReconcilePlan,
+    apply_agent_reconcile,
+    apply_skill_reconcile,
+    plan_agent_reconcile,
+    plan_skill_reconcile,
+)
+from state import State, load_state
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MARKER_INSTALLED: Final[str] = "✅"
+MARKER_NOT_INSTALLED: Final[str] = "❌"
+
+HEADER_TEXT: Final[str] = "Agent Templates Installer"
+NON_TTY_NOTICE: Final[str] = (
+    "The interactive menu needs a terminal; run 'at install' in one to use it."
+)
+TAB_PLACEHOLDER: Final[str] = "(empty — populated in a later PR)"
+MENU_CHOICES: Final[tuple[str, ...]] = (
+    "Bundles",
+    "Skills",
+    "Agents",
+    "Rules",
+    "Hooks",
+    "Exit",
+)
+
+
+# ---------------------------------------------------------------------------
+# Interfaces
+# ---------------------------------------------------------------------------
+
+
+class _PlanFn(Protocol):
+    """One unit kind's planner: diff a ticked selection into a reconcile plan."""
+
+    def __call__(
+        self, *, ticked: frozenset[str], catalog: Catalog, state: State
+    ) -> ReconcilePlan: ...
+
+
+class _ApplyFn(Protocol):
+    """One unit kind's applier: carry out a reconcile plan and return new state."""
+
+    def __call__(
+        self,
+        *,
+        plan: ReconcilePlan,
+        source_root: Path,
+        state_root: Path,
+        claude_root: Path,
+        state: State,
+    ) -> State: ...
+
+
+# ---------------------------------------------------------------------------
+# Data shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _UnitTab:
+    """The per-kind pieces the Skills and Agents tabs vary over, so one generic
+    runner drives both from data instead of two parallel branches."""
+
+    names: Callable[[Catalog], list[str]]
+    unit_id_of: Callable[[str], str]
+    plan: _PlanFn
+    apply: _ApplyFn
+    select_prompt: str
+    confirm_prompt: str
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def _unit_rows(
+    *,
+    names: Callable[[Catalog], list[str]],
+    unit_id_of: Callable[[str], str],
+    catalog: Catalog,
+    state: State,
+) -> list[str]:
+    """Pair each catalog unit with its on-disk install marker, the one row-rendering
+    the Skills and Agents tabs share, keying install state by the unit id catalog.py
+    owns."""
+    installed: frozenset[str] = frozenset(state.units)
+    return [
+        (MARKER_INSTALLED if unit_id_of(name) in installed else MARKER_NOT_INSTALLED)
+        + f" {name}"
+        for name in names(catalog)
+    ]
+
+
+def skill_rows(*, catalog: Catalog, state: State) -> list[str]:
+    """Pair each catalog skill with its on-disk install marker so the Skills tab
+    renders status, keying install state by the unit id catalog.py owns."""
+    return _unit_rows(
+        names=list_skills, unit_id_of=skill_unit_id, catalog=catalog, state=state
+    )
+
+
+def agent_rows(*, catalog: Catalog, state: State) -> list[str]:
+    """Pair each catalog agent with its on-disk install marker so the Agents tab
+    renders status, keying install state by the unit id catalog.py owns."""
+    return _unit_rows(
+        names=list_agents, unit_id_of=agent_unit_id, catalog=catalog, state=state
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data instances
+# ---------------------------------------------------------------------------
+
+_SKILLS_TAB: Final[_UnitTab] = _UnitTab(
+    names=list_skills,
+    unit_id_of=skill_unit_id,
+    plan=plan_skill_reconcile,
+    apply=apply_skill_reconcile,
+    select_prompt="Select installed skills",
+    confirm_prompt="Apply skill changes?",
+)
+
+_AGENTS_TAB: Final[_UnitTab] = _UnitTab(
+    names=list_agents,
+    unit_id_of=agent_unit_id,
+    plan=plan_agent_reconcile,
+    apply=apply_agent_reconcile,
+    select_prompt="Select installed agents",
+    confirm_prompt="Apply agent changes?",
+)
+
+_UNIT_TABS: Final[dict[str, _UnitTab]] = {
+    "Skills": _SKILLS_TAB,
+    "Agents": _AGENTS_TAB,
+}
+
+
+# ---------------------------------------------------------------------------
+# Implementation
+# ---------------------------------------------------------------------------
+
+
+def abort_on_esc(question: questionary.Question) -> questionary.Question:
+    """Let Esc abort a prompt exactly like Ctrl-C, so a user can back out with the
+    key they reach for first; returns the question for chaining."""
+    # Both real questionary Questions and the test doubles that stub only .ask() cross
+    # this seam; a double carries no prompt_toolkit Application, so there is no binding
+    # to register — hand it straight back rather than blow up on the missing attribute.
+    if getattr(question, "application", None) is None:
+        return question
+    # A confirm's existing bindings are a _MergedKeyBindings with no .add, unlike a
+    # checkbox/select's concrete KeyBindings — so register Escape on a fresh KeyBindings
+    # and merge it ahead of whatever the prompt already had, leaving those intact.
+    escape: KeyBindings = KeyBindings()
+
+    @escape.add(Keys.Escape, eager=True)
+    def _(event: KeyPressEvent) -> None:
+        event.app.exit(exception=KeyboardInterrupt, style="class:aborting")
+
+    existing: KeyBindingsBase | None = question.application.key_bindings
+    merged: list[KeyBindingsBase] = [escape] if existing is None else [existing, escape]
+    question.application.key_bindings = merge_key_bindings(merged)
+    return question
+
+
+def _run_unit_tab(*, tab: _UnitTab, console: Console) -> None:
+    """Drive one installed-units tab end to end — render status, take the ticked
+    selection, plan the diff, confirm, apply, then re-render — the body the Skills
+    and Agents tabs share, differing only by the functions and prompts in `tab`."""
+    catalog: Catalog = load_catalog(CATALOG_PATH)
+    state: State = load_state(STATE_ROOT)
+    for row in _unit_rows(
+        names=tab.names, unit_id_of=tab.unit_id_of, catalog=catalog, state=state
+    ):
+        console.print(row, markup=False)
+    installed: frozenset[str] = frozenset(state.units)
+    choices: list[questionary.Choice] = [
+        questionary.Choice(name, checked=tab.unit_id_of(name) in installed)
+        for name in tab.names(catalog)
+    ]
+    ticked: list[str] | None = abort_on_esc(
+        questionary.checkbox(tab.select_prompt, choices=choices)
+    ).ask()
+    if ticked is None:
+        return
+    plan: ReconcilePlan = tab.plan(
+        ticked=frozenset(ticked), catalog=catalog, state=state
+    )
+    if plan.is_empty:
+        return
+    confirmed: bool | None = abort_on_esc(questionary.confirm(tab.confirm_prompt)).ask()
+    if not confirmed:
+        return
+    state = tab.apply(
+        plan=plan,
+        source_root=REPO_ROOT,
+        state_root=STATE_ROOT,
+        claude_root=CLAUDE_ROOT,
+        state=state,
+    )
+    for row in _unit_rows(
+        names=tab.names, unit_id_of=tab.unit_id_of, catalog=catalog, state=state
+    ):
+        console.print(row, markup=False)
+
+
+def launch_tui() -> int:
+    """Bail out on non-interactive stdin: questionary's prompt would otherwise
+    block forever waiting on input no CI session can supply."""
+    console: Console = Console()
+    console.print(Panel(HEADER_TEXT, expand=False))
+    if not sys.stdin.isatty():
+        console.print(NON_TTY_NOTICE)
+        return 0
+    try:
+        while True:
+            choice: str | None = abort_on_esc(
+                questionary.select("Select a tab", choices=list(MENU_CHOICES))
+            ).ask()
+            if choice is None or choice == "Exit":
+                return 0
+            tab: _UnitTab | None = _UNIT_TABS.get(choice)
+            if tab is not None:
+                _run_unit_tab(tab=tab, console=console)
+                continue
+            console.print(TAB_PLACEHOLDER)
+    except KeyboardInterrupt:
+        return 0


### PR DESCRIPTION
## Slice 5.1 — Agents tab

Part of #74. Adds an interactive **Agents** tab to the `at` installer TUI — browse catalog agents with ✅/❌ markers and install/uninstall them through the menu exactly as skills work — by generalizing the previously skill-shaped engine to be kind-aware, then wiring the tab on top.

Built via the architect TDD flow (live RED→GREEN per behavior + reviewer/critic) because it adds real filesystem/state mutation for a new unit kind and generalizes existing tested behavior.

### Design

The engine was skill-named (`install_skill`, `plan_skill_reconcile`, …); this PR extracts generic cores that skills and agents share, keeping the four skill entry points as thin wrappers (behaviour-preserving — existing skill tests are unchanged and green).

| Layer | New surface | Generic core extracted |
|---|---|---|
| `catalog.py` | `list_agents`, `agent_unit`, `agent_unit_id` | `_unit_id` → public `unit_id` |
| `actions.py` | `install_agent`, `uninstall_agent` | `_install_unit` / `_uninstall_unit` |
| `reconcile.py` | `plan_agent_reconcile`, `apply_agent_reconcile` | `_plan_reconcile` / `_apply_reconcile` (Protocol-typed callables) |
| `at.py` | `agent_rows`, `_AGENTS_TAB` | `_UnitTab` / `_run_unit_tab` / `_UNIT_TABS`, `_unit_rows` |

`launch_tui` now dispatches tabs through a `{choice: _UnitTab}` map, so the later Rules/Hooks tabs (slices 5.2 / 6) are just a new `_UnitTab` entry.

### The single-file `.md` path

Skills are directories; agents are single `.md` files. `install_agent` stages `agents/<name>.md` to a **bare** `staged/agent/<name>` and links the live `~/.claude/agents/<name>.md` (keeping the `.md` so Claude Code discovers it), with `uninstall_agent` the exact inverse. This is the one genuinely new piece of logic and was the most-scrutinised — covered directly by `test_install_agent_*` / `test_uninstall_agent_*` and traced symmetric in review.

### Testing

- 7 behaviors, each driven RED→GREEN through the public interface; 3 behaviour-preserving refactors extracting the shared cores.
- Full gate green: `ruff format --check`, `ruff check`, `mypy --strict` (23 files), `pytest -W error` → **82 passed**.
- New tests in `test_{catalog,actions,reconcile,at}.py`, including a menu-level install through `main(["install"])`.

### Scope notes

- The agent **e2e** scenario (install→uninstall an agent against a fixture catalog) is the separate slice **5.e2e**, per the #74 breakdown.
- Menu-level agent *uninstall* is covered by composition (the generic `_run_unit_tab` is proven to uninstall via the Skills tab + `uninstall_agent` is tested directly), so it carries no dedicated test here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
