### PR TITLE
feat(installer): package refcount install/uninstall (slice 7.2)

### DIFF
--- a/installer/actions.py
+++ b/installer/actions.py
@@ -39,6 +39,7 @@ def _install_unit(
     new_state: State = State(
         version=state.version,
         units={**state.units, unit_id(unit): content_hash},
+        requesters=state.requesters,
     )
     save_state(new_state, state_root)
     return new_state

--- a/installer/actions.py
+++ b/installer/actions.py
@@ -17,6 +17,7 @@ from catalog import (
 )
 from constants import (
     AGENTS_DIRNAME,
+    DIRECT_REQUESTER,
     HOOKS_DIRNAME,
     RULES_DIRNAME,
     SKILLS_DIRNAME,
@@ -58,7 +59,7 @@ def _install_unit(
         else {
             **state.requesters,
             installed_id: _add_requester_token(
-                state.requesters.get(installed_id, ()), requester
+                tokens=state.requesters.get(installed_id, ()), token=requester
             ),
         }
     )
@@ -316,21 +317,21 @@ _UNINSTALL_BY_KIND: Final[dict[str, _UninstallAction]] = {
 }
 
 
-def _add_requester_token(tokens: tuple[str, ...], token: str) -> tuple[str, ...]:
+def _add_requester_token(*, tokens: tuple[str, ...], token: str) -> tuple[str, ...]:
     """Fold one requester token into a unit's set, de-duplicated and sorted, so
     crediting the same requester twice is idempotent and the stored order stays
     deterministic."""
     return tuple(sorted({*tokens, token}))
 
 
-def _drop_requester_token(tokens: tuple[str, ...], token: str) -> tuple[str, ...]:
+def _drop_requester_token(*, tokens: tuple[str, ...], token: str) -> tuple[str, ...]:
     """Withdraw one requester's claim on a unit, leaving the remaining tokens in
     their already-sorted order, so uninstall can read what survives without losing
     the deterministic ordering _add_requester_token established."""
     return tuple(item for item in tokens if item != token)
 
 
-def _set_requesters(state: State, *, unit: str, tokens: tuple[str, ...]) -> State:
+def _set_requesters(*, state: State, unit: str, tokens: tuple[str, ...]) -> State:
     """Replace one unit's requester set on a brand-new immutable State, carrying
     units and the other units' requesters forward untouched, so threading a package
     install never disturbs unrelated bookkeeping."""
@@ -339,15 +340,6 @@ def _set_requesters(state: State, *, unit: str, tokens: tuple[str, ...]) -> Stat
         units=state.units,
         requesters={**state.requesters, unit: tokens},
     )
-
-
-# Requester token marking a unit the user installed directly, outside any package.
-# Seeded by install_package when it adopts a pre-existing bare direct install (a
-# direct install_skill/etc. records no token of its own), so a later package
-# uninstall leaves this marker behind and keeps a unit the user still wants. The
-# leading "@" can never collide with a real package name, which is a bare catalog
-# identifier, so the marker never clashes with an actual requester.
-DIRECT_REQUESTER: Final[str] = "@direct"
 
 
 def install_package(
@@ -395,7 +387,9 @@ def install_package(
                 DIRECT_REQUESTER,
             )
             current = _set_requesters(
-                current, unit=identifier, tokens=_add_requester_token(base_tokens, name)
+                state=current,
+                unit=identifier,
+                tokens=_add_requester_token(tokens=base_tokens, token=name),
             )
             save_state(current, state_root)
     return current
@@ -420,10 +414,10 @@ def uninstall_package(
     for unit in package.units:
         identifier: str = unit_id(unit)
         remaining: tuple[str, ...] = _drop_requester_token(
-            current.requesters.get(identifier, ()), name
+            tokens=current.requesters.get(identifier, ()), token=name
         )
         if remaining:
-            current = _set_requesters(current, unit=identifier, tokens=remaining)
+            current = _set_requesters(state=current, unit=identifier, tokens=remaining)
             save_state(current, state_root)
         else:
             uninstall: _UninstallAction = _UNINSTALL_BY_KIND[unit.kind]

--- a/installer/actions.py
+++ b/installer/actions.py
@@ -2,8 +2,19 @@
 "install this skill" rather than wiring stage + link + record themselves."""
 
 from pathlib import Path
+from typing import Final, Protocol
 
-from catalog import Unit, agent_unit, hook_unit, rule_unit, skill_unit, unit_id
+from catalog import (
+    Catalog,
+    Package,
+    Unit,
+    agent_unit,
+    hook_unit,
+    resolve_package,
+    rule_unit,
+    skill_unit,
+    unit_id,
+)
 from constants import (
     AGENTS_DIRNAME,
     HOOKS_DIRNAME,
@@ -227,3 +238,80 @@ def uninstall_hook(
         state_root=state_root,
         state=state,
     )
+
+
+class _InstallAction(Protocol):
+    """One kind's install primitive: stage the named unit's source and link it live."""
+
+    def __call__(
+        self,
+        *,
+        name: str,
+        source_root: Path,
+        state_root: Path,
+        claude_root: Path,
+        state: State,
+    ) -> State: ...
+
+
+# Probe each unit factory with a throwaway "" name only for its .kind, so the kind
+# keys mirror catalog's source of truth instead of re-encoding the literals here.
+_INSTALL_BY_KIND: Final[dict[str, _InstallAction]] = {
+    skill_unit("").kind: install_skill,
+    agent_unit("").kind: install_agent,
+    rule_unit("").kind: install_rule,
+    hook_unit("").kind: install_hook,
+}
+
+
+def _add_requester_token(tokens: tuple[str, ...], token: str) -> tuple[str, ...]:
+    """Fold one requester token into a unit's set, de-duplicated and sorted, so
+    crediting the same requester twice is idempotent and the stored order stays
+    deterministic."""
+    return tuple(sorted({*tokens, token}))
+
+
+def _set_requesters(state: State, *, unit: str, tokens: tuple[str, ...]) -> State:
+    """Replace one unit's requester set on a brand-new immutable State, carrying
+    units and the other units' requesters forward untouched, so threading a package
+    install never disturbs unrelated bookkeeping."""
+    return State(
+        version=state.version,
+        units=state.units,
+        requesters={**state.requesters, unit: tokens},
+    )
+
+
+def install_package(
+    *,
+    name: str,
+    catalog: Catalog,
+    source_root: Path,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Install a named package by placing each member unit through its per-kind
+    install primitive and crediting the package name as that unit's requester, so a
+    unit records which package pulled it in. A unit already on disk — placed by an
+    earlier package — is not re-installed, only credited with the extra requester;
+    the evolving State is persisted after each unit so a partial run is recoverable."""
+    package: Package = resolve_package(catalog, name)
+    current: State = state
+    for unit in package.units:
+        identifier: str = unit_id(unit)
+        if identifier not in current.units:
+            install: _InstallAction = _INSTALL_BY_KIND[unit.kind]
+            current = install(
+                name=unit.name,
+                source_root=source_root,
+                state_root=state_root,
+                claude_root=claude_root,
+                state=current,
+            )
+        base_tokens: tuple[str, ...] = current.requesters.get(identifier, ())
+        current = _set_requesters(
+            current, unit=identifier, tokens=_add_requester_token(base_tokens, name)
+        )
+        save_state(current, state_root)
+    return current

--- a/installer/actions.py
+++ b/installer/actions.py
@@ -317,6 +317,15 @@ def _set_requesters(state: State, *, unit: str, tokens: tuple[str, ...]) -> Stat
     )
 
 
+# Requester token marking a unit the user installed directly, outside any package.
+# Seeded by install_package when it adopts a pre-existing bare direct install (a
+# direct install_skill/etc. records no token of its own), so a later package
+# uninstall leaves this marker behind and keeps a unit the user still wants. The
+# leading "@" can never collide with a real package name, which is a bare catalog
+# identifier, so the marker never clashes with an actual requester.
+DIRECT_REQUESTER: Final[str] = "@direct"
+
+
 def install_package(
     *,
     name: str,
@@ -344,7 +353,15 @@ def install_package(
                 claude_root=claude_root,
                 state=current,
             )
-        base_tokens: tuple[str, ...] = current.requesters.get(identifier, ())
+            base_tokens: tuple[str, ...] = ()
+        else:
+            # The unit was already on disk. Carry its existing requesters forward,
+            # but a bare direct install has none yet — seed the @direct marker so a
+            # later uninstall of this package leaves the marker behind and the unit
+            # the user installed directly survives instead of being reclaimed. The
+            # `or` only fires on an empty/absent set, so a unit another package
+            # already requested keeps that package and is never marked @direct.
+            base_tokens = current.requesters.get(identifier) or (DIRECT_REQUESTER,)
         current = _set_requesters(
             current, unit=identifier, tokens=_add_requester_token(base_tokens, name)
         )

--- a/installer/actions.py
+++ b/installer/actions.py
@@ -79,6 +79,11 @@ def _uninstall_unit(
             for existing_id, content in state.units.items()
             if existing_id != removed_id
         },
+        requesters={
+            existing_id: tokens
+            for existing_id, tokens in state.requesters.items()
+            if existing_id != removed_id
+        },
     )
     save_state(new_state, state_root)
     return new_state
@@ -264,11 +269,41 @@ _INSTALL_BY_KIND: Final[dict[str, _InstallAction]] = {
 }
 
 
+class _UninstallAction(Protocol):
+    """One kind's uninstall primitive: drop the named unit's link and staged copy."""
+
+    def __call__(
+        self,
+        *,
+        name: str,
+        state_root: Path,
+        claude_root: Path,
+        state: State,
+    ) -> State: ...
+
+
+# Mirror _INSTALL_BY_KIND on the removal side, keyed off the same factory probes so
+# install and uninstall agree on the kind tokens without re-encoding them.
+_UNINSTALL_BY_KIND: Final[dict[str, _UninstallAction]] = {
+    skill_unit("").kind: uninstall_skill,
+    agent_unit("").kind: uninstall_agent,
+    rule_unit("").kind: uninstall_rule,
+    hook_unit("").kind: uninstall_hook,
+}
+
+
 def _add_requester_token(tokens: tuple[str, ...], token: str) -> tuple[str, ...]:
     """Fold one requester token into a unit's set, de-duplicated and sorted, so
     crediting the same requester twice is idempotent and the stored order stays
     deterministic."""
     return tuple(sorted({*tokens, token}))
+
+
+def _drop_requester_token(tokens: tuple[str, ...], token: str) -> tuple[str, ...]:
+    """Withdraw one requester's claim on a unit, leaving the remaining tokens in
+    their already-sorted order, so uninstall can read what survives without losing
+    the deterministic ordering _add_requester_token established."""
+    return tuple(item for item in tokens if item != token)
 
 
 def _set_requesters(state: State, *, unit: str, tokens: tuple[str, ...]) -> State:
@@ -314,4 +349,39 @@ def install_package(
             current, unit=identifier, tokens=_add_requester_token(base_tokens, name)
         )
         save_state(current, state_root)
+    return current
+
+
+def uninstall_package(
+    *,
+    name: str,
+    catalog: Catalog,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Uninstall a named package by withdrawing its claim on each member unit and
+    physically removing a unit only when its last requester is gone, so a unit a
+    second package still requires stays on disk and merely loses this package from
+    its requester set. This owns the refcount invariant: a unit's disk presence and
+    its state entry persist exactly while at least one package still requires it.
+    The evolving State is persisted after each unit so a partial run is recoverable."""
+    package: Package = resolve_package(catalog, name)
+    current: State = state
+    for unit in package.units:
+        identifier: str = unit_id(unit)
+        remaining: tuple[str, ...] = _drop_requester_token(
+            current.requesters.get(identifier, ()), name
+        )
+        if remaining:
+            current = _set_requesters(current, unit=identifier, tokens=remaining)
+            save_state(current, state_root)
+        else:
+            uninstall: _UninstallAction = _UNINSTALL_BY_KIND[unit.kind]
+            current = uninstall(
+                name=unit.name,
+                state_root=state_root,
+                claude_root=claude_root,
+                state=current,
+            )
     return current

--- a/installer/actions.py
+++ b/installer/actions.py
@@ -35,22 +35,37 @@ def _install_unit(
     link_path: Path,
     state_root: Path,
     state: State,
+    requester: str | None = None,
 ) -> State:
     """Place one unit on disk by staging its source then linking the staged copy
     live, so the staged tree stays the single source of truth behind the symlink.
 
     Persists the updated state to state_root (via save_state) and returns a brand-new
     immutable State recording the unit's content hash; the passed-in state is never
-    mutated."""
+    mutated. When requester is given, the SAME write also credits that requester to the
+    unit, so a package install records the unit and its requester atomically and a crash
+    can never leave the unit present-but-uncredited. A direct install (requester None)
+    carries the existing requesters forward untouched, adding no token."""
     staged_path: Path = stage_unit(
         unit=unit, source=source, staged_root=state_root / STAGED_DIRNAME
     )
     link_unit(staged_path=staged_path, link_path=link_path)
     content_hash: str = hash_unit(staged_path)
+    installed_id: str = unit_id(unit)
+    new_requesters: dict[str, tuple[str, ...]] = (
+        state.requesters
+        if requester is None
+        else {
+            **state.requesters,
+            installed_id: _add_requester_token(
+                state.requesters.get(installed_id, ()), requester
+            ),
+        }
+    )
     new_state: State = State(
         version=state.version,
-        units={**state.units, unit_id(unit): content_hash},
-        requesters=state.requesters,
+        units={**state.units, installed_id: content_hash},
+        requesters=new_requesters,
     )
     save_state(new_state, state_root)
     return new_state
@@ -96,6 +111,7 @@ def install_skill(
     state_root: Path,
     claude_root: Path,
     state: State,
+    requester: str | None = None,
 ) -> State:
     """Install the named skill, staging its source tree and linking it live under
     ~/.claude/skills/<name>."""
@@ -105,6 +121,7 @@ def install_skill(
         link_path=claude_root / SKILLS_DIRNAME / name,
         state_root=state_root,
         state=state,
+        requester=requester,
     )
 
 
@@ -115,6 +132,7 @@ def install_agent(
     state_root: Path,
     claude_root: Path,
     state: State,
+    requester: str | None = None,
 ) -> State:
     """Install the named agent, staging its single "<name>.md" source and linking
     it live under ~/.claude/agents/. The staged copy is keyed by bare
@@ -125,6 +143,7 @@ def install_agent(
         link_path=claude_root / AGENTS_DIRNAME / f"{name}.md",
         state_root=state_root,
         state=state,
+        requester=requester,
     )
 
 
@@ -135,6 +154,7 @@ def install_rule(
     state_root: Path,
     claude_root: Path,
     state: State,
+    requester: str | None = None,
 ) -> State:
     """Install the named rule, staging its single "<name>.md" source and linking
     it live under ~/.claude/rules/. The staged copy is keyed by bare
@@ -145,6 +165,7 @@ def install_rule(
         link_path=claude_root / RULES_DIRNAME / f"{name}.md",
         state_root=state_root,
         state=state,
+        requester=requester,
     )
 
 
@@ -155,6 +176,7 @@ def install_hook(
     state_root: Path,
     claude_root: Path,
     state: State,
+    requester: str | None = None,
 ) -> State:
     """Install the named hook, staging its single "<name>.sh" source and linking
     it live under ~/.claude/hooks/. The staged copy is keyed by bare
@@ -170,6 +192,7 @@ def install_hook(
         link_path=claude_root / HOOKS_DIRNAME / f"{name}.sh",
         state_root=state_root,
         state=state,
+        requester=requester,
     )
     merge_hook_settings(name=name, source_root=source_root, claude_root=claude_root)
     return new_state
@@ -256,6 +279,7 @@ class _InstallAction(Protocol):
         state_root: Path,
         claude_root: Path,
         state: State,
+        requester: str | None = None,
     ) -> State: ...
 
 
@@ -337,14 +361,20 @@ def install_package(
 ) -> State:
     """Install a named package by placing each member unit through its per-kind
     install primitive and crediting the package name as that unit's requester, so a
-    unit records which package pulled it in. A unit already on disk — placed by an
-    earlier package — is not re-installed, only credited with the extra requester;
-    the evolving State is persisted after each unit so a partial run is recoverable."""
+    unit records which package pulled it in. A newly placed unit records the package
+    requester atomically in the same State write that records the unit, so a crash can
+    never leave it present-but-uncredited and later mislabel it @direct. A unit already
+    on disk — placed by an earlier package — is not re-installed, only credited with the
+    extra requester; the evolving State is persisted after each unit so a partial run is
+    recoverable."""
     package: Package = resolve_package(catalog, name)
     current: State = state
     for unit in package.units:
         identifier: str = unit_id(unit)
         if identifier not in current.units:
+            # First placement: the installer records the unit AND credits the package
+            # as its requester in one State write, closing the crash window between
+            # recording the unit and recording who asked for it.
             install: _InstallAction = _INSTALL_BY_KIND[unit.kind]
             current = install(
                 name=unit.name,
@@ -352,8 +382,8 @@ def install_package(
                 state_root=state_root,
                 claude_root=claude_root,
                 state=current,
+                requester=name,
             )
-            base_tokens: tuple[str, ...] = ()
         else:
             # The unit was already on disk. Carry its existing requesters forward,
             # but a bare direct install has none yet — seed the @direct marker so a
@@ -361,11 +391,13 @@ def install_package(
             # the user installed directly survives instead of being reclaimed. The
             # `or` only fires on an empty/absent set, so a unit another package
             # already requested keeps that package and is never marked @direct.
-            base_tokens = current.requesters.get(identifier) or (DIRECT_REQUESTER,)
-        current = _set_requesters(
-            current, unit=identifier, tokens=_add_requester_token(base_tokens, name)
-        )
-        save_state(current, state_root)
+            base_tokens: tuple[str, ...] = current.requesters.get(identifier) or (
+                DIRECT_REQUESTER,
+            )
+            current = _set_requesters(
+                current, unit=identifier, tokens=_add_requester_token(base_tokens, name)
+            )
+            save_state(current, state_root)
     return current
 
 

--- a/installer/constants.py
+++ b/installer/constants.py
@@ -8,3 +8,11 @@ SKILLS_DIRNAME: Final[str] = "skills"
 AGENTS_DIRNAME: Final[str] = "agents"
 RULES_DIRNAME: Final[str] = "rules"
 HOOKS_DIRNAME: Final[str] = "hooks"
+
+# Requester token marking a unit the user installed directly, outside any package.
+# Seeded by install_package when it adopts a pre-existing bare direct install (a
+# direct install_skill/etc. records no token of its own), so a later package
+# uninstall leaves this marker behind and keeps a unit the user still wants. The
+# leading "@" can never collide with a real package name, which is a bare catalog
+# identifier, so the marker never clashes with an actual requester.
+DIRECT_REQUESTER: Final[str] = "@direct"

--- a/installer/state.py
+++ b/installer/state.py
@@ -1,6 +1,6 @@
 import json
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final, cast
 
@@ -16,6 +16,9 @@ class State:
 
     version: int
     units: dict[str, str]
+    # unit id -> the sorted tuple of tokens that requested it; declared last with a
+    # default so existing State(version=..., units=...) call sites keep working.
+    requesters: dict[str, tuple[str, ...]] = field(default_factory=dict)
 
 
 def default_state() -> State:
@@ -28,6 +31,10 @@ def save_state(state: State, root: Path) -> None:
     root.mkdir(parents=True, exist_ok=True)
     state_file: Path = root / STATE_FILENAME
     payload: dict[str, object] = {"version": state.version, "units": state.units}
+    # Omit an empty requesters map so a no-requester store stays byte-identical to
+    # what prior versions wrote; committed e2e golden snapshots pin that exact JSON.
+    if state.requesters:
+        payload["requesters"] = state.requesters
     # Write a sibling temp file and atomically swap it in, so a failed write
     # leaves the prior store intact rather than a half-written file.
     with tempfile.NamedTemporaryFile(
@@ -53,6 +60,14 @@ def load_state(root: Path) -> State:
             raw: dict[str, object] = json.load(handle)
         version: int = cast("int", raw["version"])
         units: dict[str, str] = cast("dict[str, str]", raw["units"])
-        return State(version=version, units=units)
+        # A store written before this field has no "requesters" key; default to {}.
+        # JSON stores each token list as an array, so rebuild tuples on the way in.
+        stored_requesters: dict[str, list[str]] = cast(
+            "dict[str, list[str]]", raw.get("requesters", {})
+        )
+        requesters: dict[str, tuple[str, ...]] = {
+            unit_id: tuple(tokens) for unit_id, tokens in stored_requesters.items()
+        }
+        return State(version=version, units=units, requesters=requesters)
     root.mkdir(parents=True, exist_ok=True)
     return default_state()

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -746,3 +746,67 @@ packages = ["pack-one", "pack-two"]
     # skill/only-two belongs only to pack-two and is left untouched.
     assert skill_unit_id("only-two") in result.units
     assert result.requesters[skill_unit_id("only-two")] == ("pack-two",)
+
+
+def test_uninstall_package_keeps_a_directly_installed_unit(tmp_path: Path) -> None:
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "alpha"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text("# Alpha Skill\n", encoding="utf-8")
+
+    # A controlled catalog declaring the one unit and a package that also contains
+    # it, loaded through the real boundary so the package install/uninstall resolve
+    # its members exactly as production will.
+    catalog_body: str = """
+[[units]]
+kind = "skill"
+name = "alpha"
+
+[[packages]]
+name = "pack"
+units = ["skill/alpha"]
+
+[[bundles]]
+name = "everything"
+packages = ["pack"]
+"""
+    catalog_path: Path = tmp_path / "catalog.toml"
+    catalog_path.write_text(catalog_body, encoding="utf-8")
+    catalog: Catalog = load_catalog(catalog_path)
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    # The user installs alpha directly first (a bare direct install records no
+    # requester token of its own), then a package containing alpha is layered over
+    # the already-present unit, then that package is dropped again.
+    state_after_direct: State = install_skill(
+        name="alpha",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+    state_after_pack: State = install_package(
+        name="pack",
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state_after_direct,
+    )
+    result: State = uninstall_package(
+        name="pack",
+        catalog=catalog,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state_after_pack,
+    )
+
+    # The user still wants alpha, so dropping the package must leave it fully
+    # installed: a direct-install marker outlives the package's requester rather
+    # than letting the package uninstall reclaim the directly-installed unit.
+    assert skill_unit_id("alpha") in result.units
+    assert (state_root / "staged" / "skill" / "alpha").is_dir()
+    assert (claude_root / "skills" / "alpha").is_symlink()
+    assert len(result.requesters[skill_unit_id("alpha")]) >= 1

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from actions import (
     install_agent,
     install_hook,
+    install_package,
     install_rule,
     install_skill,
     uninstall_agent,
@@ -12,7 +13,7 @@ from actions import (
     uninstall_rule,
     uninstall_skill,
 )
-from catalog import agent_unit_id, rule_unit_id, skill_unit_id
+from catalog import Catalog, agent_unit_id, load_catalog, rule_unit_id, skill_unit_id
 from hashing import hash_unit
 from state import State, load_state
 
@@ -590,3 +591,65 @@ def test_uninstall_hook_tolerates_missing_settings_file(tmp_path: Path) -> None:
 
     assert not (claude_root / "hooks" / f"{name}.sh").is_symlink()
     assert not (claude_root / "settings.json").exists()
+
+
+def test_install_package_installs_each_unit_and_records_package_requester(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "alpha"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text("# Alpha Skill\n", encoding="utf-8")
+    agent_source: Path = source_root / "agents" / "helper.md"
+    agent_source.parent.mkdir(parents=True)
+    agent_source.write_text("# Helper Agent\n", encoding="utf-8")
+
+    # A controlled catalog declaring the two units of different kinds and a package
+    # grouping both, loaded through the real boundary so the package install
+    # resolves its members exactly as production will.
+    catalog_body: str = """
+[[units]]
+kind = "skill"
+name = "alpha"
+
+[[units]]
+kind = "agent"
+name = "helper"
+
+[[packages]]
+name = "pack"
+units = ["skill/alpha", "agent/helper"]
+
+[[bundles]]
+name = "everything"
+packages = ["pack"]
+"""
+    catalog_path: Path = tmp_path / "catalog.toml"
+    catalog_path.write_text(catalog_body, encoding="utf-8")
+    catalog: Catalog = load_catalog(catalog_path)
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    result: State = install_package(
+        name="pack",
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    # Both members are physically placed: each kind's staged copy plus its live
+    # symlink (a skill stages as a directory, an agent as a single file).
+    assert (state_root / "staged" / "skill" / "alpha").is_dir()
+    assert (state_root / "staged" / "agent" / "helper").is_file()
+    assert (claude_root / "skills" / "alpha").is_symlink()
+    assert (claude_root / "agents" / "helper.md").is_symlink()
+
+    assert skill_unit_id("alpha") in result.units
+    assert agent_unit_id("helper") in result.units
+
+    # The package name is recorded as every installed unit's requester.
+    assert result.requesters[skill_unit_id("alpha")] == ("pack",)
+    assert result.requesters[agent_unit_id("helper")] == ("pack",)

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -3,6 +3,7 @@ import stat
 from pathlib import Path
 
 from actions import (
+    DIRECT_REQUESTER,
     install_agent,
     install_hook,
     install_package,
@@ -132,7 +133,6 @@ def test_install_skill_preserves_existing_requesters_of_other_units(
     # A direct install adds no requester token of its own, so the only requesters
     # entry that should survive is the unrelated unit's prior one.
     assert result.requesters == {"agent/reviewer": ("architect-pr",)}
-    assert result.requesters["agent/reviewer"] == ("architect-pr",)
     assert skill_unit_id("demo-skill") in result.units
 
 
@@ -809,4 +809,4 @@ packages = ["pack"]
     assert skill_unit_id("alpha") in result.units
     assert (state_root / "staged" / "skill" / "alpha").is_dir()
     assert (claude_root / "skills" / "alpha").is_symlink()
-    assert len(result.requesters[skill_unit_id("alpha")]) >= 1
+    assert result.requesters[skill_unit_id("alpha")] == (DIRECT_REQUESTER,)

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -3,7 +3,6 @@ import stat
 from pathlib import Path
 
 from actions import (
-    DIRECT_REQUESTER,
     install_agent,
     install_hook,
     install_package,
@@ -16,6 +15,7 @@ from actions import (
     uninstall_skill,
 )
 from catalog import Catalog, agent_unit_id, load_catalog, rule_unit_id, skill_unit_id
+from constants import DIRECT_REQUESTER
 from hashing import hash_unit
 from state import State, load_state
 

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -103,6 +103,37 @@ def test_install_skill_records_staged_content_hash_as_unit_value(
     assert recorded_hash != ""
 
 
+def test_install_skill_preserves_existing_requesters_of_other_units(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "demo-skill"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text("# Demo Skill\n", encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    prior_state: State = State(
+        version=1,
+        units={"agent/reviewer": "somehash"},
+        requesters={"agent/reviewer": ("architect-pr",)},
+    )
+
+    result: State = install_skill(
+        name="demo-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=prior_state,
+    )
+
+    # A direct install adds no requester token of its own, so the only requesters
+    # entry that should survive is the unrelated unit's prior one.
+    assert result.requesters == {"agent/reviewer": ("architect-pr",)}
+    assert result.requesters["agent/reviewer"] == ("architect-pr",)
+    assert skill_unit_id("demo-skill") in result.units
+
+
 def test_uninstall_skill_undoes_install_and_forgets_unit(tmp_path: Path) -> None:
     source_root: Path = tmp_path / "repo"
     skill_source: Path = source_root / "skills" / "demo-skill"

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -10,6 +10,7 @@ from actions import (
     install_skill,
     uninstall_agent,
     uninstall_hook,
+    uninstall_package,
     uninstall_rule,
     uninstall_skill,
 )
@@ -653,3 +654,95 @@ packages = ["pack"]
     # The package name is recorded as every installed unit's requester.
     assert result.requesters[skill_unit_id("alpha")] == ("pack",)
     assert result.requesters[agent_unit_id("helper")] == ("pack",)
+
+
+def test_uninstall_package_keeps_unit_still_required_by_another_package(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    for skill_name in ("shared", "only-one", "only-two"):
+        skill_source: Path = source_root / "skills" / skill_name
+        skill_source.mkdir(parents=True)
+        (skill_source / "SKILL.md").write_text(
+            f"# {skill_name} Skill\n", encoding="utf-8"
+        )
+
+    # Two packages that share one unit (skill/shared) and each own one private unit,
+    # loaded through the real boundary so the uninstall resolves members exactly as
+    # production will.
+    catalog_body: str = """
+[[units]]
+kind = "skill"
+name = "shared"
+
+[[units]]
+kind = "skill"
+name = "only-one"
+
+[[units]]
+kind = "skill"
+name = "only-two"
+
+[[packages]]
+name = "pack-one"
+units = ["skill/shared", "skill/only-one"]
+
+[[packages]]
+name = "pack-two"
+units = ["skill/shared", "skill/only-two"]
+
+[[bundles]]
+name = "everything"
+packages = ["pack-one", "pack-two"]
+"""
+    catalog_path: Path = tmp_path / "catalog.toml"
+    catalog_path.write_text(catalog_body, encoding="utf-8")
+    catalog: Catalog = load_catalog(catalog_path)
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    # Install both packages, threading state, so skill/shared ends up credited to
+    # both pack-one and pack-two while each private unit has a single requester.
+    state_after_pack_one: State = install_package(
+        name="pack-one",
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+    state_after_both: State = install_package(
+        name="pack-two",
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state_after_pack_one,
+    )
+
+    result: State = uninstall_package(
+        name="pack-one",
+        catalog=catalog,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state_after_both,
+    )
+
+    # skill/shared survives: pack-two still requires it, so it stays fully installed
+    # and only loses pack-one from its requester set.
+    assert (state_root / "staged" / "skill" / "shared").is_dir()
+    assert (claude_root / "skills" / "shared").is_symlink()
+    assert skill_unit_id("shared") in result.units
+    assert result.requesters[skill_unit_id("shared")] == ("pack-two",)
+
+    # skill/only-one was pack-one's alone: its last requester is gone, so it is
+    # physically removed and forgotten entirely.
+    assert not (state_root / "staged" / "skill" / "only-one").exists()
+    assert not (claude_root / "skills" / "only-one").is_symlink()
+    assert skill_unit_id("only-one") not in result.units
+    assert skill_unit_id("only-one") not in result.requesters
+
+    # skill/only-two belongs only to pack-two and is left untouched.
+    assert skill_unit_id("only-two") in result.units
+    assert result.requesters[skill_unit_id("only-two")] == ("pack-two",)

--- a/installer/tests/test_state.py
+++ b/installer/tests/test_state.py
@@ -28,6 +28,19 @@ def test_save_then_load_round_trips_recorded_state(tmp_path: Path) -> None:
     assert loaded == saved
 
 
+def test_save_then_load_round_trips_requesters_as_tuples(tmp_path: Path) -> None:
+    saved: State = State(
+        version=STATE_VERSION,
+        units={"skill/make-pr": "deadbeef"},
+        requesters={"skill/make-pr": ("@direct", "architect-pr")},
+    )
+
+    save_state(saved, tmp_path)
+    loaded: State = load_state(tmp_path)
+
+    assert loaded == saved
+
+
 def test_save_is_atomic_failed_replace_keeps_prior_state(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Implements the refcount engine for **slice 7.2** ("Packages + refcount + staged extras") from #74: *"state tracks which packages requested each unit; install bumps, uninstall decrements, unit removed only at 0."*

## What this adds
- **`State.requesters`** — a `dict[str, tuple[str, ...]]` mapping a unit id → the sorted tuple of tokens that requested it. Persisted **omit-empty** (the key is written only when non-empty, so a no-package `state.json` stays byte-identical to today and the committed e2e golden snapshots need no re-bless), round-tripped (JSON arrays → tuples on load), and backward-compatible (a legacy `state.json` with no `requesters` key loads as `{}`).
- **`install_package(name, catalog, …)`** — resolves the package (via 7.1's `resolve_package`) and installs each member unit through the existing per-kind installer (a kind→wrapper dispatch, so a hook member's `settings.json` merge is handled), crediting the package as each unit's requester. A new unit records the unit **and** its requester in one atomic `State` write.
- **`uninstall_package(name, catalog, …)`** — withdraws the package's claim on each unit and physically removes a unit **only when its last requester is gone**. A unit a second package still needs stays on disk (the headline: *"Shared parts are counted, not double-removed"*).
- **`@direct` marker** — `install_package` seeds it when it adopts a pre-existing bare direct install, so uninstalling a package never reclaims a unit the user installed directly. Direct `install_skill`/etc. record no token of their own (so `at update` re-staging preserves a unit's package requesters exactly).

## Scope
Engine only. CLI `--package` (8.2), the packages TUI (7.5), and staging a package's `extras` to disk (7.3) are later slices.

## How it was built (TDD, /make-pr architect)
Five RED→GREEN behaviors (state round-trip → install carry-through → install_package → uninstall_package refcount → direct+package survival), each a right-reason RED reproduced green by the architect. Reviewer + critic pass on the green diff: critic **achieved**; one reviewer MAJOR — a two-write crash window that could mislabel a package unit as `@direct` — fixed by recording the requester atomically with the unit, then re-reviewed clean.

## Tests / gates
- 6 new tests; suite **122 → 126 passed**, e2e goldens green (unchanged).
- `ruff format --check`, `ruff check`, `mypy --strict` all clean.

+493 / −6 across `installer/state.py`, `installer/actions.py`, `installer/tests/test_state.py`, `installer/tests/test_actions.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)