### PR TITLE
test(installer): e2e agent + rule install/uninstall scenarios (slice 5.e2e)

### DIFF
--- a/installer/at.py
+++ b/installer/at.py
@@ -9,7 +9,7 @@ import sys
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final
+from typing import Final, Protocol
 
 import click
 
@@ -83,6 +83,32 @@ def _run_update() -> int:
     return 0
 
 
+class _PlanReconcile(Protocol):
+    """One kind's planner: diff a ticked selection against state into a ReconcilePlan.
+    A Protocol (not bare `Callable[..., ReconcilePlan]`) so mypy checks the keyword-only
+    call sites in `_run_per_kind` instead of accepting any argument shape."""
+
+    def __call__(
+        self, *, ticked: frozenset[str], catalog: Catalog, state: State
+    ) -> ReconcilePlan: ...
+
+
+class _ApplyReconcile(Protocol):
+    """One kind's apply: carry out a ReconcilePlan and return the persisted State.
+    A Protocol (not bare `Callable[..., State]`) so mypy checks the keyword-only call
+    sites in `_run_per_kind` instead of accepting any argument shape."""
+
+    def __call__(
+        self,
+        *,
+        plan: ReconcilePlan,
+        source_root: Path,
+        state_root: Path,
+        claude_root: Path,
+        state: State,
+    ) -> State: ...
+
+
 @dataclass(frozen=True)
 class _Kind:
     """Binds one unit kind's catalog/reconcile entry points so the scriptable
@@ -93,8 +119,8 @@ class _Kind:
     label: str
     list_names: Callable[[Catalog], list[str]]
     unit_id_of: Callable[[str], str]
-    plan: Callable[..., ReconcilePlan]
-    apply: Callable[..., State]
+    plan: _PlanReconcile
+    apply: _ApplyReconcile
 
 
 _SKILL: Final[_Kind] = _Kind(
@@ -136,59 +162,50 @@ def _reject_unknown_units(
     return 2
 
 
-def _reconcile_to(
-    ticked: frozenset[str], *, kind: _Kind, catalog: Catalog, state: State
+def _run_per_kind(
+    requested: tuple[tuple[_Kind, tuple[str, ...]], ...], *, additive: bool
 ) -> int:
-    """The one apply path every scriptable install/uninstall shares, so reconcile
-    wiring lives in one place regardless of unit kind."""
-    plan: ReconcilePlan = kind.plan(ticked=ticked, catalog=catalog, state=state)
-    kind.apply(
-        plan=plan,
-        source_root=_source_root(),
-        state_root=STATE_ROOT,
-        claude_root=CLAUDE_ROOT,
-        state=state,
-    )
+    """The one scriptable (non-TUI) install/uninstall path every flag routes through,
+    so install and uninstall share one dispatch instead of near-identical per-kind
+    loops. `additive` picks the ticked set: install joins the named units to what's
+    installed (`installed | names`), uninstall drops them (`installed - names`).
+
+    Atomic across kinds: every requested kind's names are validated up front, so a
+    typo in any flag rejects the whole command (exit 2) before any kind is applied —
+    nothing is installed or removed. The returned State is threaded from each kind's
+    apply into the next so the persisted store is the union over all kinds, not the
+    last kind clobbering the rest."""
+    catalog: Catalog = load_catalog(_catalog_path())
+    for kind, names in requested:
+        if not names:
+            continue
+        rejection: int | None = _reject_unknown_units(
+            list(names), kind=kind, catalog=catalog
+        )
+        if rejection is not None:
+            return rejection
+    state: State = load_state(STATE_ROOT)
+    for kind, names in requested:
+        if not names:
+            continue
+        installed: set[str] = {
+            name
+            for name in kind.list_names(catalog)
+            if kind.unit_id_of(name) in state.units
+        }
+        selected: set[str] = set(names)
+        ticked: frozenset[str] = frozenset(
+            installed | selected if additive else installed - selected
+        )
+        plan: ReconcilePlan = kind.plan(ticked=ticked, catalog=catalog, state=state)
+        state = kind.apply(
+            plan=plan,
+            source_root=_source_root(),
+            state_root=STATE_ROOT,
+            claude_root=CLAUDE_ROOT,
+            state=state,
+        )
     return 0
-
-
-def _install_named_units(names: list[str], *, kind: _Kind) -> int:
-    """Install every named unit of one kind without the TUI, so
-    `at install --<kind> <name> ...` is a scriptable path that drives the same
-    declarative reconcile the menu does. Install is additive: the named units join
-    whatever is already installed."""
-    catalog: Catalog = load_catalog(_catalog_path())
-    rejection: int | None = _reject_unknown_units(names, kind=kind, catalog=catalog)
-    if rejection is not None:
-        return rejection
-    state: State = load_state(STATE_ROOT)
-    installed: set[str] = {
-        name
-        for name in kind.list_names(catalog)
-        if kind.unit_id_of(name) in state.units
-    }
-    ticked: frozenset[str] = frozenset(installed | set(names))
-    return _reconcile_to(ticked, kind=kind, catalog=catalog, state=state)
-
-
-def _uninstall_named_units(names: list[str], *, kind: _Kind) -> int:
-    """Remove every named unit of one kind without the TUI, so
-    `at uninstall --<kind> <name> ...` is a scriptable path that drives the same
-    declarative reconcile the menu does. Uninstall is subtractive: the named units
-    drop out of whatever is installed, and every other installed unit stays ticked
-    and thus untouched."""
-    catalog: Catalog = load_catalog(_catalog_path())
-    rejection: int | None = _reject_unknown_units(names, kind=kind, catalog=catalog)
-    if rejection is not None:
-        return rejection
-    state: State = load_state(STATE_ROOT)
-    installed: set[str] = {
-        name
-        for name in kind.list_names(catalog)
-        if kind.unit_id_of(name) in state.units
-    }
-    ticked: frozenset[str] = frozenset(installed - set(names))
-    return _reconcile_to(ticked, kind=kind, catalog=catalog, state=state)
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -215,24 +232,18 @@ def install(
 ) -> int:
     """Install named units (--skill/--agent/--rule/--all) without the menu,
     else open it."""
-    requested: tuple[tuple[_Kind, tuple[str, ...]], ...] = (
-        (_SKILL, skills),
-        (_AGENT, agents),
-        (_RULE, rules),
-    )
     if skills or agents or rules:
-        # Each kind reconciles against its own catalog slice, so a flagged install
-        # runs one reconcile per kind and stops at the first that rejects a name.
-        for kind, names in requested:
-            if not names:
-                continue
-            kind_exit: int = _install_named_units(list(names), kind=kind)
-            if kind_exit != 0:
-                return kind_exit
-        return 0
+        requested: tuple[tuple[_Kind, tuple[str, ...]], ...] = (
+            (_SKILL, skills),
+            (_AGENT, agents),
+            (_RULE, rules),
+        )
+        return _run_per_kind(requested, additive=True)
     if install_all:
-        catalog_skills: list[str] = list_skills(load_catalog(_catalog_path()))
-        return _install_named_units(catalog_skills, kind=_SKILL)
+        catalog_skills: tuple[str, ...] = tuple(
+            list_skills(load_catalog(_catalog_path()))
+        )
+        return _run_per_kind(((_SKILL, catalog_skills),), additive=True)
     return launch_tui()
 
 
@@ -255,15 +266,7 @@ def uninstall(
         (_AGENT, agents),
         (_RULE, rules),
     )
-    # Each kind reconciles against its own catalog slice, so a flagged uninstall
-    # runs one reconcile per kind and stops at the first that rejects a name.
-    for kind, names in requested:
-        if not names:
-            continue
-        kind_exit: int = _uninstall_named_units(list(names), kind=kind)
-        if kind_exit != 0:
-            return kind_exit
-    return 0
+    return _run_per_kind(requested, additive=False)
 
 
 @cli.command()

--- a/installer/at.py
+++ b/installer/at.py
@@ -6,14 +6,33 @@
 import os
 import subprocess
 import sys
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
 
 import click
 
-from catalog import Catalog, list_skills, load_catalog, skill_unit_id
+from catalog import (
+    Catalog,
+    agent_unit_id,
+    list_agents,
+    list_rules,
+    list_skills,
+    load_catalog,
+    rule_unit_id,
+    skill_unit_id,
+)
 from paths import CATALOG_PATH, CLAUDE_ROOT, REPO_ROOT, STATE_ROOT
-from reconcile import ReconcilePlan, apply_skill_reconcile, plan_skill_reconcile
+from reconcile import (
+    ReconcilePlan,
+    apply_agent_reconcile,
+    apply_rule_reconcile,
+    apply_skill_reconcile,
+    plan_agent_reconcile,
+    plan_rule_reconcile,
+    plan_skill_reconcile,
+)
 from state import State, load_state
 from tui import launch_tui
 from update import update_installed_skills
@@ -64,27 +83,66 @@ def _run_update() -> int:
     return 0
 
 
-def _reject_unknown_skills(names: list[str], catalog: Catalog) -> int | None:
-    """Reject a --skill the catalog doesn't list before any reconcile runs, so a typo
-    fails atomically instead of silently no-opping; names the unknowns on stderr and
-    returns exit code 2, or None when every name is known."""
-    known: frozenset[str] = frozenset(list_skills(catalog))
+@dataclass(frozen=True)
+class _Kind:
+    """Binds one unit kind's catalog/reconcile entry points so the scriptable
+    install/uninstall paths route every kind through one code path, rather than a
+    near-identical skill/agent/rule copy each. `label` names the kind in error text
+    and matches the CLI flag (`--<label>`)."""
+
+    label: str
+    list_names: Callable[[Catalog], list[str]]
+    unit_id_of: Callable[[str], str]
+    plan: Callable[..., ReconcilePlan]
+    apply: Callable[..., State]
+
+
+_SKILL: Final[_Kind] = _Kind(
+    label="skill",
+    list_names=list_skills,
+    unit_id_of=skill_unit_id,
+    plan=plan_skill_reconcile,
+    apply=apply_skill_reconcile,
+)
+_AGENT: Final[_Kind] = _Kind(
+    label="agent",
+    list_names=list_agents,
+    unit_id_of=agent_unit_id,
+    plan=plan_agent_reconcile,
+    apply=apply_agent_reconcile,
+)
+_RULE: Final[_Kind] = _Kind(
+    label="rule",
+    list_names=list_rules,
+    unit_id_of=rule_unit_id,
+    plan=plan_rule_reconcile,
+    apply=apply_rule_reconcile,
+)
+
+
+def _reject_unknown_units(
+    names: list[str], *, kind: _Kind, catalog: Catalog
+) -> int | None:
+    """Reject a name the catalog doesn't list for this kind before any reconcile runs,
+    so a typo fails atomically instead of silently no-opping; names the unknowns on
+    stderr and returns exit code 2, or None when every name is known."""
+    known: frozenset[str] = frozenset(kind.list_names(catalog))
     unknown: list[str] = [name for name in names if name not in known]
     if not unknown:
         return None
     for name in unknown:
-        print(f"error: unknown skill '{name}'", file=sys.stderr)
+        print(f"error: unknown {kind.label} '{name}'", file=sys.stderr)
     print("Try 'at --help' for usage.", file=sys.stderr)
     return 2
 
 
-def _reconcile_to(ticked: frozenset[str], *, catalog: Catalog, state: State) -> int:
+def _reconcile_to(
+    ticked: frozenset[str], *, kind: _Kind, catalog: Catalog, state: State
+) -> int:
     """The one apply path every scriptable install/uninstall shares, so reconcile
