### PR TITLE
feat(installer): stage + refcount package extras (slice 7.3)

### DIFF
--- a/installer/actions.py
+++ b/installer/actions.py
@@ -24,7 +24,14 @@ from constants import (
     STAGED_DIRNAME,
 )
 from hashing import hash_unit
-from placement import link_unit, stage_extra, stage_unit, unlink_unit, unstage_unit
+from placement import (
+    link_unit,
+    stage_extra,
+    stage_unit,
+    unlink_unit,
+    unstage_extra,
+    unstage_unit,
+)
 from settings import merge_hook_settings, unmerge_hook_settings
 from state import State, save_state
 
@@ -67,6 +74,7 @@ def _install_unit(
         version=state.version,
         units={**state.units, installed_id: content_hash},
         requesters=new_requesters,
+        extras=state.extras,
     )
     save_state(new_state, state_root)
     return new_state
@@ -100,6 +108,7 @@ def _uninstall_unit(
             for existing_id, tokens in state.requesters.items()
             if existing_id != removed_id
         },
+        extras=state.extras,
     )
     save_state(new_state, state_root)
     return new_state
@@ -356,6 +365,23 @@ def _set_extras(*, state: State, extra: str, tokens: tuple[str, ...]) -> State:
     )
 
 
+def _forget_extra(*, state: State, extra: str) -> State:
+    """Drop one extra key entirely from a brand-new immutable State, carrying units,
+    requesters, and the other extras forward untouched, so removing an extra whose
+    last requester is gone never disturbs unrelated bookkeeping — the extras analogue
+    of how the unit loop rebuilds state without the removed unit."""
+    return State(
+        version=state.version,
+        units=state.units,
+        requesters=state.requesters,
+        extras={
+            relpath: tokens
+            for relpath, tokens in state.extras.items()
+            if relpath != extra
+        },
+    )
+
+
 def install_package(
     *,
     name: str,
@@ -437,7 +463,10 @@ def uninstall_package(
     second package still requires stays on disk and merely loses this package from
     its requester set. This owns the refcount invariant: a unit's disk presence and
     its state entry persist exactly while at least one package still requires it.
-    The evolving State is persisted after each unit so a partial run is recoverable."""
+    After the units, each declared extra is refcounted the same way — kept while
+    another package still requires it, physically removed once its last requester is
+    gone. The evolving State is persisted after each unit and extra so a partial run
+    is recoverable."""
     package: Package = resolve_package(catalog, name)
     current: State = state
     for unit in package.units:
@@ -456,4 +485,18 @@ def uninstall_package(
                 claude_root=claude_root,
                 state=current,
             )
+    for relpath in package.extras:
+        # Refcount each extra exactly as the unit loop above refcounts units:
+        # withdraw this package's claim, keep the staged copy while another package
+        # still requires it, or physically remove it once its last requester is gone.
+        # State is persisted after each extra so a partial run is recoverable.
+        remaining_extra: tuple[str, ...] = _drop_requester_token(
+            tokens=current.extras.get(relpath, ()), token=name
+        )
+        if remaining_extra:
+            current = _set_extras(state=current, extra=relpath, tokens=remaining_extra)
+        else:
+            unstage_extra(relpath=relpath, state_root=state_root)
+            current = _forget_extra(state=current, extra=relpath)
+        save_state(current, state_root)
     return current

--- a/installer/actions.py
+++ b/installer/actions.py
@@ -24,7 +24,7 @@ from constants import (
     STAGED_DIRNAME,
 )
 from hashing import hash_unit
-from placement import link_unit, stage_unit, unlink_unit, unstage_unit
+from placement import link_unit, stage_extra, stage_unit, unlink_unit, unstage_unit
 from settings import merge_hook_settings, unmerge_hook_settings
 from state import State, save_state
 
@@ -333,12 +333,26 @@ def _drop_requester_token(*, tokens: tuple[str, ...], token: str) -> tuple[str, 
 
 def _set_requesters(*, state: State, unit: str, tokens: tuple[str, ...]) -> State:
     """Replace one unit's requester set on a brand-new immutable State, carrying
-    units and the other units' requesters forward untouched, so threading a package
-    install never disturbs unrelated bookkeeping."""
+    units, extras, and the other units' requesters forward untouched, so threading a
+    package install never disturbs unrelated bookkeeping."""
     return State(
         version=state.version,
         units=state.units,
         requesters={**state.requesters, unit: tokens},
+        extras=state.extras,
+    )
+
+
+def _set_extras(*, state: State, extra: str, tokens: tuple[str, ...]) -> State:
+    """Replace one extra's requester set on a brand-new immutable State, carrying
+    units, requesters, and the other extras forward untouched, so recording one
+    extra never disturbs unrelated bookkeeping — the extras analogue of
+    _set_requesters."""
+    return State(
+        version=state.version,
+        units=state.units,
+        requesters=state.requesters,
+        extras={**state.extras, extra: tokens},
     )
 
 
@@ -358,7 +372,9 @@ def install_package(
     never leave it present-but-uncredited and later mislabel it @direct. A unit already
     on disk — placed by an earlier package — is not re-installed, only credited with the
     extra requester; the evolving State is persisted after each unit so a partial run is
-    recoverable."""
+    recoverable. After the units, each declared extra (a support file or directory) is
+    staged to the state root at its source-relative path and credited to the package the
+    same way, with the same per-step persistence."""
     package: Package = resolve_package(catalog, name)
     current: State = state
     for unit in package.units:
@@ -392,6 +408,19 @@ def install_package(
                 tokens=_add_requester_token(tokens=base_tokens, token=name),
             )
             save_state(current, state_root)
+    for relpath in package.extras:
+        # Stage the extra to disk, then credit the package as its requester in the
+        # same per-extra State write the unit loop uses, so a partial run is
+        # recoverable and an extra is never present-but-uncredited.
+        stage_extra(relpath=relpath, source_root=source_root, state_root=state_root)
+        current = _set_extras(
+            state=current,
+            extra=relpath,
+            tokens=_add_requester_token(
+                tokens=current.extras.get(relpath, ()), token=name
+            ),
+        )
+        save_state(current, state_root)
     return current
 
 

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -20,6 +20,17 @@ def _remove_staged_entry(path: Path) -> None:
         path.unlink()
 
 
+def _copy_entry(*, source: Path, destination: Path) -> None:
+    """Copy a source entry to destination without the caller minding its shape —
+    a directory tree or a single file — so staging a unit and staging an extra
+    share one copy decision. copy2 (not copyfile) carries the source's mode across,
+    so an executable hook script stays executable once staged — matching copytree."""
+    if source.is_dir():
+        shutil.copytree(source, destination)
+    else:
+        shutil.copy2(source, destination)
+
+
 def staged_unit_path(*, unit: Unit, staged_root: Path) -> Path:
     """Own the "<kind>/<name>" staged-layout decision in one place, so callers
     locate a unit's staged copy without re-encoding the path this module lays down."""
@@ -34,12 +45,20 @@ def stage_unit(*, unit: Unit, source: Path, staged_root: Path) -> Path:
     # Clear any prior staging of this unit so a re-stage fully supersedes it,
     # leaving no stale files behind, rather than colliding with the old tree.
     _remove_staged_entry(destination)
-    # copy2 (not copyfile) carries the source's mode across, so an executable
-    # hook script stays executable once staged — matching copytree below.
-    if source.is_dir():
-        shutil.copytree(source, destination)
-    else:
-        shutil.copy2(source, destination)
+    _copy_entry(source=source, destination=destination)
+    return destination
+
+
+def stage_extra(*, relpath: str, source_root: Path, state_root: Path) -> Path:
+    """Copy a package's extra support file or directory to the state root at its
+    source-relative path, so a skill finds its schemas and helper scripts where it
+    expects them rather than back in the source tree."""
+    destination: Path = state_root / relpath
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    # Clear any prior copy so a re-stage fully supersedes it, leaving no stale
+    # files behind, rather than colliding with the old entry.
+    _remove_staged_entry(destination)
+    _copy_entry(source=source_root / relpath, destination=destination)
     return destination
 
 

--- a/installer/placement.py
+++ b/installer/placement.py
@@ -70,6 +70,13 @@ def unstage_unit(*, unit: Unit, staged_root: Path) -> None:
     _remove_staged_entry(staged_path)
 
 
+def unstage_extra(*, relpath: str, state_root: Path) -> None:
+    """Tear down an extra's staged copy at its source-relative path so the state
+    root no longer holds it — the inverse of stage_extra, dropping either the
+    directory tree or the single file it laid down."""
+    _remove_staged_entry(state_root / relpath)
+
+
 def backup_staged_unit(*, unit: Unit, staged_root: Path) -> Path | None:
     """Move a hand-edited staged unit aside to "<name>.bak" so the user's local
     edit survives a following re-stage that overwrites the staged tree, returning

--- a/installer/state.py
+++ b/installer/state.py
@@ -19,6 +19,10 @@ class State:
     # unit id -> the sorted tuple of tokens that requested it; declared last with a
     # default so existing State(version=..., units=...) call sites keep working.
     requesters: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    # extra source-relative path -> the sorted tuple of tokens that requested it,
+    # the same refcount shape as requesters; declared last with a default so existing
+    # State(version=..., units=..., requesters=...) call sites keep working.
+    extras: dict[str, tuple[str, ...]] = field(default_factory=dict)
 
 
 def default_state() -> State:
@@ -35,6 +39,10 @@ def save_state(state: State, root: Path) -> None:
     # what prior versions wrote; committed e2e golden snapshots pin that exact JSON.
     if state.requesters:
         payload["requesters"] = state.requesters
+    # Omit an empty extras map for the same reason — committed e2e goldens pin the
+    # exact JSON of stores that have no extras, so an empty map must not appear.
+    if state.extras:
+        payload["extras"] = state.extras
     # Write a sibling temp file and atomically swap it in, so a failed write
     # leaves the prior store intact rather than a half-written file.
     with tempfile.NamedTemporaryFile(
@@ -68,6 +76,14 @@ def load_state(root: Path) -> State:
         requesters: dict[str, tuple[str, ...]] = {
             unit_id: tuple(tokens) for unit_id, tokens in stored_requesters.items()
         }
-        return State(version=version, units=units, requesters=requesters)
+        # A store written before this field has no "extras" key; default to {} and
+        # rebuild each token list as a tuple, mirroring the requesters rebuild above.
+        stored_extras: dict[str, list[str]] = cast(
+            "dict[str, list[str]]", raw.get("extras", {})
+        )
+        extras: dict[str, tuple[str, ...]] = {
+            relpath: tuple(tokens) for relpath, tokens in stored_extras.items()
+        }
+        return State(version=version, units=units, requesters=requesters, extras=extras)
     root.mkdir(parents=True, exist_ok=True)
     return default_state()

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -656,6 +656,70 @@ packages = ["pack"]
     assert result.requesters[agent_unit_id("helper")] == ("pack",)
 
 
+def test_install_package_stages_extras_and_records_package_requester(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "alpha"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text("# Alpha Skill\n", encoding="utf-8")
+
+    schemas_source: Path = source_root / "schemas"
+    schemas_source.mkdir(parents=True)
+    (schemas_source / "thing.json").write_text(
+        '{"type": "object"}\n', encoding="utf-8"
+    )
+
+    tool_source: Path = source_root / "scripts" / "tool.py"
+    tool_source.parent.mkdir(parents=True)
+    tool_source.write_text("print('tool')\n", encoding="utf-8")
+
+    # A controlled catalog declaring the one unit and a package that also carries
+    # two extras — a whole directory ("schemas") and a single file nested in a
+    # subdir ("scripts/tool.py") — loaded through the real boundary so the package
+    # install resolves its members and extras exactly as production will.
+    catalog_body: str = """
+[[units]]
+kind = "skill"
+name = "alpha"
+
+[[packages]]
+name = "pack"
+units = ["skill/alpha"]
+extras = ["schemas", "scripts/tool.py"]
+
+[[bundles]]
+name = "everything"
+packages = ["pack"]
+"""
+    catalog_path: Path = tmp_path / "catalog.toml"
+    catalog_path.write_text(catalog_body, encoding="utf-8")
+    catalog: Catalog = load_catalog(catalog_path)
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    result: State = install_package(
+        name="pack",
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    # The directory extra is staged whole under the state root, preserving its
+    # source-relative path, so a skill finds its schemas where it expects them.
+    assert (state_root / "schemas" / "thing.json").is_file()
+    # The file extra nested in a subdir lands at the same relative path too.
+    assert (state_root / "scripts" / "tool.py").is_file()
+
+    # Each extra records the package name as its requester, keyed by the extra's
+    # source-relative path string.
+    assert result.extras["schemas"] == ("pack",)
+    assert result.extras["scripts/tool.py"] == ("pack",)
+
+
 def test_uninstall_package_keeps_unit_still_required_by_another_package(
     tmp_path: Path,
 ) -> None:

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -874,3 +874,104 @@ packages = ["pack"]
     assert (state_root / "staged" / "skill" / "alpha").is_dir()
     assert (claude_root / "skills" / "alpha").is_symlink()
     assert result.requesters[skill_unit_id("alpha")] == (DIRECT_REQUESTER,)
+
+
+def test_uninstall_package_refcounts_extras_keeping_shared_removing_sole(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    for skill_name in ("alpha", "beta"):
+        skill_source: Path = source_root / "skills" / skill_name
+        skill_source.mkdir(parents=True)
+        (skill_source / "SKILL.md").write_text(
+            f"# {skill_name} Skill\n", encoding="utf-8"
+        )
+
+    # A shared extra directory both packages declare, plus one private extra file
+    # per package nested in its own subdir, so refcounting an extra mirrors how the
+    # units test exercises a shared-vs-private unit. The units are incidental here.
+    shared_extra: Path = source_root / "shared"
+    shared_extra.mkdir(parents=True)
+    (shared_extra / "keep.txt").write_text("shared\n", encoding="utf-8")
+
+    one_private: Path = source_root / "one" / "private.txt"
+    one_private.parent.mkdir(parents=True)
+    one_private.write_text("one\n", encoding="utf-8")
+
+    two_private: Path = source_root / "two" / "private.txt"
+    two_private.parent.mkdir(parents=True)
+    two_private.write_text("two\n", encoding="utf-8")
+
+    # Two packages that share one extra ("shared") and each own one private extra,
+    # loaded through the real boundary so the uninstall resolves the package's
+    # extras exactly as production will.
+    catalog_body: str = """
+[[units]]
+kind = "skill"
+name = "alpha"
+
+[[units]]
+kind = "skill"
+name = "beta"
+
+[[packages]]
+name = "pack-one"
+units = ["skill/alpha"]
+extras = ["shared", "one/private.txt"]
+
+[[packages]]
+name = "pack-two"
+units = ["skill/beta"]
+extras = ["shared", "two/private.txt"]
+
+[[bundles]]
+name = "everything"
+packages = ["pack-one", "pack-two"]
+"""
+    catalog_path: Path = tmp_path / "catalog.toml"
+    catalog_path.write_text(catalog_body, encoding="utf-8")
+    catalog: Catalog = load_catalog(catalog_path)
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    # Install both packages, threading state, so the shared extra ends up credited
+    # to both pack-one and pack-two while each private extra has a single requester.
+    state_after_pack_one: State = install_package(
+        name="pack-one",
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+    state_after_both: State = install_package(
+        name="pack-two",
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state_after_pack_one,
+    )
+
+    result: State = uninstall_package(
+        name="pack-one",
+        catalog=catalog,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state_after_both,
+    )
+
+    # pack-one's private extra had pack-one as its sole requester: its last
+    # requester is gone, so it is physically removed and forgotten entirely.
+    assert not (state_root / "one" / "private.txt").exists()
+    assert "one/private.txt" not in result.extras
+
+    # The shared extra survives: pack-two still requires it, so it stays on disk and
+    # only loses pack-one from its requester set.
+    assert (state_root / "shared" / "keep.txt").is_file()
+    assert result.extras["shared"] == ("pack-two",)
+
+    # pack-two's private extra belongs only to pack-two and is left untouched.
+    assert (state_root / "two" / "private.txt").is_file()
+    assert result.extras["two/private.txt"] == ("pack-two",)

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -666,9 +666,7 @@ def test_install_package_stages_extras_and_records_package_requester(
 
     schemas_source: Path = source_root / "schemas"
     schemas_source.mkdir(parents=True)
-    (schemas_source / "thing.json").write_text(
-        '{"type": "object"}\n', encoding="utf-8"
-    )
+    (schemas_source / "thing.json").write_text('{"type": "object"}\n', encoding="utf-8")
 
     tool_source: Path = source_root / "scripts" / "tool.py"
     tool_source.parent.mkdir(parents=True)


### PR DESCRIPTION
## Slice 7.3 — Stage extras (installer packages)

Closes the "stage extras" slice of the installer PRD (#74). On package install, each declared **extra** (a source-relative path to a runtime support file/dir a skill reads — schemas/gates/scripts) is now physically staged into the `~/.claude/at/` state root and recorded in state with a per-extra refcount; on uninstall, extras are reconciled **like units** — a shared extra survives while another package still requires it, and an extra is removed (disk + state) only once its last requester is gone.

Builds on 7.1 (`Package.extras` model, #109) and 7.2 (`install_package`/`uninstall_package` unit refcount via `State.requesters`, #110).

### What changed
- **`state.py`** — new `State.extras: dict[str, tuple[str, ...]]` (relpath → sorted requester tokens), mirroring `requesters`. Omitted from `save_state` when empty so committed e2e goldens stay **byte-identical**; defaulted to `{}` + tuple-rebuilt in `load_state`.
- **`placement.py`** — `stage_extra` (copy `source_root/<relpath>` → `state_root/<relpath>`, dir tree or nested file, mode-preserving) and its inverse `unstage_extra`. The dir-vs-file copy is factored into a shared `_copy_entry` helper reused by `stage_unit`.
- **`actions.py`** — `install_package` stages + credits each extra; `uninstall_package` refcounts each extra (`_set_extras` to keep, `unstage_extra` + `_forget_extra` to remove). Also fixes `_install_unit`/`_uninstall_unit`, which rebuilt `State(...)` without `extras` and so silently dropped a prior package's extras on any cross-package install/uninstall (latent once 7.3 added the field; surfaced by the cross-package test).

### Design decisions
- **Stage at `state_root/<relpath>`** (e.g. `~/.claude/at/schemas`, `~/.claude/at/scripts/validate_return.py`) so 7.4's skill-path cutover is a clean "same relpath, different root."
- `State.extras` is a faithful refcount analogue of `requesters`; no `@direct` marker (extras only enter via packages).

### Tests (TDD, RED-first)
- `test_install_package_stages_extras_and_records_package_requester` — a directory extra and a nested-file extra both land at their source-relative path under the state root, recorded with the package as requester.
- `test_uninstall_package_refcounts_extras_keeping_shared_removing_sole` — two packages share one extra + own a private one; uninstalling one keeps the shared extra (losing only that package) and removes the sole extra from both disk and state.

### Gates
`ruff format --check` · `ruff check` · `mypy --strict` · `pytest -W error` → **128 passed** (incl. 12 e2e golden snapshots unchanged).

### Out of scope (later slices)
Skills *reading* extras from `~/.claude/at` (7.4), packages TUI (7.5), dep composition + content hash (7.6), package e2e goldens (7.e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
