### PR TITLE
feat(installer): settings.json un-merge on hook uninstall (slice 6.3)

### DIFF
--- a/installer/actions.py
+++ b/installer/actions.py
@@ -13,7 +13,7 @@ from constants import (
 )
 from hashing import hash_unit
 from placement import link_unit, stage_unit, unlink_unit, unstage_unit
-from settings import merge_hook_settings
+from settings import merge_hook_settings, unmerge_hook_settings
 from state import State, save_state
 
 
@@ -216,8 +216,10 @@ def uninstall_hook(
     claude_root: Path,
     state: State,
 ) -> State:
-    """Uninstall the named hook, the inverse of install_hook: drop its live
-    symlink then its staged file."""
+    """Uninstall the named hook, the inverse of install_hook: as a first, separate
+    step un-merge the hook's settings.json block by its tracked id, then drop its
+    live symlink and its staged file."""
+    unmerge_hook_settings(name=name, claude_root=claude_root)
     return _uninstall_unit(
         unit=hook_unit(name),
         link_path=claude_root / HOOKS_DIRNAME / f"{name}.sh",

--- a/installer/settings.py
+++ b/installer/settings.py
@@ -66,7 +66,13 @@ def unmerge_hook_fragment(
             for group in cast("list[dict[str, object]]", groups)
             if group.get("id") != hook_id
         ]
-    merged["hooks"] = hooks
+    # A settings doc that never had a "hooks" block should round-trip unchanged,
+    # so only re-attach the map when it carries groups; otherwise drop the key
+    # rather than leaving an empty "hooks": {} behind.
+    if hooks:
+        merged["hooks"] = hooks
+    else:
+        merged.pop("hooks", None)
     return merged
 
 

--- a/installer/settings.py
+++ b/installer/settings.py
@@ -135,3 +135,14 @@ def merge_hook_settings(*, name: str, source_root: Path, claude_root: Path) -> N
         load_settings(settings_path), hook_id=hook_unit_id(name), fragment=fragment
     )
     save_settings(merged, settings_path)
+
+
+def unmerge_hook_settings(*, name: str, claude_root: Path) -> None:
+    """Strip the hook's tracked matcher-groups back out of the user's settings.json
+    by their id alone, so an uninstall reverses merge_hook_settings without depending
+    on the repo source still existing or the hook's fragment being unchanged."""
+    settings_path: Path = claude_root / SETTINGS_FILENAME
+    unmerged: dict[str, object] = unmerge_hook_fragment(
+        load_settings(settings_path), hook_id=hook_unit_id(name)
+    )
+    save_settings(unmerged, settings_path)

--- a/installer/settings.py
+++ b/installer/settings.py
@@ -146,7 +146,12 @@ def unmerge_hook_settings(*, name: str, claude_root: Path) -> None:
     # load/save rather than persisting an empty document the install never created.
     if not settings_path.exists():
         return
+    loaded: dict[str, object] = load_settings(settings_path)
     unmerged: dict[str, object] = unmerge_hook_fragment(
-        load_settings(settings_path), hook_id=hook_unit_id(name)
+        loaded, hook_id=hook_unit_id(name)
     )
-    save_settings(unmerged, settings_path)
+    # Persist only when the un-merge actually removed something, so uninstalling a
+    # hook that contributed no groups leaves the user's hand-edited settings.json
+    # byte-for-byte intact rather than reformatting it through save_settings.
+    if unmerged != loaded:
+        save_settings(unmerged, settings_path)