-    wiring lives in one place."""
-    plan: ReconcilePlan = plan_skill_reconcile(
-        ticked=ticked, catalog=catalog, state=state
-    )
-    apply_skill_reconcile(
+    wiring lives in one place regardless of unit kind."""
+    plan: ReconcilePlan = kind.plan(ticked=ticked, catalog=catalog, state=state)
+    kind.apply(
         plan=plan,
         source_root=_source_root(),
         state_root=STATE_ROOT,
@@ -94,37 +152,43 @@ def _reconcile_to(ticked: frozenset[str], *, catalog: Catalog, state: State) -> 
     return 0
 
 
-def _install_named_skills(names: list[str]) -> int:
-    """Install every named skill without the TUI, so `at install --skill <name> ...`
-    is a scriptable path that drives the same declarative reconcile the menu does.
-    Install is additive: the named skills join whatever is already installed."""
+def _install_named_units(names: list[str], *, kind: _Kind) -> int:
+    """Install every named unit of one kind without the TUI, so
+    `at install --<kind> <name> ...` is a scriptable path that drives the same
+    declarative reconcile the menu does. Install is additive: the named units join
+    whatever is already installed."""
     catalog: Catalog = load_catalog(_catalog_path())
-    rejection: int | None = _reject_unknown_skills(names, catalog)
+    rejection: int | None = _reject_unknown_units(names, kind=kind, catalog=catalog)
     if rejection is not None:
         return rejection
     state: State = load_state(STATE_ROOT)
     installed: set[str] = {
-        name for name in list_skills(catalog) if skill_unit_id(name) in state.units
+        name
+        for name in kind.list_names(catalog)
+        if kind.unit_id_of(name) in state.units
     }
     ticked: frozenset[str] = frozenset(installed | set(names))
-    return _reconcile_to(ticked, catalog=catalog, state=state)
+    return _reconcile_to(ticked, kind=kind, catalog=catalog, state=state)
 
 
-def _uninstall_named_skills(names: list[str]) -> int:
-    """Remove every named skill without the TUI, so `at uninstall --skill <name> ...`
-    is a scriptable path that drives the same declarative reconcile the menu does.
-    Uninstall is subtractive: the named skills drop out of whatever is installed,
-    and every other installed skill stays ticked and thus untouched."""
+def _uninstall_named_units(names: list[str], *, kind: _Kind) -> int:
+    """Remove every named unit of one kind without the TUI, so
+    `at uninstall --<kind> <name> ...` is a scriptable path that drives the same
+    declarative reconcile the menu does. Uninstall is subtractive: the named units
+    drop out of whatever is installed, and every other installed unit stays ticked
+    and thus untouched."""
     catalog: Catalog = load_catalog(_catalog_path())
-    rejection: int | None = _reject_unknown_skills(names, catalog)
+    rejection: int | None = _reject_unknown_units(names, kind=kind, catalog=catalog)
     if rejection is not None:
         return rejection
     state: State = load_state(STATE_ROOT)
     installed: set[str] = {
-        name for name in list_skills(catalog) if skill_unit_id(name) in state.units
+        name
+        for name in kind.list_names(catalog)
+        if kind.unit_id_of(name) in state.units
     }
     ticked: frozenset[str] = frozenset(installed - set(names))
-    return _reconcile_to(ticked, catalog=catalog, state=state)
+    return _reconcile_to(ticked, kind=kind, catalog=catalog, state=state)
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -137,17 +201,38 @@ def cli() -> None:
 
 @cli.command()
 @click.option("--skill", "skills", multiple=True, metavar="<name>")
+@click.option("--agent", "agents", multiple=True, metavar="<name>")
+@click.option("--rule", "rules", multiple=True, metavar="<name>")
 @click.option("--all", "install_all", is_flag=True)
 # Accepted so a scripted `install --all` can pass it, but it changes nothing: the
 # --all path never opens the menu, so the flag never needs to reach the callback.
 @click.option("--non-interactive", is_flag=True, expose_value=False)
-def install(skills: tuple[str, ...], install_all: bool) -> int:
-    """Install named skills (--skill/--all) without the menu, else open it."""
-    if skills:
-        return _install_named_skills(list(skills))
+def install(
+    skills: tuple[str, ...],
+    agents: tuple[str, ...],
+    rules: tuple[str, ...],
+    install_all: bool,
+) -> int:
+    """Install named units (--skill/--agent/--rule/--all) without the menu,
+    else open it."""
+    requested: tuple[tuple[_Kind, tuple[str, ...]], ...] = (
+        (_SKILL, skills),
+        (_AGENT, agents),
+        (_RULE, rules),
+    )
+    if skills or agents or rules:
+        # Each kind reconciles against its own catalog slice, so a flagged install
+        # runs one reconcile per kind and stops at the first that rejects a name.
+        for kind, names in requested:
+            if not names:
+                continue
+            kind_exit: int = _install_named_units(list(names), kind=kind)
+            if kind_exit != 0:
+                return kind_exit
+        return 0
     if install_all:
         catalog_skills: list[str] = list_skills(load_catalog(_catalog_path()))
-        return _install_named_skills(catalog_skills)
+        return _install_named_units(catalog_skills, kind=_SKILL)
     return launch_tui()
 
 
@@ -157,7 +242,7 @@ def uninstall(skills: tuple[str, ...]) -> int:
     """Uninstall the named skills; at least one --skill is required."""
     if not skills:
         raise click.UsageError("uninstall requires at least one --skill <name>")
-    return _uninstall_named_skills(list(skills))
+    return _uninstall_named_units(list(skills), kind=_SKILL)
 
 
 @cli.command()

--- a/installer/at.py
+++ b/installer/at.py
@@ -238,11 +238,32 @@ def install(
 
 @cli.command()
 @click.option("--skill", "skills", multiple=True, metavar="<name>")
-def uninstall(skills: tuple[str, ...]) -> int:
-    """Uninstall the named skills; at least one --skill is required."""
-    if not skills:
-        raise click.UsageError("uninstall requires at least one --skill <name>")
-    return _uninstall_named_units(list(skills), kind=_SKILL)
+@click.option("--agent", "agents", multiple=True, metavar="<name>")
+@click.option("--rule", "rules", multiple=True, metavar="<name>")
+def uninstall(
+    skills: tuple[str, ...],
+    agents: tuple[str, ...],
+    rules: tuple[str, ...],
+) -> int:
+    """Uninstall named units (--skill/--agent/--rule); at least one is required."""
+    if not skills and not agents and not rules:
+        raise click.UsageError(
+            "uninstall requires at least one --skill/--agent/--rule <name>"
+        )
+    requested: tuple[tuple[_Kind, tuple[str, ...]], ...] = (
+        (_SKILL, skills),
+        (_AGENT, agents),
+        (_RULE, rules),
+    )
+    # Each kind reconciles against its own catalog slice, so a flagged uninstall
+    # runs one reconcile per kind and stops at the first that rejects a name.
+    for kind, names in requested:
+        if not names:
+            continue
+        kind_exit: int = _uninstall_named_units(list(names), kind=kind)
+        if kind_exit != 0:
+            return kind_exit
+    return 0
 
 
 @cli.command()

--- a/installer/tests/e2e/fixtures/agents/demo-agent.md
+++ b/installer/tests/e2e/fixtures/agents/demo-agent.md
@@ -1,0 +1,8 @@
+---
+name: demo-agent
+description: Frozen fixture agent for installer e2e snapshot scenarios.
+---
+
+# demo-agent
+
+A fixture agent with stable bytes so the e2e golden never churns.

--- a/installer/tests/e2e/fixtures/catalog.toml
+++ b/installer/tests/e2e/fixtures/catalog.toml
@@ -11,3 +11,11 @@ name = "demo-skill"
 [[units]]
 kind = "skill"
 name = "demo-skill-two"
+
+[[units]]
+kind = "agent"
+name = "demo-agent"
+
+[[units]]
+kind = "rule"
+name = "demo-rule"

--- a/installer/tests/e2e/fixtures/rules/demo-rule.md
+++ b/installer/tests/e2e/fixtures/rules/demo-rule.md
@@ -1,0 +1,8 @@
+---
+name: demo-rule
+description: Frozen fixture rule for installer e2e snapshot scenarios.
+---
+
+# demo-rule
+
+A fixture rule with stable bytes so the e2e golden never churns.

--- a/installer/tests/e2e/goldens/install_agent_and_rule.golden
+++ b/installer/tests/e2e/goldens/install_agent_and_rule.golden
@@ -1,0 +1,11 @@
+dir .claude/agents
+link .claude/agents/demo-agent.md -> .claude/at/staged/agent/demo-agent
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/agent
+file .claude/at/staged/agent/demo-agent b5ab887c16f11fd42f38c3972bb7019d601a4686b12069ba3e4ef87ac5c5f831
+dir .claude/at/staged/rule
+file .claude/at/staged/rule/demo-rule 94b4fcca183f1a395b2231260530d3d608b66d70206d8eff1d0000d680d65d6a
+json .claude/at/state.json {"units":{"agent/demo-agent":"b5ab887c16f11fd42f38c3972bb7019d601a4686b12069ba3e4ef87ac5c5f831","rule/demo-rule":"94b4fcca183f1a395b2231260530d3d608b66d70206d8eff1d0000d680d65d6a"},"version":1}
+dir .claude/rules
+link .claude/rules/demo-rule.md -> .claude/at/staged/rule/demo-rule

--- a/installer/tests/e2e/goldens/uninstall_agent_and_rule.golden
+++ b/installer/tests/e2e/goldens/uninstall_agent_and_rule.golden
@@ -1,0 +1,7 @@
+dir .claude/agents
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/agent
+dir .claude/at/staged/rule
+json .claude/at/state.json {"units":{},"version":1}
+dir .claude/rules

--- a/installer/tests/e2e/test_agents_rules.py
+++ b/installer/tests/e2e/test_agents_rules.py
@@ -1,0 +1,64 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+from harness import FIXTURES_DIR, GOLDENS_DIR, assert_matches_golden, run_at, snapshot
+
+
+@pytest.mark.e2e
+def test_install_agent_and_rule_matches_golden(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+
+    result: subprocess.CompletedProcess[str] = run_at(
+        args=[
+            "install",
+            "--agent",
+            "demo-agent",
+            "--rule",
+            "demo-rule",
+            "--non-interactive",
+        ],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=FIXTURES_DIR / "catalog.toml",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert_matches_golden(
+        name="install_agent_and_rule", actual=snapshot(home), goldens_dir=GOLDENS_DIR
+    )
+
+
+@pytest.mark.e2e
+def test_uninstall_agent_and_rule_leaves_clean_tree(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    install_result: subprocess.CompletedProcess[str] = run_at(
+        args=[
+            "install",
+            "--agent",
+            "demo-agent",
+            "--rule",
+            "demo-rule",
+            "--non-interactive",
+        ],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    uninstall_result: subprocess.CompletedProcess[str] = run_at(
+        args=["uninstall", "--agent", "demo-agent", "--rule", "demo-rule"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert uninstall_result.returncode == 0, uninstall_result.stderr
+
+    assert_matches_golden(
+        name="uninstall_agent_and_rule", actual=snapshot(home), goldens_dir=GOLDENS_DIR
+    )

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -1360,3 +1360,61 @@ def test_malformed_skill_request_exits_two_without_crash_or_tui(
     captured_err: str = capsys.readouterr().err
     assert exit_code == 2
     assert captured_err.strip() != ""
+
+
+@pytest.mark.parametrize(
+    ("kind", "subdir", "unit_id_of"),
+    [("agent", "agents", agent_unit_id), ("rule", "rules", rule_unit_id)],
+)
+def test_install_non_skill_flag_installs_named_unit_non_interactively(
+    kind: str,
+    subdir: str,
+    unit_id_of: Callable[[str], str],
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # An agent/rule source is a single .md file (skills are directories), and the
+    # CLI accepts only --skill today, so nothing is installed up front: a clean
+    # `install --<kind>` run must stage, link, and record this non-skill unit.
+    name: str = f"demo-{kind}"
+    source: Path = repo_root / subdir / f"{name}.md"
+    source.parent.mkdir(parents=True)
+    source.write_text(f"# {name}\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        f'packages = []\nbundles = []\n\n[[units]]\nkind = "{kind}"\nname = "{name}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # The --agent/--rule path must place the unit without ever opening the TUI: route
+    # every questionary prompt to a factory that fails loudly, so a regression that
+    # falls back through launch_tui's select/checkbox/confirm trips this guard, not a
+    # prompt.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["install", f"--{kind}", name])
+
+    # Routed through the same declarative reconcile as skills, the named non-skill unit
+    # lands: exit 0, the live symlink at claude_root/<subdir>/<name>.md, the staged copy
+    # at state_root/staged/<kind>/<name> (bare name, no .md), and a state entry.
+    final_state: State = load_state(state_root)
+    unit_link: Path = claude_root / subdir / f"{name}.md"
+    unit_staging: Path = state_root / "staged" / kind / name
+    assert exit_code == 0
+    assert unit_link.is_symlink()
+    assert unit_staging.exists()
+    assert unit_id_of(name) in final_state.units

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -9,7 +9,7 @@ from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.output import DummyOutput
 from pytest import CaptureFixture, MonkeyPatch
 
-from actions import install_skill
+from actions import install_agent, install_rule, install_skill
 from at import main
 from catalog import (
     Catalog,
@@ -1418,3 +1418,73 @@ def test_install_non_skill_flag_installs_named_unit_non_interactively(
     assert unit_link.is_symlink()
     assert unit_staging.exists()
     assert unit_id_of(name) in final_state.units
+
+
+@pytest.mark.parametrize(
+    ("kind", "subdir", "install_action", "unit_id_of"),
+    [
+        ("agent", "agents", install_agent, agent_unit_id),
+        ("rule", "rules", install_rule, rule_unit_id),
+    ],
+)
+def test_uninstall_non_skill_flag_removes_named_unit_non_interactively(
+    kind: str,
+    subdir: str,
+    install_action: Callable[..., State],
+    unit_id_of: Callable[[str], str],
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # An agent/rule source is a single .md file (skills are directories). Install the
+    # unit up front through the real public action so on-disk state, staging, and the
+    # live symlink all exist before the targeted uninstall must wipe every trace of it.
+    name: str = f"demo-{kind}"
+    source: Path = repo_root / subdir / f"{name}.md"
+    source.parent.mkdir(parents=True)
+    source.write_text(f"# {name}\n", encoding="utf-8")
+    install_action(
+        name=name,
+        source_root=repo_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=load_state(state_root),
+    )
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        f'packages = []\nbundles = []\n\n[[units]]\nkind = "{kind}"\nname = "{name}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # The --agent/--rule uninstall must remove the unit without ever opening the TUI:
+    # route every questionary prompt to a factory that fails loudly, so a regression
+    # that falls back through launch_tui's select/checkbox/confirm trips this guard,
+    # not a prompt.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["uninstall", f"--{kind}", name])
+
+    # Routed through the same declarative reconcile as skills, an `uninstall --<kind>
+    # <name>` is subtractive: the unit's live symlink at claude_root/<subdir>/<name>.md,
+    # its staged copy at state_root/staged/<kind>/<name>, and its state entry all go,
+    # and the command exits zero.
+    final_state: State = load_state(state_root)
+    unit_link: Path = claude_root / subdir / f"{name}.md"
+    unit_staging: Path = state_root / "staged" / kind / name
+    assert exit_code == 0
+    assert not unit_link.exists() and not unit_link.is_symlink()
+    assert not unit_staging.exists()
+    assert unit_id_of(name) not in final_state.units

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -1488,3 +1488,55 @@ def test_uninstall_non_skill_flag_removes_named_unit_non_interactively(
     assert not unit_link.exists() and not unit_link.is_symlink()
     assert not unit_staging.exists()
     assert unit_id_of(name) not in final_state.units
+
+
+def test_install_rejects_unknown_name_in_any_kind_before_applying_any(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # The catalog lists a real skill (good-skill) with a source on disk so it *could*
+    # install, but names no rule 'nonesuch'. The request mixes both kinds: a valid
+    # --skill alongside an unknown --rule, so validation must span all kinds.
+    source: Path = repo_root / "skills" / "good-skill" / "SKILL.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("# good-skill\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "good-skill"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # The rejection path must stay non-interactive: route every questionary prompt to a
+    # factory that fails loudly, so a regression that falls back into launch_tui's
+    # select/checkbox/confirm trips this guard instead of silently prompting.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["install", "--skill", "good-skill", "--rule", "nonesuch"])
+
+    # Validation is atomic across kinds: an unknown name in *any* requested kind aborts
+    # before *any* kind is applied, so main exits 2 naming the bad rule ('nonesuch') and
+    # the valid skill is never installed — no live symlink, no staged copy, no state
+    # entry — rather than landing the skill and only then catching the typo.
+    captured_err: str = capsys.readouterr().err
+    final_state: State = load_state(state_root)
+    skill_link: Path = claude_root / "skills" / "good-skill"
+    skill_staging: Path = state_root / "staged" / "skill" / "good-skill"
+    assert exit_code == 2
+    assert "nonesuch" in captured_err
+    assert not skill_link.exists() and not skill_link.is_symlink()
+    assert not skill_staging.exists()
+    assert skill_unit_id("good-skill") not in final_state.units


### PR DESCRIPTION
## Slice 5.e2e — install then uninstall an agent and a rule → golden

Closes the last remaining slice-5 row in #74. Adds e2e golden-snapshot scenarios that drive the **real** `at` binary to install then uninstall an agent and a rule, extending the 4.5 harness.

### Why this needed production code (architect, not lite)
The engine/reconcile/actions layers were already kind-generic and tested after 5.1/5.2, **but the non-interactive CLI exposed only `--skill`** — and the e2e harness can only drive `at` through that CLI. So the headline e2e work required first wiring `at install/uninstall --agent/--rule`. (Future 6.e2e hooks will hit the same prerequisite.)

### What changed (`installer/` only)
- **CLI** (`at.py`): `install`/`uninstall` now accept `--agent`/`--rule` (repeatable, like `--skill`), routed through a kind-generic dispatch (`_Kind` descriptors `_SKILL`/`_AGENT`/`_RULE` + a single `_run_per_kind(requested, *, additive)` helper). Validation is **atomic across kinds** — an unknown name in any flag rejects the whole command (exit 2) before anything is applied — and `State` is threaded across kinds so a multi-kind install records the union. `_PlanReconcile`/`_ApplyReconcile` Protocols replace loose `Callable[...]`. Existing `--skill`/`--all`/no-flag-TUI behavior is unchanged.
- **Unit tests** (`tests/test_at.py`): parametrized install/uninstall over (agent, rule), asserting real symlink/staging/state effects with a non-interactive guard; plus an atomic cross-kind rejection test.
- **E2E** (`tests/e2e/test_agents_rules.py` + fixtures + goldens): `install_agent_and_rule` and `uninstall_agent_and_rule` (clean-tree) scenarios against frozen `demo-agent`/`demo-rule` fixtures, each pinned by a committed golden (regenerable with `AT_BLESS=1`).

### Verification
- `ruff format --check`, `ruff check`, `mypy --strict` all clean.
- `pytest -W error` → **96 passed** (94 prior + 2 new e2e); no existing golden churned; e2e scenarios verified against committed goldens without `AT_BLESS`.

### Process
Built test-first via the make-pr architect workflow: RED→GREEN per CLI behavior, then the e2e scenarios, then a reviewer/critic pass (critic 93/achieved) and one batched fix round for 3 MINOR findings (scoped re-review 94, no findings). Full run log in `.v1-runs/` (not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)