### PR TITLE
feat(installer): settings.json merge on hook install — tracked id + idempotent (slice 6.2)

### DIFF
--- a/hooks/ruff-format.settings.json
+++ b/hooks/ruff-format.settings.json
@@ -1,0 +1,13 @@
+{
+  "PostToolUse": [
+    {
+      "matcher": "Edit|Write|MultiEdit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "~/.claude/hooks/ruff-format.sh"
+        }
+      ]
+    }
+  ]
+}

--- a/installer/actions.py
+++ b/installer/actions.py
@@ -13,6 +13,7 @@ from constants import (
 )
 from hashing import hash_unit
 from placement import link_unit, stage_unit, unlink_unit, unstage_unit
+from settings import merge_hook_settings
 from state import State, save_state
 
 
@@ -141,14 +142,18 @@ def install_hook(
     """Install the named hook, staging its single "<name>.sh" source and linking
     it live under ~/.claude/hooks/. The staged copy is keyed by bare
     "<kind>/<name>" (no ".sh"), while the live symlink keeps the ".sh" suffix;
-    the source's executable mode is preserved through staging."""
-    return _install_unit(
+    the source's executable mode is preserved through staging. Also merges the
+    hook's settings.json fragment into the user's settings under the tracked id,
+    so staging the script and registering it as live happen as one install."""
+    new_state: State = _install_unit(
         unit=hook_unit(name),
         source=source_root / HOOKS_DIRNAME / f"{name}.sh",
         link_path=claude_root / HOOKS_DIRNAME / f"{name}.sh",
         state_root=state_root,
         state=state,
     )
+    merge_hook_settings(name=name, source_root=source_root, claude_root=claude_root)
+    return new_state
 
 
 def uninstall_skill(

--- a/installer/actions.py
+++ b/installer/actions.py
@@ -142,9 +142,11 @@ def install_hook(
     """Install the named hook, staging its single "<name>.sh" source and linking
     it live under ~/.claude/hooks/. The staged copy is keyed by bare
     "<kind>/<name>" (no ".sh"), while the live symlink keeps the ".sh" suffix;
-    the source's executable mode is preserved through staging. Also merges the
-    hook's settings.json fragment into the user's settings under the tracked id,
-    so staging the script and registering it as live happen as one install."""
+    the source's executable mode is preserved through staging. As a final,
+    separate step — after the script is staged, linked, and recorded — merges the
+    hook's settings.json fragment into the user's settings under the tracked id;
+    the install is idempotent, so re-running it completes a partial install whose
+    settings merge did not land."""
     new_state: State = _install_unit(
         unit=hook_unit(name),
         source=source_root / HOOKS_DIRNAME / f"{name}.sh",

--- a/installer/settings.py
+++ b/installer/settings.py
@@ -1,7 +1,16 @@
-"""Own how a hook unit's fragment merges into the user's settings.json, tagging
-each contributed matcher-group with its hook id so the membership stays reversible."""
+"""Own the hook<->settings.json round-trip: read a hook's fragment, merge it into
+the user's settings.json tagging each contributed matcher-group with its hook id so
+the membership stays reversible, and persist the result atomically."""
 
-from typing import cast
+import json
+import tempfile
+from pathlib import Path
+from typing import Final, cast
+
+from catalog import hook_unit_id
+from constants import HOOKS_DIRNAME
+
+SETTINGS_FILENAME: Final[str] = "settings.json"
 
 
 def merge_hook_fragment(
@@ -34,3 +43,60 @@ def merge_hook_fragment(
         ]
     merged["hooks"] = hooks
     return merged
+
+
+def load_settings(path: Path) -> dict[str, object]:
+    """Treat a missing settings.json as a first install rather than an error, so a
+    hook merges into an empty document instead of every caller handling absence."""
+    if path.exists():
+        with path.open(encoding="utf-8") as handle:
+            return cast("dict[str, object]", json.load(handle))
+    return {}
+
+
+def save_settings(settings: dict[str, object], path: Path) -> None:
+    """Persist the merged settings so a later run — and the user's own editor —
+    sees what this install registered."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Write a sibling temp file and atomically swap it in, so a failed write leaves
+    # the user's prior settings.json intact rather than a half-written file. Indent
+    # and a trailing newline keep settings.json readable, since users hand-edit it.
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=path.parent, suffix=".tmp", delete=False
+    ) as handle:
+        json.dump(settings, handle, indent=2)
+        handle.write("\n")
+        tmp_path: Path = Path(handle.name)
+    # A failed swap must not leave the sibling temp behind; the original error
+    # still propagates so callers see the write failed.
+    try:
+        tmp_path.replace(path)
+    except OSError:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def read_hook_fragment(*, source_root: Path, name: str) -> dict[str, object] | None:
+    """Treat a hook with no "<name>.settings.json" as contributing no settings, so
+    the caller distinguishes "no fragment" from an empty one rather than guessing."""
+    fragment_path: Path = source_root / HOOKS_DIRNAME / f"{name}.settings.json"
+    if fragment_path.exists():
+        with fragment_path.open(encoding="utf-8") as handle:
+            return cast("dict[str, object]", json.load(handle))
+    return None
+
+
+def merge_hook_settings(*, name: str, source_root: Path, claude_root: Path) -> None:
+    """Fold a hook's settings fragment into the user's settings.json under the
+    hook's tracked id, so installing the hook also registers its matcher-groups;
+    a hook without a fragment touches no settings, keeping plain-hook installs inert."""
+    fragment: dict[str, object] | None = read_hook_fragment(
+        source_root=source_root, name=name
+    )
+    if fragment is None:
+        return
+    settings_path: Path = claude_root / SETTINGS_FILENAME
+    merged: dict[str, object] = merge_hook_fragment(
+        load_settings(settings_path), hook_id=hook_unit_id(name), fragment=fragment
+    )
+    save_settings(merged, settings_path)

--- a/installer/settings.py
+++ b/installer/settings.py
@@ -18,12 +18,16 @@ def merge_hook_fragment(
     for event, groups in fragment.items():
         # The fragment is untrusted external shape, so cast to the matcher-group
         # list at this boundary; stamping each group as {"id": ..., **group}
-        # copies it, leaving the fragment's own dicts untouched. Append our
-        # stamped groups after any the user already had for this event, so a
-        # pre-existing group in the same event survives the merge.
-        existing: list[dict[str, object]] = list(
-            cast("list[dict[str, object]]", hooks.get(event, []))
-        )
+        # copies it, leaving the fragment's own dicts untouched. Drop any group
+        # this hook stamped on a previous merge before re-appending, so merging
+        # the same fragment twice replaces our groups rather than duplicating
+        # them; user groups (no "id") and other hooks' groups (a different "id")
+        # are kept, so they survive the merge.
+        existing: list[dict[str, object]] = [
+            group
+            for group in cast("list[dict[str, object]]", hooks.get(event, []))
+            if group.get("id") != hook_id
+        ]
         hooks[event] = existing + [
             {"id": hook_id, **group}
             for group in cast("list[dict[str, object]]", groups)

--- a/installer/settings.py
+++ b/installer/settings.py
@@ -1,0 +1,27 @@
+"""Own how a hook unit's fragment merges into the user's settings.json, tagging
+each contributed matcher-group with its hook id so the membership stays reversible."""
+
+from typing import cast
+
+
+def merge_hook_fragment(
+    settings: dict[str, object], *, hook_id: str, fragment: dict[str, object]
+) -> dict[str, object]:
+    """Stamp a hook unit's id onto every matcher-group it contributes, so the
+    merged settings carry which hook owns each group and a later uninstall can
+    strip exactly that hook's groups back out without disturbing the rest."""
+    # Build a fresh settings dict (and a fresh "hooks" map) rather than mutating
+    # the caller's: settings is the on-disk shape callers may still read, so the
+    # merge stays a pure function of its inputs.
+    merged: dict[str, object] = dict(settings)
+    hooks: dict[str, object] = dict(cast("dict[str, object]", merged.get("hooks", {})))
+    for event, groups in fragment.items():
+        # The fragment is untrusted external shape, so cast to the matcher-group
+        # list at this boundary; stamping each group as {"id": ..., **group}
+        # copies it, leaving the fragment's own dicts untouched.
+        hooks[event] = [
+            {"id": hook_id, **group}
+            for group in cast("list[dict[str, object]]", groups)
+        ]
+    merged["hooks"] = hooks
+    return merged

--- a/installer/settings.py
+++ b/installer/settings.py
@@ -18,8 +18,13 @@ def merge_hook_fragment(
     for event, groups in fragment.items():
         # The fragment is untrusted external shape, so cast to the matcher-group
         # list at this boundary; stamping each group as {"id": ..., **group}
-        # copies it, leaving the fragment's own dicts untouched.
-        hooks[event] = [
+        # copies it, leaving the fragment's own dicts untouched. Append our
+        # stamped groups after any the user already had for this event, so a
+        # pre-existing group in the same event survives the merge.
+        existing: list[dict[str, object]] = list(
+            cast("list[dict[str, object]]", hooks.get(event, []))
+        )
+        hooks[event] = existing + [
             {"id": hook_id, **group}
             for group in cast("list[dict[str, object]]", groups)
         ]

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -1,3 +1,4 @@
+import json
 import stat
 from pathlib import Path
 
@@ -265,6 +266,79 @@ def test_install_hook_stages_executable_sh_and_links_into_claude_hooks(
     assert link_path.read_text(encoding="utf-8") == hook_content
 
     assert f"hook/{name}" in result.units
+
+
+def test_install_hook_merges_settings_fragment_preserving_user_settings(
+    tmp_path: Path,
+) -> None:
+    name: str = "demo-hook"
+    source_root: Path = tmp_path / "repo"
+    hook_source: Path = source_root / "hooks" / f"{name}.sh"
+    hook_source.parent.mkdir(parents=True)
+    hook_source.write_text("#!/usr/bin/env bash\necho demo\n", encoding="utf-8")
+    hook_source.chmod(0o755)
+
+    fragment: dict[str, object] = {
+        "PostToolUse": [
+            {
+                "matcher": "Edit|Write",
+                "hooks": [
+                    {"type": "command", "command": "~/.claude/hooks/demo-hook.sh"}
+                ],
+            }
+        ]
+    }
+    (source_root / "hooks" / f"{name}.settings.json").write_text(
+        json.dumps(fragment), encoding="utf-8"
+    )
+
+    claude_root: Path = tmp_path / "claude"
+    claude_root.mkdir(parents=True)
+    user_post_group: dict[str, object] = {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "user.sh"}],
+    }
+    existing_settings: dict[str, object] = {
+        "model": "opus",
+        "hooks": {"PostToolUse": [user_post_group]},
+    }
+    settings_path: Path = claude_root / "settings.json"
+    settings_path.write_text(json.dumps(existing_settings), encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+
+    install_hook(
+        name=name,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    result: dict[str, object] = json.loads(settings_path.read_text(encoding="utf-8"))
+
+    assert result["model"] == "opus"
+
+    hooks_map: object = result["hooks"]
+    assert isinstance(hooks_map, dict)
+    post_groups: object = hooks_map["PostToolUse"]
+    assert isinstance(post_groups, list)
+    assert user_post_group in post_groups
+
+    tracked_groups: list[dict[str, object]] = [
+        group
+        for group in post_groups
+        if isinstance(group, dict) and group.get("id") == f"hook/{name}"
+    ]
+    assert len(tracked_groups) == 1
+
+    tracked_hooks: object = tracked_groups[0]["hooks"]
+    assert isinstance(tracked_hooks, list)
+    first_hook: object = tracked_hooks[0]
+    assert isinstance(first_hook, dict)
+    command: object = first_hook["command"]
+    assert isinstance(command, str)
+    assert command.endswith("demo-hook.sh")
 
 
 def test_uninstall_rule_undoes_install_and_forgets_unit(tmp_path: Path) -> None:

--- a/installer/tests/test_settings.py
+++ b/installer/tests/test_settings.py
@@ -1,0 +1,26 @@
+from settings import merge_hook_fragment
+
+
+def test_merge_hook_fragment_stamps_fragment_into_settings_under_tracked_id() -> None:
+    settings: dict[str, object] = {}
+    fragment: dict[str, object] = {
+        "PostToolUse": [
+            {"matcher": "Edit", "hooks": [{"type": "command", "command": "x.sh"}]}
+        ]
+    }
+
+    result: dict[str, object] = merge_hook_fragment(
+        settings, hook_id="hook/demo", fragment=fragment
+    )
+
+    hooks_map: object = result["hooks"]
+    assert isinstance(hooks_map, dict)
+    groups: object = hooks_map["PostToolUse"]
+    assert groups == [
+        {
+            "id": "hook/demo",
+            "matcher": "Edit",
+            "hooks": [{"type": "command", "command": "x.sh"}],
+        }
+    ]
+    assert settings == {}

--- a/installer/tests/test_settings.py
+++ b/installer/tests/test_settings.py
@@ -72,3 +72,31 @@ def test_merge_hook_fragment_preserves_other_settings_and_hook_groups() -> None:
         "matcher": "Edit",
         "hooks": [{"type": "command", "command": "ours.sh"}],
     } in post_groups
+
+
+def test_merge_hook_fragment_is_idempotent_for_repeated_same_hook_merge() -> None:
+    fragment: dict[str, object] = {
+        "PostToolUse": [
+            {"matcher": "Edit", "hooks": [{"type": "command", "command": "ours.sh"}]}
+        ]
+    }
+
+    once: dict[str, object] = merge_hook_fragment(
+        {}, hook_id="hook/demo", fragment=fragment
+    )
+    twice: dict[str, object] = merge_hook_fragment(
+        once, hook_id="hook/demo", fragment=fragment
+    )
+
+    assert twice == once
+
+    hooks_map: object = twice["hooks"]
+    assert isinstance(hooks_map, dict)
+    post_groups: object = hooks_map["PostToolUse"]
+    assert isinstance(post_groups, list)
+    our_group_count: int = sum(
+        1
+        for group in post_groups
+        if isinstance(group, dict) and group.get("id") == "hook/demo"
+    )
+    assert our_group_count == 1

--- a/installer/tests/test_settings.py
+++ b/installer/tests/test_settings.py
@@ -24,3 +24,51 @@ def test_merge_hook_fragment_stamps_fragment_into_settings_under_tracked_id() ->
         }
     ]
     assert settings == {}
+
+
+def test_merge_hook_fragment_preserves_other_settings_and_hook_groups() -> None:
+    user_post_group: dict[str, object] = {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "user.sh"}],
+    }
+    user_pre_group: dict[str, object] = {
+        "matcher": "Read",
+        "hooks": [{"type": "command", "command": "pre.sh"}],
+    }
+    settings: dict[str, object] = {
+        "permissions": {"allow": ["Bash"]},
+        "hooks": {
+            "PostToolUse": [user_post_group],
+            "PreToolUse": [user_pre_group],
+        },
+    }
+    fragment: dict[str, object] = {
+        "PostToolUse": [
+            {"matcher": "Edit", "hooks": [{"type": "command", "command": "ours.sh"}]}
+        ]
+    }
+
+    result: dict[str, object] = merge_hook_fragment(
+        settings, hook_id="hook/demo", fragment=fragment
+    )
+
+    assert result["permissions"] == {"allow": ["Bash"]}
+
+    hooks_map: object = result["hooks"]
+    assert isinstance(hooks_map, dict)
+    assert hooks_map["PreToolUse"] == [
+        {"matcher": "Read", "hooks": [{"type": "command", "command": "pre.sh"}]}
+    ]
+
+    post_groups: object = hooks_map["PostToolUse"]
+    assert isinstance(post_groups, list)
+    assert len(post_groups) == 2
+    assert {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "user.sh"}],
+    } in post_groups
+    assert {
+        "id": "hook/demo",
+        "matcher": "Edit",
+        "hooks": [{"type": "command", "command": "ours.sh"}],
+    } in post_groups


