### PR TITLE
feat(installer): package model — extras + resolve_package (slice 7.1)

### DIFF
--- a/installer/catalog.py
+++ b/installer/catalog.py
@@ -20,10 +20,15 @@ class Unit:
 @dataclass(frozen=True)
 class Package:
     """A named group of units installed together; holds the resolved Unit
-    objects, not raw id strings, so callers never re-join against the unit table."""
+    objects, not raw id strings, so callers never re-join against the unit table.
+    `extras` are source-relative paths (files or directories) to the runtime
+    support files a skill reads — schemas, gates, helper scripts — staged
+    alongside the units so an install is self-contained; default `()` keeps
+    `Package(name=..., units=...)` construction working for packages with none."""
 
     name: str
     units: tuple[Unit, ...]
+    extras: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -144,7 +149,28 @@ def _resolve(ref: str, by_id: dict[str, Unit], package: str) -> Unit:
 def _build_package(row: dict[str, object], by_id: dict[str, Unit]) -> Package:
     name: str = cast("str", row["name"])
     refs: list[str] = cast("list[str]", row["units"])
-    return Package(name=name, units=tuple(_resolve(ref, by_id, name) for ref in refs))
+    extras: tuple[str, ...] = tuple(cast("list[str]", row.get("extras", [])))
+    return Package(
+        name=name,
+        units=tuple(_resolve(ref, by_id, name) for ref in refs),
+        extras=extras,
+    )
+
+
+def resolve_package(catalog: Catalog, name: str) -> Package:
+    """Turn a package name into its declared Package — the unit set plus extras —
+    in one place, so callers select a curated group without re-scanning the
+    package table; an undeclared name fails loudly here rather than silently
+    resolving to nothing downstream."""
+    by_name: dict[str, Package] = {
+        package.name: package for package in catalog.packages
+    }
+    try:
+        return by_name[name]
+    except KeyError as missing:
+        raise ValueError(
+            f"package {name!r} is not declared in the catalog"
+        ) from missing
 
 
 def load_catalog(path: Path) -> Catalog:

--- a/installer/catalog.toml
+++ b/installer/catalog.toml
@@ -114,6 +114,9 @@ kind = "hook"
 name = "ruff-format"
 
 # --- packages (provisional curation; mirrors issue #74's examples) ---
+# extras = source-relative paths (files or dirs) to the runtime support files a
+# skill reads — schemas, gates, helper scripts — staged with the units so an
+# install is self-contained.
 [[packages]]
 name = "architect-pr"
 units = [
@@ -125,6 +128,7 @@ units = [
   "rule/design-principles",
   "rule/tdd",
 ]
+extras = ["schemas", "gates", "scripts/validate_return.py"]
 
 [[packages]]
 name = "lite-pr"
@@ -136,6 +140,7 @@ units = [
   "rule/design-principles",
   "rule/tdd",
 ]
+extras = ["gates"]
 
 [[packages]]
 name = "breakdown"

--- a/installer/tests/test_catalog.py
+++ b/installer/tests/test_catalog.py
@@ -13,6 +13,7 @@ from catalog import (
     list_rules,
     list_skills,
     load_catalog,
+    resolve_package,
     skill_unit_id,
 )
 
@@ -130,6 +131,33 @@ packages = ["pack"]
 """
 
 
+# One package declares extras (three paths, order significant) and another omits
+# the key entirely, so a single catalog pins both extras-order preservation and
+# the empty-tuple default.
+_EXTRAS_FIXTURE: Final[str] = """
+[[units]]
+kind = "skill"
+name = "alpha"
+
+[[units]]
+kind = "agent"
+name = "helper"
+
+[[packages]]
+name = "withextras"
+units = ["skill/alpha"]
+extras = ["schemas", "gates", "scripts/run.py"]
+
+[[packages]]
+name = "bare"
+units = ["agent/helper"]
+
+[[bundles]]
+name = "everything"
+packages = ["withextras", "bare"]
+"""
+
+
 def _write(tmp_path: Path, body: str) -> Path:
     catalog: Path = tmp_path / "catalog.toml"
     catalog.write_text(body, encoding="utf-8")
@@ -153,6 +181,44 @@ def test_load_catalog_populates_all_three_tiers(tmp_path: Path) -> None:
         in catalog.packages
     )
     assert Bundle(name="everything", packages=("pack",)) in catalog.bundles
