### PR TITLE
docs(rules): make python.md keyword-only absolute (* first, no tiny-helper exception)

### DIFF
--- a/rules/python.md
+++ b/rules/python.md
@@ -46,10 +46,12 @@ unpack into single annotated assignments when the types matter.
 
 Prefer functions over classes unless state is needed. If a method doesn't use `self`, prefer a module-level function; use `@staticmethod` only when it must conceptually live on the class.
 
-- Use keyword-only arguments for public functions and helpers when named arguments improve
-  call-site clarity. Exceptions: `self`/`cls`, dunder methods, protocol/callback signatures,
-  pytest fixture injection, framework-required signatures, and tiny private helpers where
-  positional use is clearer.
+- All parameters of project functions and helpers are keyword-only: `*` is the FIRST
+  parameter of every `def`. Apply this uniformly — there is NO exception for "tiny" or
+  private helpers, and no "clearer positionally" judgement call. Exempt ONLY `self`/`cls`,
+  dunder methods, `Protocol`/callback `__call__` signatures, pytest fixture injection, and
+  framework-required signatures. When surrounding code is positional, the rule still wins for
+  new or changed code: fix the old signature or flag it — never copy the violation.
 - Never use mutable defaults (`list`, `dict`, `set`). Use `None` sentinel with `if arg is None: arg = []`
 - Sensible immutable defaults (strings, numbers, booleans, `None`, tuples) are fine
 - Return frozen dataclasses for multi-value returns, never bare tuples — return a

--- a/skills/make-pr-lite/rules/python.md
+++ b/skills/make-pr-lite/rules/python.md
@@ -46,10 +46,12 @@ unpack into single annotated assignments when the types matter.
 
 Prefer functions over classes unless state is needed. If a method doesn't use `self`, prefer a module-level function; use `@staticmethod` only when it must conceptually live on the class.
 
-- Use keyword-only arguments for public functions and helpers when named arguments improve
-  call-site clarity. Exceptions: `self`/`cls`, dunder methods, protocol/callback signatures,
-  pytest fixture injection, framework-required signatures, and tiny private helpers where
-  positional use is clearer.
+- All parameters of project functions and helpers are keyword-only: `*` is the FIRST
+  parameter of every `def`. Apply this uniformly — there is NO exception for "tiny" or
+  private helpers, and no "clearer positionally" judgement call. Exempt ONLY `self`/`cls`,
+  dunder methods, `Protocol`/callback `__call__` signatures, pytest fixture injection, and
+  framework-required signatures. When surrounding code is positional, the rule still wins for
+  new or changed code: fix the old signature or flag it — never copy the violation.
 - Never use mutable defaults (`list`, `dict`, `set`). Use `None` sentinel with `if arg is None: arg = []`
 - Sensible immutable defaults (strings, numbers, booleans, `None`, tuples) are fine
 - Return frozen dataclasses for multi-value returns, never bare tuples — return a

--- a/skills/make-pr/rules/python.md
+++ b/skills/make-pr/rules/python.md
@@ -46,10 +46,12 @@ unpack into single annotated assignments when the types matter.
 
 Prefer functions over classes unless state is needed. If a method doesn't use `self`, prefer a module-level function; use `@staticmethod` only when it must conceptually live on the class.
 
-- Use keyword-only arguments for public functions and helpers when named arguments improve
-  call-site clarity. Exceptions: `self`/`cls`, dunder methods, protocol/callback signatures,
-  pytest fixture injection, framework-required signatures, and tiny private helpers where
-  positional use is clearer.
+- All parameters of project functions and helpers are keyword-only: `*` is the FIRST
+  parameter of every `def`. Apply this uniformly — there is NO exception for "tiny" or
+  private helpers, and no "clearer positionally" judgement call. Exempt ONLY `self`/`cls`,
+  dunder methods, `Protocol`/callback `__call__` signatures, pytest fixture injection, and
+  framework-required signatures. When surrounding code is positional, the rule still wins for
+  new or changed code: fix the old signature or flag it — never copy the violation.
 - Never use mutable defaults (`list`, `dict`, `set`). Use `None` sentinel with `if arg is None: arg = []`
 - Sensible immutable defaults (strings, numbers, booleans, `None`, tuples) are fine
 - Return frozen dataclasses for multi-value returns, never bare tuples — return a


### PR DESCRIPTION
Closes the `python.md` loophole that let PR #110 (slice 7.2) ship positional helpers and a `*`-not-first signature past the worker-coder conform-gate **and** the reviewer's rule pass.

## The loophole
The keyword-only rule was discretionary — *"Use keyword-only arguments … when named arguments improve call-site clarity. Exceptions: … tiny private helpers where positional use is clearer."* So `_add_requester_token(tokens, token)` (a tiny private helper) was *allowed* by the literal text, and "`*` must be **first**" (so even a "subject" arg is keyword-only) wasn't stated at all. Agents also matched surrounding non-conforming code (positional private helpers in `catalog.py`).

## The change
Rewrites the bullet to be absolute:
- `*` is the **first** parameter of every `def` — all params keyword-only.
- **No** "tiny / private helper" or "clearer positionally" exception.
- Exempt ONLY `self`/`cls`, dunders, `Protocol`/callback `__call__`, pytest fixtures, framework-required signatures.
- **The rule beats surrounding precedent** for new/changed code — fix or flag the old positional signature, don't copy it.

Applied identically to the canonical `rules/python.md` and the two drift-guarded bundled copies (`skills/make-pr/rules/python.md`, `skills/make-pr-lite/rules/python.md`), which stay byte-identical.

## Companion
This tightens the *rule text*. Mechanical enforcement is #111 (wire [pyguard](https://github.com/a1f/pyguard) into the gates) — the durable fix so this isn't left to LLM review. Text + tool together close the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)