### PR DESCRIPTION
Implements **slice 6.2** of #74 — `settings.json` merge on hook install.

## What

On hook install, the installer now folds the hook's `settings.json` fragment into `~/.claude/settings.json`, stamping each contributed matcher-group with a tracked id (`hook/<name>`) so a later uninstall can remove exactly that block while leaving the user's other settings and other hooks untouched.

- **`installer/settings.py`** (new):
  - `merge_hook_fragment` — pure; stamps the tracked `id`, drops any prior same-id group then re-appends → **idempotent**, while preserving user groups (no `id`) and other hooks' groups (different `id`).
  - `load_settings` — a missing `settings.json` reads as `{}` (first install).
  - `save_settings` — atomic temp-file + `replace` (mirrors `state.save_state`); `indent=2` + trailing newline since users hand-edit it.
  - `read_hook_fragment` — `None` when a hook ships no companion fragment.
  - `merge_hook_settings` — read → load → merge → save; no-ops when there's no fragment (plain-script hooks stay inert).
- **`installer/actions.py`** — `install_hook` merges the fragment as a final step after staging/linking/recording.
- **`hooks/ruff-format.settings.json`** (new) — the real fragment for the catalogued `ruff-format` hook (`PostToolUse`, matcher `Edit|Write|MultiEdit`, command `~/.claude/hooks/ruff-format.sh`).

## Scope

Install-time merge only. The un-merge on uninstall is **6.3**; the install/uninstall round-trip golden is **6.e2e**.

## Tests (TDD)

- `tests/test_settings.py` — stamp tracked id into empty settings; preserve the user's other settings + other hooks' groups; idempotent re-merge (no duplicate).
- `tests/test_actions.py` — `install_hook` merges into a **pre-existing** user `settings.json`, preserving the user's `model` key and group while adding the tracked block.

Gates green: `ruff format --check` · `ruff check` · `mypy --strict` · `pytest -W error` → **109 passed** (incl. 10 e2e).

## Design note

The tracking id is embedded as an `id` key on each managed matcher-group. Confirmed Claude Code silently ignores unknown keys there today (anthropics/claude-code#5886) — a future strict-validation change is the only forward risk, which would move tracking to a sidecar.

## Follow-up (non-blocking)

`save_settings` mirrors `state.save_state`'s atomic-write dance; once a third caller appears, extract a shared `atomic_write_text` helper (deferred per review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