+
+
+def test_load_catalog_parses_package_extras_in_declared_order(tmp_path: Path) -> None:
+    catalog: Catalog = load_catalog(_write(tmp_path, _EXTRAS_FIXTURE))
+
+    # extras parse into Package.extras as a tuple in declaration order; tuple
+    # equality is ordered, so a reorder would fail this.
+    assert (
+        Package(
+            name="withextras",
+            units=(Unit(kind="skill", name="alpha"),),
+            extras=("schemas", "gates", "scripts/run.py"),
+        )
+        in catalog.packages
+    )
+    # A package row with no extras key defaults to an empty tuple.
+    assert (
+        Package(name="bare", units=(Unit(kind="agent", name="helper"),))
+        in catalog.packages
+    )
+
+
+def test_resolve_package_returns_the_named_package(tmp_path: Path) -> None:
+    catalog: Catalog = load_catalog(_write(tmp_path, _EXTRAS_FIXTURE))
+
+    package: Package = resolve_package(catalog, "withextras")
+
+    assert package.name == "withextras"
+    assert package.extras == ("schemas", "gates", "scripts/run.py")
+    assert package.units == (Unit(kind="skill", name="alpha"),)
+
+
+def test_resolve_package_raises_naming_an_undeclared_package(tmp_path: Path) -> None:
+    catalog: Catalog = load_catalog(_write(tmp_path, _EXTRAS_FIXTURE))
+
+    # A name with no matching package fails loudly, naming the missing package.
+    with pytest.raises(ValueError, match="ghost"):
+        resolve_package(catalog, "ghost")
 
 
 def test_list_skills_returns_only_skill_names_sorted(tmp_path: Path) -> None:
@@ -204,6 +270,22 @@ def test_load_catalog_rejects_package_referencing_undeclared_unit(
 
     with pytest.raises(ValueError, match="skill/does-not-exist"):
         load_catalog(broken)
+
+
+def test_real_seed_resolve_package_carries_declared_extras_and_units() -> None:
+    # Smoke check against the shipped seed without hard-coding its full, growing
+    # extras list (the seed curation is provisional): membership checks confirm a
+    # named package resolves to its declared extras (the runtime support files
+    # staged with it) and still carries its units, so resolution didn't drop
+    # either tier. Exact extras order is pinned by the controlled-fixture test
+    # test_load_catalog_parses_package_extras_in_declared_order, so this smoke
+    # test does not re-pin it.
+    catalog: Catalog = load_catalog(SEED)
+    package: Package = resolve_package(catalog, "architect-pr")
+
+    assert "schemas" in package.extras  # a known declared extra is carried
+    assert "gates" in package.extras  # a second known extra is carried too
+    assert Unit(kind="skill", name="make-pr") in package.units
 
 
 def test_real_seed_loads_and_skills_are_sorted_skill_names() -> None:


### PR DESCRIPTION
Closes the model/parse layer of **slice 7.1** ("Packages + refcount + staged extras") from #74.

## What this adds
The catalog's three-tier model already resolved a package's `units`. This slice teaches the model two new things, and nothing more:

- **`extras` on a package** — `Package` gains `extras: tuple[str, ...] = ()`: source-relative paths (files or dirs) to the runtime support files a skill reads — schemas, gates, helper scripts — that must be staged alongside the units so an install is self-contained. The default `()` keeps existing `Package(name=…, units=…)` construction valid. `load_catalog`/`_build_package` parse an optional per-package `extras` array, preserving declaration order; an absent key → `()`.
- **`resolve_package(catalog, name) -> Package`** — turns a package name into its declared package (unit set + extras) in one place, failing loudly with a `ValueError` naming the package on an undeclared name (same loud-failure idiom as the existing `_resolve`).

The seed `catalog.toml` is extended with **real** extras: `architect-pr` → `["schemas", "gates", "scripts/validate_return.py"]`, `lite-pr` → `["gates"]`. Package curation stays provisional, as flagged in the catalog header.

## Scope
Model + parse only. Staging/copying extras into `~/.claude/at/` (7.3), refcount install/uninstall (7.2), and the packages TUI view (7.5) are deliberately **out of scope** for this slice.

## Tests / gates
- 4 new behavioral tests (TDD, right-reason RED each): extras parse + order + empty-default, `resolve_package` found + loud-failure, real-seed smoke.
- The real-seed smoke test uses membership checks (not an exact tuple), matching the file's documented "don't couple to the growing seed" convention.
- Full suite 117 → **121 passed**; `catalog.py` 100% covered. `ruff format --check`, `ruff check`, `mypy --strict` all clean.

+115 / −2 across `installer/catalog.py`, `installer/catalog.toml`, `installer/tests/test_catalog.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)