### PR TITLE
feat(installer): Rules tab — install rules through the generic engine (slice 5.2)

### DIFF
--- a/installer/actions.py
+++ b/installer/actions.py
@@ -3,8 +3,8 @@
 
 from pathlib import Path
 
-from catalog import Unit, agent_unit, skill_unit, unit_id
-from constants import AGENTS_DIRNAME, SKILLS_DIRNAME, STAGED_DIRNAME
+from catalog import Unit, agent_unit, rule_unit, skill_unit, unit_id
+from constants import AGENTS_DIRNAME, RULES_DIRNAME, SKILLS_DIRNAME, STAGED_DIRNAME
 from hashing import hash_unit
 from placement import link_unit, stage_unit, unlink_unit, unstage_unit
 from state import State, save_state
@@ -104,6 +104,26 @@ def install_agent(
     )
 
 
+def install_rule(
+    *,
+    name: str,
+    source_root: Path,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Install the named rule, staging its single "<name>.md" source and linking
+    it live under ~/.claude/rules/. The staged copy is keyed by bare
+    "<kind>/<name>" (no ".md"), while the live symlink keeps the ".md" suffix."""
+    return _install_unit(
+        unit=rule_unit(name),
+        source=source_root / RULES_DIRNAME / f"{name}.md",
+        link_path=claude_root / RULES_DIRNAME / f"{name}.md",
+        state_root=state_root,
+        state=state,
+    )
+
+
 def uninstall_skill(
     *,
     name: str,
@@ -133,6 +153,23 @@ def uninstall_agent(
     return _uninstall_unit(
         unit=agent_unit(name),
         link_path=claude_root / AGENTS_DIRNAME / f"{name}.md",
+        state_root=state_root,
+        state=state,
+    )
+
+
+def uninstall_rule(
+    *,
+    name: str,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Uninstall the named rule, the inverse of install_rule: drop its live
+    symlink then its staged file."""
+    return _uninstall_unit(
+        unit=rule_unit(name),
+        link_path=claude_root / RULES_DIRNAME / f"{name}.md",
         state_root=state_root,
         state=state,
     )

--- a/installer/catalog.py
+++ b/installer/catalog.py
@@ -48,6 +48,7 @@ class Catalog:
 
 _SKILL_KIND: Final[str] = "skill"
 _AGENT_KIND: Final[str] = "agent"
+_RULE_KIND: Final[str] = "rule"
 
 
 def unit_id(unit: Unit) -> str:
@@ -80,6 +81,18 @@ def agent_unit_id(name: str) -> str:
     return unit_id(agent_unit(name))
 
 
+def rule_unit(name: str) -> Unit:
+    """Own the rule-kind decision here, so callers stage rules without
+    re-encoding the "rule" kind token this module is the source of truth for."""
+    return Unit(kind=_RULE_KIND, name=name)
+
+
+def rule_unit_id(name: str) -> str:
+    """Expose the id a rule unit is keyed by, so callers render install status
+    without re-encoding the "<kind>/<name>" join this module owns."""
+    return unit_id(rule_unit(name))
+
+
 def list_skills(catalog: Catalog) -> list[str]:
     """Surface the installable skills by name in a stable order, so a UI listing
     doesn't depend on declaration order in the toml."""
@@ -90,6 +103,12 @@ def list_agents(catalog: Catalog) -> list[str]:
     """Surface the installable agents by name in a stable order, so a UI listing
     doesn't depend on declaration order in the toml."""
     return sorted(unit.name for unit in catalog.units if unit.kind == _AGENT_KIND)
+
+
+def list_rules(catalog: Catalog) -> list[str]:
+    """Surface the installable rules by name in a stable order, so a UI listing
+    doesn't depend on declaration order in the toml."""
+    return sorted(unit.name for unit in catalog.units if unit.kind == _RULE_KIND)
 
 
 def _resolve(ref: str, by_id: dict[str, Unit], package: str) -> Unit:

--- a/installer/constants.py
+++ b/installer/constants.py
@@ -6,3 +6,4 @@ from typing import Final
 STAGED_DIRNAME: Final[str] = "staged"
 SKILLS_DIRNAME: Final[str] = "skills"
 AGENTS_DIRNAME: Final[str] = "agents"
+RULES_DIRNAME: Final[str] = "rules"

--- a/installer/reconcile.py
+++ b/installer/reconcile.py
@@ -3,12 +3,21 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
-from actions import install_agent, install_skill, uninstall_agent, uninstall_skill
+from actions import (
+    install_agent,
+    install_rule,
+    install_skill,
+    uninstall_agent,
+    uninstall_rule,
+    uninstall_skill,
+)
 from catalog import (
     Catalog,
     agent_unit_id,
     list_agents,
+    list_rules,
     list_skills,
+    rule_unit_id,
     skill_unit_id,
 )
 from state import State
@@ -69,6 +78,19 @@ def plan_agent_reconcile(
         ticked=ticked,
         names=list_agents(catalog),
         unit_id_of=agent_unit_id,
+        state=state,
+    )
+
+
+def plan_rule_reconcile(
+    *, ticked: frozenset[str], catalog: Catalog, state: State
+) -> ReconcilePlan:
+    """Diff the ticked selection against installed state over the catalog's rules,
+    so the apply step works from a decided plan instead of re-deriving the diff."""
+    return _plan_reconcile(
+        ticked=ticked,
+        names=list_rules(catalog),
+        unit_id_of=rule_unit_id,
         state=state,
     )
 
@@ -166,6 +188,27 @@ def apply_agent_reconcile(
         plan=plan,
         install=install_agent,
         uninstall=uninstall_agent,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state,
+    )
+
+
+def apply_rule_reconcile(
+    *,
+    plan: ReconcilePlan,
+    source_root: Path,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Carry out a planned diff by installing then uninstalling each named rule,
+    threading the persisted State through so the final return reflects every action."""
+    return _apply_reconcile(
+        plan=plan,
+        install=install_rule,
+        uninstall=uninstall_rule,
         source_root=source_root,
         state_root=state_root,
         claude_root=claude_root,

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -1,7 +1,14 @@
 from pathlib import Path
 
-from actions import install_agent, install_skill, uninstall_agent, uninstall_skill
-from catalog import agent_unit_id, skill_unit_id
+from actions import (
+    install_agent,
+    install_rule,
+    install_skill,
+    uninstall_agent,
+    uninstall_rule,
+    uninstall_skill,
+)
+from catalog import agent_unit_id, rule_unit_id, skill_unit_id
 from hashing import hash_unit
 from state import State, load_state
 
@@ -184,6 +191,72 @@ def test_uninstall_agent_undoes_install_and_forgets_unit(tmp_path: Path) -> None
     unit_id: str = agent_unit_id(name)
     assert not (claude_root / "agents" / f"{name}.md").is_symlink()
     assert not (state_root / "staged" / "agent" / name).exists()
+    assert unit_id not in result.units
+    assert unit_id not in load_state(state_root).units
+    assert unit_id in installed_state.units
+
+
+def test_install_rule_stages_md_file_and_links_into_claude_rules(
+    tmp_path: Path,
+) -> None:
+    rule_content: str = "# Demo Rule\n\nDemonstrates installation.\n"
+    name: str = "demo-rule"
+    source_root: Path = tmp_path / "repo"
+    rule_source: Path = source_root / "rules" / f"{name}.md"
+    rule_source.parent.mkdir(parents=True)
+    rule_source.write_text(rule_content, encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    result: State = install_rule(
+        name=name,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    staged_path: Path = state_root / "staged" / "rule" / name
+    assert staged_path.is_file()
+    assert staged_path.read_text(encoding="utf-8") == rule_content
+
+    link_path: Path = claude_root / "rules" / f"{name}.md"
+    assert link_path.is_symlink()
+    assert link_path.resolve() == staged_path.resolve()
+    assert link_path.read_text(encoding="utf-8") == rule_content
+
+    assert rule_unit_id(name) in result.units
+
+
+def test_uninstall_rule_undoes_install_and_forgets_unit(tmp_path: Path) -> None:
+    rule_content: str = "# Demo Rule\n\nDemonstrates installation.\n"
+    name: str = "demo-rule"
+    source_root: Path = tmp_path / "repo"
+    rule_source: Path = source_root / "rules" / f"{name}.md"
+    rule_source.parent.mkdir(parents=True)
+    rule_source.write_text(rule_content, encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    installed_state: State = install_rule(
+        name=name,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    result: State = uninstall_rule(
+        name=name,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=installed_state,
+    )
+
+    unit_id: str = rule_unit_id(name)
+    assert not (claude_root / "rules" / f"{name}.md").is_symlink()
+    assert not (state_root / "staged" / "rule" / name).exists()
     assert unit_id not in result.units
     assert unit_id not in load_state(state_root).units
     assert unit_id in installed_state.units

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -17,6 +17,7 @@ from catalog import (
     agent_unit_id,
     list_skills,
     load_catalog,
+    rule_unit_id,
     skill_unit_id,
 )
 from hashing import hash_unit
@@ -27,6 +28,7 @@ from tui import (
     TAB_PLACEHOLDER,
     abort_on_esc,
     agent_rows,
+    rule_rows,
     skill_rows,
 )
 
@@ -122,6 +124,23 @@ def test_agent_rows_marks_installed_sorted_and_excludes_non_agents() -> None:
     state: State = State(version=1, units={agent_unit_id("alpha"): "hash"})
 
     rows: list[str] = agent_rows(catalog=catalog, state=state)
+
+    assert rows == [f"{MARKER_INSTALLED} alpha", f"{MARKER_NOT_INSTALLED} zeta"]
+
+
+def test_rule_rows_marks_installed_sorted_and_excludes_non_rules() -> None:
+    catalog: Catalog = Catalog(
+        units=(
+            Unit(kind="rule", name="zeta"),
+            Unit(kind="rule", name="alpha"),
+            Unit(kind="skill", name="some-skill"),
+        ),
+        packages=(),
+        bundles=(),
+    )
+    state: State = State(version=1, units={rule_unit_id("alpha"): "hash"})
+
+    rows: list[str] = rule_rows(catalog=catalog, state=state)
 
     assert rows == [f"{MARKER_INSTALLED} alpha", f"{MARKER_NOT_INSTALLED} zeta"]
 
@@ -223,6 +242,65 @@ def test_agents_tab_installs_ticked_agent_through_reconcile(
     assert agent_link.is_symlink()
     assert agent_unit_id("demo-agent") in final_state.units
     assert f"{MARKER_INSTALLED} demo-agent" in captured
+    assert TAB_PLACEHOLDER not in captured
+
+
+def test_rules_tab_installs_ticked_rule_through_reconcile(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("tui.STATE_ROOT", state_root)
+    monkeypatch.setattr("tui.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("tui.REPO_ROOT", repo_root)
+
+    # A real rule source on disk is the only input the install needs; nothing is
+    # installed up front, so ticking demo-rule through the Rules tab must stage,
+    # link, and record it — mirroring how the Agents tab installs a ticked agent.
+    rule_source: Path = repo_root / "rules" / "demo-rule.md"
+    rule_source.parent.mkdir(parents=True)
+    rule_source.write_text("# demo-rule\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        'packages = []\nbundles = []\n\n[[units]]\nkind = "rule"\nname = "demo-rule"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("tui.CATALOG_PATH", catalog_file)
+    # The tab menu opens the Rules tab, then closes it after the reconcile applies.
+    select_answers: Iterator[str] = iter(["Rules", "Exit"])
+
+    class FakeSelect:
+        def ask(self) -> str:
+            return next(select_answers)
+
+    # Tick the lone catalog rule so the desired set installs demo-rule.
+    class FakeCheckbox:
+        def ask(self) -> list[str]:
+            return ["demo-rule"]
+
+    class ConfirmPrompt:
+        def ask(self) -> bool:
+            return True
+
+    monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakeSelect())
+    monkeypatch.setattr("questionary.checkbox", lambda *args, **kwargs: FakeCheckbox())
+    monkeypatch.setattr("questionary.confirm", lambda *args, **kwargs: ConfirmPrompt())
+
+    exit_code: int = main(["install"])
+
+    # Ticking demo-rule applies plan_rule_reconcile then apply_rule_reconcile, so the
+    # rule ends up linked live and recorded in state, and the rows re-render with the
+    # installed marker.
+    captured: str = capsys.readouterr().out
+    final_state: State = load_state(state_root)
+    rule_link: Path = claude_root / "rules" / "demo-rule.md"
+    assert exit_code == 0
+    assert rule_link.is_symlink()
+    assert rule_unit_id("demo-rule") in final_state.units
+    assert f"{MARKER_INSTALLED} demo-rule" in captured
     assert TAB_PLACEHOLDER not in captured
 
 

--- a/installer/tests/test_catalog.py
+++ b/installer/tests/test_catalog.py
@@ -9,6 +9,7 @@ from catalog import (
     Package,
     Unit,
     list_agents,
+    list_rules,
     list_skills,
     load_catalog,
     skill_unit_id,
@@ -70,6 +71,35 @@ packages = ["pack"]
 """
 
 
+# Two rule units declared out of order (zeta before alpha) plus a skill and an
+# agent, so a single catalog pins both the sort and the non-rule exclusion.
+_RULES_FIXTURE: Final[str] = """
+[[units]]
+kind = "rule"
+name = "zeta"
+
+[[units]]
+kind = "rule"
+name = "alpha"
+
+[[units]]
+kind = "skill"
+name = "beta"
+
+[[units]]
+kind = "agent"
+name = "helper"
+
+[[packages]]
+name = "pack"
+units = ["rule/alpha"]
+
+[[bundles]]
+name = "everything"
+packages = ["pack"]
+"""
+
+
 def _write(tmp_path: Path, body: str) -> Path:
     catalog: Path = tmp_path / "catalog.toml"
     catalog.write_text(body, encoding="utf-8")
@@ -108,6 +138,14 @@ def test_list_agents_returns_only_agent_names_sorted(tmp_path: Path) -> None:
     # Only agent-kind units, and sorted (declaration order is zeta, alpha); the
     # skill and rule units must not leak into the agent listing.
     assert list_agents(catalog) == ["alpha", "zeta"]
+
+
+def test_list_rules_returns_only_rule_names_sorted(tmp_path: Path) -> None:
+    catalog: Catalog = load_catalog(_write(tmp_path, _RULES_FIXTURE))
+
+    # Only rule-kind units, and sorted (declaration order is zeta, alpha); the
+    # skill and agent units must not leak into the rule listing.
+    assert list_rules(catalog) == ["alpha", "zeta"]
 
 
 def test_skill_unit_id_joins_kind_and_name() -> None:

--- a/installer/tests/test_reconcile.py
+++ b/installer/tests/test_reconcile.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 
-from actions import install_agent, install_skill
-from catalog import Catalog, Unit, agent_unit_id, skill_unit_id
+from actions import install_agent, install_rule, install_skill
+from catalog import Catalog, Unit, agent_unit_id, rule_unit_id, skill_unit_id
 from reconcile import (
     ReconcilePlan,
     apply_agent_reconcile,
+    apply_rule_reconcile,
     apply_skill_reconcile,
     plan_agent_reconcile,
+    plan_rule_reconcile,
     plan_skill_reconcile,
 )
 from state import State, load_state
@@ -47,6 +49,27 @@ def test_plan_classifies_agents_by_tick_against_installed_state() -> None:
     ticked: frozenset[str] = frozenset({"alpha", "gamma"})
 
     plan: ReconcilePlan = plan_agent_reconcile(
+        ticked=ticked, catalog=catalog, state=state
+    )
+
+    assert plan.to_install == ("alpha",)
+    assert plan.to_remove == ("beta",)
+
+
+def test_plan_classifies_rules_by_tick_against_installed_state() -> None:
+    catalog: Catalog = Catalog(
+        units=(
+            Unit(kind="rule", name="alpha"),
+            Unit(kind="rule", name="beta"),
+            Unit(kind="rule", name="gamma"),
+        ),
+        packages=(),
+        bundles=(),
+    )
+    state: State = State(version=1, units={"rule/beta": "hash", "rule/gamma": "hash"})
+    ticked: frozenset[str] = frozenset({"alpha", "gamma"})
+
+    plan: ReconcilePlan = plan_rule_reconcile(
         ticked=ticked, catalog=catalog, state=state
     )
 
@@ -140,5 +163,50 @@ def test_apply_installs_planned_agents_and_uninstalls_removed_ones(
 
     assert not (claude_root / "agents" / "old-agent.md").is_symlink()
     assert not (state_root / "staged" / "agent" / "old-agent").exists()
+    assert old_id not in result.units
+    assert old_id not in persisted.units
+
+
+def test_apply_installs_planned_rules_and_uninstalls_removed_ones(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    rules_source: Path = source_root / "rules"
+    rules_source.mkdir(parents=True)
+    for name in ("old-rule", "new-rule"):
+        (rules_source / f"{name}.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    installed_state: State = install_rule(
+        name="old-rule",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    plan: ReconcilePlan = ReconcilePlan(
+        to_install=("new-rule",), to_remove=("old-rule",)
+    )
+    result: State = apply_rule_reconcile(
+        plan=plan,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=installed_state,
+    )
+
+    persisted: State = load_state(state_root)
+    new_id: str = rule_unit_id("new-rule")
+    old_id: str = rule_unit_id("old-rule")
+
+    assert (claude_root / "rules" / "new-rule.md").is_symlink()
+    assert (state_root / "staged" / "rule" / "new-rule").is_file()
+    assert new_id in result.units
+    assert new_id in persisted.units
+
+    assert not (claude_root / "rules" / "old-rule.md").is_symlink()
+    assert not (state_root / "staged" / "rule" / "old-rule").exists()
     assert old_id not in result.units
     assert old_id not in persisted.units

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -23,16 +23,20 @@ from catalog import (
     Catalog,
     agent_unit_id,
     list_agents,
+    list_rules,
     list_skills,
     load_catalog,
+    rule_unit_id,
     skill_unit_id,
 )
 from paths import CATALOG_PATH, CLAUDE_ROOT, REPO_ROOT, STATE_ROOT
 from reconcile import (
     ReconcilePlan,
     apply_agent_reconcile,
+    apply_rule_reconcile,
     apply_skill_reconcile,
     plan_agent_reconcile,
+    plan_rule_reconcile,
     plan_skill_reconcile,
 )
 from state import State, load_state
@@ -93,8 +97,8 @@ class _ApplyFn(Protocol):
 
 @dataclass(frozen=True)
 class _UnitTab:
-    """The per-kind pieces the Skills and Agents tabs vary over, so one generic
-    runner drives both from data instead of two parallel branches."""
+    """The per-kind pieces every installed-unit tab varies over, so one generic
+    runner drives them all from data instead of parallel branches."""
 
     names: Callable[[Catalog], list[str]]
     unit_id_of: Callable[[str], str]
@@ -117,7 +121,7 @@ def _unit_rows(
     state: State,
 ) -> list[str]:
     """Pair each catalog unit with its on-disk install marker, the one row-rendering
-    the Skills and Agents tabs share, keying install state by the unit id catalog.py
+    every installed-unit tab shares, keying install state by the unit id catalog.py
     owns."""
     installed: frozenset[str] = frozenset(state.units)
     return [
@@ -143,6 +147,14 @@ def agent_rows(*, catalog: Catalog, state: State) -> list[str]:
     )
 
 
+def rule_rows(*, catalog: Catalog, state: State) -> list[str]:
+    """Pair each catalog rule with its on-disk install marker so the Rules tab
+    renders status, keying install state by the unit id catalog.py owns."""
+    return _unit_rows(
+        names=list_rules, unit_id_of=rule_unit_id, catalog=catalog, state=state
+    )
+
+
 # ---------------------------------------------------------------------------
 # Data instances
 # ---------------------------------------------------------------------------
@@ -165,9 +177,19 @@ _AGENTS_TAB: Final[_UnitTab] = _UnitTab(
     confirm_prompt="Apply agent changes?",
 )
 
+_RULES_TAB: Final[_UnitTab] = _UnitTab(
+    names=list_rules,
+    unit_id_of=rule_unit_id,
+    plan=plan_rule_reconcile,
+    apply=apply_rule_reconcile,
+    select_prompt="Select installed rules",
+    confirm_prompt="Apply rule changes?",
+)
+
 _UNIT_TABS: Final[dict[str, _UnitTab]] = {
     "Skills": _SKILLS_TAB,
     "Agents": _AGENTS_TAB,
+    "Rules": _RULES_TAB,
 }
 
 
@@ -201,8 +223,8 @@ def abort_on_esc(question: questionary.Question) -> questionary.Question:
 
 def _run_unit_tab(*, tab: _UnitTab, console: Console) -> None:
     """Drive one installed-units tab end to end — render status, take the ticked
-    selection, plan the diff, confirm, apply, then re-render — the body the Skills
-    and Agents tabs share, differing only by the functions and prompts in `tab`."""
+    selection, plan the diff, confirm, apply, then re-render — the body every
+    installed-unit tab shares, differing only by the functions and prompts in `tab`."""
     catalog: Catalog = load_catalog(CATALOG_PATH)
     state: State = load_state(STATE_ROOT)
     for row in _unit_rows(


### PR DESCRIPTION
## Slice 5.2 of #74 — Rules tab

Wires a **Rules** tab into the installer TUI, mirroring the Agents tab (5.1, #102): list the catalog's rules with install markers, tick/untick to install/uninstall, symlinking each rule into `~/.claude/rules/<name>.md`. Since 5.1 made the engine kind-generic and split out `tui.py`, this is a near-trivial `_UnitTab` entry plus thin rule-kind wrappers that delegate to the already-tested generic primitives — no new filesystem/state-mutation logic.

### What's added
- `catalog.py`: `rule_unit`, `rule_unit_id`, `list_rules` (+ `_RULE_KIND`)
- `constants.py`: `RULES_DIRNAME`
- `actions.py`: `install_rule` / `uninstall_rule` → delegate to the generic `_install_unit` / `_uninstall_unit`
- `reconcile.py`: `plan_rule_reconcile` / `apply_rule_reconcile`
- `tui.py`: `rule_rows`, `_RULES_TAB`, and `"Rules"` registered in `_UNIT_TABS` so `launch_tui` routes Rules through the shared tab runner instead of the placeholder

A rule is a single `rules/<name>.md` file, handled identically to an agent: staged under `~/.claude/at/staged/rule/<name>`, symlinked live with the `.md` suffix, recorded in state under `rule/<name>`. Uninstall is the exact inverse.

### Out of scope
The rules **e2e** golden scenario is the separate `5.e2e` PR.

### Testing
7 new tests mirroring the agent equivalents (`test_catalog`, `test_actions`, `test_reconcile`, `test_at`), each driven RED→GREEN through the public interface. Full suite **89 passed** (`pytest -W error`, was 82); `ruff format --check`, `ruff check`, and `mypy --strict` all green.