--- a/installer/settings.py
+++ b/installer/settings.py
@@ -45,6 +45,31 @@ def merge_hook_fragment(
     return merged
 
 
+def unmerge_hook_fragment(
+    settings: dict[str, object], *, hook_id: str
+) -> dict[str, object]:
+    """Strip back out exactly the matcher-groups a hook stamped with its id, so an
+    uninstall reverses merge_hook_fragment — dropping that hook's groups while user
+    groups (no "id") and other hooks' groups (a different "id") stay registered."""
+    # Build a fresh settings dict (and a fresh "hooks" map) rather than mutating
+    # the caller's: settings is the on-disk shape callers may still read, so the
+    # unmerge stays a pure function of its inputs.
+    merged: dict[str, object] = dict(settings)
+    hooks: dict[str, object] = {}
+    for event, groups in cast("dict[str, object]", merged.get("hooks", {})).items():
+        # The settings are untrusted external shape, so cast each event's groups to
+        # the matcher-group list at this boundary and keep only the groups this hook
+        # did not stamp; user groups (no "id") and other hooks' groups (a different
+        # "id") survive, so the unmerge removes exactly this hook's contributions.
+        hooks[event] = [
+            group
+            for group in cast("list[dict[str, object]]", groups)
+            if group.get("id") != hook_id
+        ]
+    merged["hooks"] = hooks
+    return merged
+
+
 def load_settings(path: Path) -> dict[str, object]:
     """Treat a missing settings.json as a first install rather than an error, so a
     hook merges into an empty document instead of every caller handling absence."""

--- a/installer/settings.py
+++ b/installer/settings.py
@@ -142,6 +142,10 @@ def unmerge_hook_settings(*, name: str, claude_root: Path) -> None:
     by their id alone, so an uninstall reverses merge_hook_settings without depending
     on the repo source still existing or the hook's fragment being unchanged."""
     settings_path: Path = claude_root / SETTINGS_FILENAME
+    # A settings.json that was never written has nothing to un-merge, so bail before
+    # load/save rather than persisting an empty document the install never created.
+    if not settings_path.exists():
+        return
     unmerged: dict[str, object] = unmerge_hook_fragment(
         load_settings(settings_path), hook_id=hook_unit_id(name)
     )

--- a/installer/settings.py
+++ b/installer/settings.py
@@ -61,11 +61,15 @@ def unmerge_hook_fragment(
         # the matcher-group list at this boundary and keep only the groups this hook
         # did not stamp; user groups (no "id") and other hooks' groups (a different
         # "id") survive, so the unmerge removes exactly this hook's contributions.
-        hooks[event] = [
+        # Drop an event whose groups are now all gone rather than leaving an empty
+        # "Event": [] behind, so a merge that introduced the event round-trips away.
+        kept: list[dict[str, object]] = [
             group
             for group in cast("list[dict[str, object]]", groups)
             if group.get("id") != hook_id
         ]
+        if kept:
+            hooks[event] = kept
     # A settings doc that never had a "hooks" block should round-trip unchanged,
     # so only re-attach the map when it carries groups; otherwise drop the key
     # rather than leaving an empty "hooks": {} behind.

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -480,3 +480,33 @@ def test_uninstall_hook_removes_its_settings_block_preserving_user_settings(
         if isinstance(group, dict) and group.get("id") == f"hook/{name}"
     ]
     assert tracked_groups == []
+
+
+def test_uninstall_hook_tolerates_missing_settings_file(tmp_path: Path) -> None:
+    hook_content: str = "#!/usr/bin/env bash\necho demo\n"
+    name: str = "demo-hook"
+    source_root: Path = tmp_path / "repo"
+    hook_source: Path = source_root / "hooks" / f"{name}.sh"
+    hook_source.parent.mkdir(parents=True)
+    hook_source.write_text(hook_content, encoding="utf-8")
+    hook_source.chmod(0o755)
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    installed_state: State = install_hook(
+        name=name,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    uninstall_hook(
+        name=name,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=installed_state,
+    )
+
+    assert not (claude_root / "hooks" / f"{name}.sh").is_symlink()
+    assert not (claude_root / "settings.json").exists()

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -482,6 +482,55 @@ def test_uninstall_hook_removes_its_settings_block_preserving_user_settings(
     assert tracked_groups == []
 
 
+def test_uninstall_hook_leaves_settings_untouched_when_nothing_is_removed(
+    tmp_path: Path,
+) -> None:
+    name: str = "demo-hook"
+    source_root: Path = tmp_path / "repo"
+    hook_source: Path = source_root / "hooks" / f"{name}.sh"
+    hook_source.parent.mkdir(parents=True)
+    hook_source.write_text("#!/usr/bin/env bash\necho demo\n", encoding="utf-8")
+    hook_source.chmod(0o755)
+
+    claude_root: Path = tmp_path / "claude"
+    claude_root.mkdir(parents=True)
+    user_doc: dict[str, object] = {
+        "model": "opus",
+        "hooks": {
+            "PostToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "user.sh"}],
+                }
+            ]
+        },
+    }
+    settings_path: Path = claude_root / "settings.json"
+    settings_path.write_text(
+        json.dumps(user_doc, separators=(",", ":")), encoding="utf-8"
+    )
+    original_text: str = settings_path.read_text(encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+
+    installed_state: State = install_hook(
+        name=name,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    uninstall_hook(
+        name=name,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=installed_state,
+    )
+
+    assert settings_path.read_text(encoding="utf-8") == original_text
+
+
 def test_uninstall_hook_tolerates_missing_settings_file(tmp_path: Path) -> None:
     hook_content: str = "#!/usr/bin/env bash\necho demo\n"
     name: str = "demo-hook"

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -406,3 +406,77 @@ def test_uninstall_hook_undoes_install_and_forgets_unit(tmp_path: Path) -> None:
     assert unit_id not in result.units
     assert unit_id not in load_state(state_root).units
     assert unit_id in installed_state.units
+
+
+def test_uninstall_hook_removes_its_settings_block_preserving_user_settings(
+    tmp_path: Path,
+) -> None:
+    name: str = "demo-hook"
+    source_root: Path = tmp_path / "repo"
+    hook_source: Path = source_root / "hooks" / f"{name}.sh"
+    hook_source.parent.mkdir(parents=True)
+    hook_source.write_text("#!/usr/bin/env bash\necho demo\n", encoding="utf-8")
+    hook_source.chmod(0o755)
+
+    fragment: dict[str, object] = {
+        "PostToolUse": [
+            {
+                "matcher": "Edit|Write",
+                "hooks": [
+                    {"type": "command", "command": "~/.claude/hooks/demo-hook.sh"}
+                ],
+            }
+        ]
+    }
+    (source_root / "hooks" / f"{name}.settings.json").write_text(
+        json.dumps(fragment), encoding="utf-8"
+    )
+
+    claude_root: Path = tmp_path / "claude"
+    claude_root.mkdir(parents=True)
+    user_post_group: dict[str, object] = {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "user.sh"}],
+    }
+    existing_settings: dict[str, object] = {
+        "model": "opus",
+        "hooks": {"PostToolUse": [user_post_group]},
+    }
+    settings_path: Path = claude_root / "settings.json"
+    settings_path.write_text(json.dumps(existing_settings), encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+
+    installed_state: State = install_hook(
+        name=name,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    uninstall_hook(
+        name=name,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=installed_state,
+    )
+
+    result: dict[str, object] = json.loads(settings_path.read_text(encoding="utf-8"))
+
+    assert result["model"] == "opus"
+
+    hooks_map: object = result["hooks"]
+    assert isinstance(hooks_map, dict)
+    post_groups: object = hooks_map["PostToolUse"]
+    assert isinstance(post_groups, list)
+    assert user_post_group in post_groups
+
+    tracked_groups: list[dict[str, object]] = [
+        group
+        for groups in hooks_map.values()
+        if isinstance(groups, list)
+        for group in groups
+        if isinstance(group, dict) and group.get("id") == f"hook/{name}"
+    ]
+    assert tracked_groups == []

--- a/installer/tests/test_settings.py
+++ b/installer/tests/test_settings.py
@@ -163,3 +163,26 @@ def test_unmerge_hook_fragment_leaves_settings_without_a_hooks_block_unchanged()
 
     assert result == {"model": "opus", "permissions": {"allow": ["Bash"]}}
     assert "hooks" not in result
+
+
+def test_merge_then_unmerge_round_trips_to_the_original_settings() -> None:
+    original: dict[str, object] = {
+        "model": "opus",
+        "hooks": {
+            "PreToolUse": [
+                {"matcher": "Read", "hooks": [{"type": "command", "command": "pre.sh"}]}
+            ]
+        },
+    }
+    fragment: dict[str, object] = {
+        "PostToolUse": [
+            {"matcher": "Edit", "hooks": [{"type": "command", "command": "ours.sh"}]}
+        ]
+    }
+
+    merged: dict[str, object] = merge_hook_fragment(
+        original, hook_id="hook/demo", fragment=fragment
+    )
+    restored: dict[str, object] = unmerge_hook_fragment(merged, hook_id="hook/demo")
+
+    assert restored == original

--- a/installer/tests/test_settings.py
+++ b/installer/tests/test_settings.py
@@ -156,7 +156,7 @@ def test_unmerge_hook_fragment_removes_tracked_groups_preserving_the_rest() -> N
     assert demo_post_group in original_post_groups
 
 
-def test_unmerge_hook_fragment_leaves_settings_without_a_hooks_block_unchanged() -> None:
+def test_unmerge_hook_fragment_leaves_a_no_hooks_doc_unchanged() -> None:
     settings: dict[str, object] = {"model": "opus", "permissions": {"allow": ["Bash"]}}
 
     result: dict[str, object] = unmerge_hook_fragment(settings, hook_id="hook/demo")

--- a/installer/tests/test_settings.py
+++ b/installer/tests/test_settings.py
@@ -1,4 +1,4 @@
-from settings import merge_hook_fragment
+from settings import merge_hook_fragment, unmerge_hook_fragment
 
 
 def test_merge_hook_fragment_stamps_fragment_into_settings_under_tracked_id() -> None:
@@ -100,3 +100,57 @@ def test_merge_hook_fragment_is_idempotent_for_repeated_same_hook_merge() -> Non
         if isinstance(group, dict) and group.get("id") == "hook/demo"
     )
     assert our_group_count == 1
+
+
+def test_unmerge_hook_fragment_removes_tracked_groups_preserving_the_rest() -> None:
+    user_post_group: dict[str, object] = {
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "user.sh"}],
+    }
+    demo_post_group: dict[str, object] = {
+        "id": "hook/demo",
+        "matcher": "Edit",
+        "hooks": [{"type": "command", "command": "demo.sh"}],
+    }
+    other_pre_group: dict[str, object] = {
+        "id": "hook/other",
+        "matcher": "Read",
+        "hooks": [{"type": "command", "command": "other.sh"}],
+    }
+    settings: dict[str, object] = {
+        "permissions": {"allow": ["Bash"]},
+        "hooks": {
+            "PostToolUse": [user_post_group, demo_post_group],
+            "PreToolUse": [other_pre_group],
+        },
+    }
+
+    result: dict[str, object] = unmerge_hook_fragment(settings, hook_id="hook/demo")
+
+    hooks_map: object = result["hooks"]
+    assert isinstance(hooks_map, dict)
+    remaining_ids: list[object] = [
+        group.get("id")
+        for event_groups in hooks_map.values()
+        if isinstance(event_groups, list)
+        for group in event_groups
+        if isinstance(group, dict)
+    ]
+    assert "hook/demo" not in remaining_ids
+    assert "hook/other" in remaining_ids
+
+    post_groups: object = hooks_map["PostToolUse"]
+    assert isinstance(post_groups, list)
+    assert user_post_group in post_groups
+
+    pre_groups: object = hooks_map["PreToolUse"]
+    assert isinstance(pre_groups, list)
+    assert other_pre_group in pre_groups
+
+    assert result["permissions"] == {"allow": ["Bash"]}
+
+    original_hooks: object = settings["hooks"]
+    assert isinstance(original_hooks, dict)
+    original_post_groups: object = original_hooks["PostToolUse"]
+    assert isinstance(original_post_groups, list)
+    assert demo_post_group in original_post_groups

--- a/installer/tests/test_settings.py
+++ b/installer/tests/test_settings.py
@@ -154,3 +154,12 @@ def test_unmerge_hook_fragment_removes_tracked_groups_preserving_the_rest() -> N
     original_post_groups: object = original_hooks["PostToolUse"]
     assert isinstance(original_post_groups, list)
     assert demo_post_group in original_post_groups
+
+
+def test_unmerge_hook_fragment_leaves_settings_without_a_hooks_block_unchanged() -> None:
+    settings: dict[str, object] = {"model": "opus", "permissions": {"allow": ["Bash"]}}
+
+    result: dict[str, object] = unmerge_hook_fragment(settings, hook_id="hook/demo")
+
+    assert result == {"model": "opus", "permissions": {"allow": ["Bash"]}}
+    assert "hooks" not in result


### PR DESCRIPTION
## Slice 6.3 — `settings.json` un-merge on hook uninstall

Closes the un-merge half of Slice 6 (Hooks tab + settings merge) from #74. The inverse of 6.2's merge (#105): when a hook is uninstalled, its tracked block is removed from `~/.claude/settings.json`, leaving the user's other hooks and settings intact.

### What

- **`unmerge_hook_fragment(settings, *, hook_id)`** (pure, in `installer/settings.py`) — the inverse of `merge_hook_fragment`. Removes exactly the matcher-groups stamped with `id == hook_id` from each event under `hooks`, preserving user groups (no `id`) and other hooks' groups (a different `id`) plus all other top-level keys. Drops an event list that becomes empty and an emptied `hooks` map, so a `merge → unmerge` round-trips back to the original document. Never mutates its input.
- **`unmerge_hook_settings(*, name, claude_root)`** (on-disk, in `installer/settings.py`) — loads `settings.json`, strips the hook's block by tracked id (`hook/<name>`), and saves. Removal is **by tracked id alone** — it takes no `source_root`, so an uninstall never depends on the repo source still existing or the fragment being unchanged.
- **`uninstall_hook`** (`installer/actions.py`) now un-merges the hook's settings block, mirroring how `install_hook` ends with the merge.

### Robustness ("tolerate missing/edited settings")

- A **missing** `settings.json` is a no-op — no crash, and no spurious empty file is created.
- A settings doc with **no `hooks` block** is returned unchanged (no empty `"hooks": {}` introduced).
- An uninstall that removes **nothing** (a fragment-less hook, or a repeat uninstall) leaves `settings.json` **byte-for-byte unchanged** — it is never reformatted/normalized. This keeps uninstall symmetric with the inert plain-hook install path.

### How it was built

Architect TDD (`/make-pr`), RED→GREEN per behavior, gates before judgment:

| Behavior | Test |
|----------|------|
| remove tracked groups, preserve the rest | `test_unmerge_hook_fragment_removes_tracked_groups_preserving_the_rest` |
| no-hooks doc unchanged | `test_unmerge_hook_fragment_leaves_a_no_hooks_doc_unchanged` |
| merge→unmerge round-trip | `test_merge_then_unmerge_round_trips_to_the_original_settings` |
| strip block on disk, preserve user settings | `test_uninstall_hook_removes_its_settings_block_preserving_user_settings` |
| tolerate missing settings.json | `test_uninstall_hook_tolerates_missing_settings_file` |
| no rewrite when nothing removed | `test_uninstall_hook_leaves_settings_untouched_when_nothing_is_removed` |

### Testing

`installer/` gate profile, all green: `ruff format --check` · `ruff check` · `mypy --strict` · `pytest -W error` → **115 passed** (was 109 at base). ~59 lines of production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
