### PR TITLE
test(installer): e2e hook install/uninstall settings.json round-trip (slice 6.e2e)

### DIFF
--- a/installer/tests/e2e/fixtures/catalog.toml
+++ b/installer/tests/e2e/fixtures/catalog.toml
@@ -19,3 +19,7 @@ name = "demo-agent"
 [[units]]
 kind = "rule"
 name = "demo-rule"
+
+[[units]]
+kind = "hook"
+name = "demo-hook"

--- a/installer/tests/e2e/fixtures/hooks/demo-hook.settings.json
+++ b/installer/tests/e2e/fixtures/hooks/demo-hook.settings.json
@@ -1,0 +1,13 @@
+{
+  "PostToolUse": [
+    {
+      "matcher": "Edit|Write",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "~/.claude/hooks/demo-hook.sh"
+        }
+      ]
+    }
+  ]
+}

--- a/installer/tests/e2e/fixtures/hooks/demo-hook.sh
+++ b/installer/tests/e2e/fixtures/hooks/demo-hook.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Inert e2e fixture hook: never executed during the test, only staged and linked.
+exit 0

--- a/installer/tests/e2e/goldens/install_hook.golden
+++ b/installer/tests/e2e/goldens/install_hook.golden
@@ -1,0 +1,8 @@
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/hook
+file .claude/at/staged/hook/demo-hook a17dede5c3b44bff25d3543d16a6d76e3be70370d92619fe428ba1d4f798c70c
+json .claude/at/state.json {"units":{"hook/demo-hook":"a17dede5c3b44bff25d3543d16a6d76e3be70370d92619fe428ba1d4f798c70c"},"version":1}
+dir .claude/hooks
+link .claude/hooks/demo-hook.sh -> .claude/at/staged/hook/demo-hook
+file .claude/settings.json e965653bcfa5692b483ed8bcc92d26a524e09fd17a12f0b983319513df569f31

--- a/installer/tests/e2e/goldens/uninstall_hook.golden
+++ b/installer/tests/e2e/goldens/uninstall_hook.golden
@@ -1,0 +1,6 @@
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/hook
+json .claude/at/state.json {"units":{},"version":1}
+dir .claude/hooks
+file .claude/settings.json d11149a8d698fc3e6f6e336da59420cc8aca3e022f5c316edd218f56bc82b744

--- a/installer/tests/e2e/test_hooks.py
+++ b/installer/tests/e2e/test_hooks.py
@@ -1,0 +1,130 @@
+import json
+import subprocess
+from pathlib import Path
+from typing import Final, cast
+
+import pytest
+from harness import FIXTURES_DIR, GOLDENS_DIR, assert_matches_golden, run_at, snapshot
+
+_USER_HOOK_COMMAND: Final[str] = "~/.claude/hooks/user-hook.sh"
+_DEMO_HOOK_COMMAND: Final[str] = "~/.claude/hooks/demo-hook.sh"
+_DEMO_HOOK_ID: Final[str] = "hook/demo-hook"
+
+
+def _seed_user_settings(home: Path) -> str:
+    """Pre-seed a user-owned PostToolUse hook the exact way save_settings serializes
+    it, so the uninstall round-trip can be asserted byte-for-byte against this text
+    and the merge can be shown to leave the user's own group untouched."""
+    user_settings: dict[str, object] = {
+        "hooks": {
+            "PostToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": _USER_HOOK_COMMAND}],
+                }
+            ]
+        }
+    }
+    settings_path: Path = home / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    seeded_text: str = json.dumps(user_settings, indent=2) + "\n"
+    settings_path.write_text(seeded_text, encoding="utf-8")
+    return seeded_text
+
+
+def _post_tool_use_groups(settings_text: str) -> list[dict[str, object]]:
+    """Read the merged PostToolUse matcher-groups out of settings.json text, so a
+    scenario asserts on the user's and the demo hook's groups by structure rather
+    than trusting the golden's opaque settings hash alone."""
+    settings: dict[str, object] = json.loads(settings_text)
+    hooks: dict[str, object] = cast("dict[str, object]", settings["hooks"])
+    return cast("list[dict[str, object]]", hooks["PostToolUse"])
+
+
+def _group_command(group: dict[str, object]) -> str:
+    """Pull the single command a matcher-group's first hook runs, so a scenario can
+    name which script a group wires up without re-walking the nested shape."""
+    command_specs: list[dict[str, object]] = cast(
+        "list[dict[str, object]]", group["hooks"]
+    )
+    return cast("str", command_specs[0]["command"])
+
+
+@pytest.mark.e2e
+def test_install_hook_merges_settings_matches_golden(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    _seed_user_settings(home)
+
+    result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--hook", "demo-hook", "--non-interactive"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=FIXTURES_DIR / "catalog.toml",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert_matches_golden(
+        name="install_hook", actual=snapshot(home), goldens_dir=GOLDENS_DIR
+    )
+
+    settings_path: Path = home / ".claude" / "settings.json"
+    groups: list[dict[str, object]] = _post_tool_use_groups(
+        settings_path.read_text(encoding="utf-8")
+    )
+    demo_groups: list[dict[str, object]] = [
+        group for group in groups if group.get("id") == _DEMO_HOOK_ID
+    ]
+    assert len(demo_groups) == 1
+    assert _group_command(demo_groups[0]) == _DEMO_HOOK_COMMAND
+
+    user_groups: list[dict[str, object]] = [
+        group for group in groups if "id" not in group
+    ]
+    assert len(user_groups) == 1
+    assert _group_command(user_groups[0]) == _USER_HOOK_COMMAND
+
+
+@pytest.mark.e2e
+def test_uninstall_hook_roundtrips_and_user_hook_survives(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    seeded_text: str = _seed_user_settings(home)
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+    settings_path: Path = home / ".claude" / "settings.json"
+
+    install_result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--hook", "demo-hook", "--non-interactive"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    installed_groups: list[dict[str, object]] = _post_tool_use_groups(
+        settings_path.read_text(encoding="utf-8")
+    )
+    demo_groups: list[dict[str, object]] = [
+        group for group in installed_groups if group.get("id") == _DEMO_HOOK_ID
+    ]
+    assert len(demo_groups) == 1
+    assert _group_command(demo_groups[0]) == _DEMO_HOOK_COMMAND
+    user_groups: list[dict[str, object]] = [
+        group for group in installed_groups if "id" not in group
+    ]
+    assert len(user_groups) == 1
+    assert _group_command(user_groups[0]) == _USER_HOOK_COMMAND
+
+    uninstall_result: subprocess.CompletedProcess[str] = run_at(
+        args=["uninstall", "--hook", "demo-hook"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert uninstall_result.returncode == 0, uninstall_result.stderr
+
+    assert_matches_golden(
+        name="uninstall_hook", actual=snapshot(home), goldens_dir=GOLDENS_DIR
+    )
+
+    assert settings_path.read_text(encoding="utf-8") == seeded_text


### PR DESCRIPTION
Closes slice **6.e2e** of the installer PRD (#74), completing slice 6 (Hooks tab + `settings.json` merge) at 4/4.

## What
Adds two end-to-end golden scenarios that drive the **real** `at` binary (via the existing `tests/e2e/` harness) to lock the hook ↔ `settings.json` round-trip. **Tests + fixtures only — no production code.** The merge/un-merge engine and the `--hook` CLI already landed in 6.1 (#101), 6.2 (#105), and 6.3 (#106); this PR exercises them through the real CLI.

- `test_install_hook_merges_settings_matches_golden` — pre-seeds `~/.claude/settings.json` with a user-owned `PostToolUse` hook (no tracked `id`), installs `--hook demo-hook`, and asserts the merged settings contain **both** the user's group (surviving, un-`id`'d) and the demo group stamped `id: hook/demo-hook` — gated by `install_hook.golden`.
- `test_uninstall_hook_roundtrips_and_user_hook_survives` — installs, asserts the demo block is present, then uninstalls and asserts `settings.json` is restored **byte-for-byte** to the user's original (demo block gone, user's hook intact) — gated by `uninstall_hook.golden`.

## Fixtures
- `fixtures/hooks/demo-hook.sh` — inert, executable (`100755`) e2e fixture script.
- `fixtures/hooks/demo-hook.settings.json` — a `PostToolUse` fragment (no `id`; the installer stamps it at merge time), modeled on the real `hooks/ruff-format.settings.json`.
- one `kind = "hook"` entry appended to the frozen fixture catalog.

## Determinism
`snapshot()` hashes `settings.json` opaquely (only `state.json` is rendered canonically), so the goldens pin exact bytes and the tests back them with explicit structural + byte-for-byte assertions. The golden hashes are independently reproducible without running `at`:
- uninstall golden's `settings.json` sha256 == `sha256(json.dumps(user_settings, indent=2) + "\n")`
- install golden's == the recomputed `merge_hook_fragment` output
- staged-hook hash == `sha256(demo-hook.sh)`

## Gates
`pytest -W error` → **117 passed** (e2e runs without `AT_BLESS`, so the committed goldens gate); `ruff format --check`, `ruff check`, `mypy --strict` all green.