### PR TITLE
feat(installer): point skills at ~/.claude/at for staged extras (slice 7.4)

### DIFF
--- a/installer/tests/test_skill_extras_paths.py
+++ b/installer/tests/test_skill_extras_paths.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+from typing import Final
+
+from catalog import Catalog, load_catalog
+from paths import STATE_ROOT
+
+# installer/tests/ -> installer/ -> repo root, holding skills/<name>/ and the catalog.
+_REPO_ROOT: Final[Path] = Path(__file__).resolve().parent.parent.parent
+_CATALOG_PATH: Final[Path] = _REPO_ROOT / "installer" / "catalog.toml"
+_SKILLS_ROOT: Final[Path] = _REPO_ROOT / "skills"
+
+# The state root the installer stages each package's extras into, in the tilde form a
+# SKILL.md writes. Derived from the installer's own STATE_ROOT so the skill text and the
+# installer cannot drift: the skill must read extras from the SAME root the installer
+# stages them to.
+_EXTRAS_ROOT: Final[str] = "~/" + str(STATE_ROOT.relative_to(Path.home()))
+
+# Unit kind whose SKILL.md prompt resolves the package's extras at runtime.
+_SKILL_KIND: Final[str] = "skill"
+
+
+def test_skill_prompts_resolve_package_extras_from_state_root() -> None:
+    """A package's extras are staged into the ~/.claude/at state root, so its skill
+    units must resolve each extra from that root and not from <skill_root>; driven off
+    catalog truth so the check tracks whatever packages declare extras."""
+    catalog: Catalog = load_catalog(_CATALOG_PATH)
+    checked_pairs: int = 0
+
+    for package in catalog.packages:
+        if not package.extras:
+            continue
+        for unit in package.units:
+            if unit.kind != _SKILL_KIND:
+                continue
+            prompt: str = (_SKILLS_ROOT / unit.name / "SKILL.md").read_text(
+                encoding="utf-8"
+            )
+            for relpath in package.extras:
+                staged_ref: str = f"{_EXTRAS_ROOT}/{relpath}"
+                stale_root: str = f"<skill_root>/{relpath.split('/')[0]}"
+                assert staged_ref in prompt, (
+                    f"skill {unit.name!r} must resolve extra {relpath!r} from "
+                    f"{staged_ref!r}, the state root the installer stages it into"
+                )
+                assert stale_root not in prompt, (
+                    f"skill {unit.name!r} still resolves extra {relpath!r} from "
+                    f"{stale_root!r}; the cutover must replace the <skill_root> "
+                    f"reference, not keep it alongside {_EXTRAS_ROOT!r}"
+                )
+                checked_pairs += 1
+
+    assert checked_pairs > 0, (
+        "no (skill, extra) pair was checked — no package declares extras whose units "
+        "include a skill, so this test would pass vacuously"
+    )

--- a/skills/make-pr-lite/SKILL.md
+++ b/skills/make-pr-lite/SKILL.md
@@ -24,15 +24,17 @@ guarantees that.)
 
 ## Runtime resolution
 
-- **skill_root** — the directory this `SKILL.md` lives in. It bundles the `rules/` and `gates/`
-  this skill needs, so they travel with the skill on install — resolve both from here, never from
-  the target repo or a repo checkout.
+- **skill_root** — the directory this `SKILL.md` lives in. Use it for the bundled `rules/` beside
+  it (`rules_root`, below); the runtime `gates/` are resolved from `extras_root`, not from here.
+- **extras_root** — the installer's state root `~/.claude/at`, the single source of truth the
+  installer stages a package's extras into — this skill's `gates/` live here. Resolving them from
+  this one root keeps an install self-contained, with no dependency on a repo checkout.
 - **rules_root** — `<skill_root>/rules`; pass rule files as absolute paths (a subagent's cwd is the
   target repo, so bare names won't resolve).
 - **target_cwd** — the repo being changed; run every `git`/gate command there.
 - **base** — user/spec-named → else `git merge-base HEAD origin/main` → else `… main` → else stop
   and ask.
-- **gates** — preflight: pick `<skill_root>/gates/<lang>.json` by the task's language(s) /
+- **gates** — preflight: pick `~/.claude/at/gates/<lang>.json` by the task's language(s) /
   `allowed_paths`. After the coder runs, re-check against `git diff --name-only <base>...HEAD`. A
   changed language with no profile → stop and report.
 - **rules to pass** — always `design-principles.md`; `tdd.md` for behavioral work; the language

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -35,12 +35,12 @@ give `worker-coder` its **`mode`** (`green` | `refactor` | `non_behavioral`) plu
 `dependencies_allowed` (and any named dependency/version) when the task permits dependencies —
 otherwise the coder blocks on any new dependency. Keep each dispatch
 prompt tight and scoped to one job. Require each agent to return exactly the JSON object defined
-in its prompt, and **validate that return against `<skill_root>/schemas/<role>.schema.json`**
+in its prompt, and **validate that return against `~/.claude/at/schemas/<role>.schema.json`**
 (keyed by the `role` field in the return). The validator reads the instance from a **file**, so
 first write the agent's raw return verbatim with `Write` (not `echo`/heredoc — those mangle the
 embedded quotes and newlines) to `<run_root>/<run-id>.<role>.json`, then run:
 
-`uv run --no-project --with jsonschema python <skill_root>/scripts/validate_return.py <skill_root>/schemas/<role>.schema.json <run_root>/<run-id>.<role>.json`
+`uv run --no-project --with jsonschema python ~/.claude/at/scripts/validate_return.py ~/.claude/at/schemas/<role>.schema.json <run_root>/<run-id>.<role>.json`
 
 (The validator depends on `jsonschema`; `uv run --no-project --with jsonschema` supplies it on first run and caches it — no separate install step.)
 
@@ -61,9 +61,13 @@ stage it unchanged with your production code. Module boundary: `cart` only. Base
 
 Resolve these values before the first dispatch:
 
-- **skill_root**: the directory this `SKILL.md` lives in. It bundles the immutable template
-  assets — `schemas/`, `scripts/`, `gates/`, and `rules/` — so they travel with the skill on
-  install; resolve them here, never from the target repo or a repo checkout.
+- **skill_root**: the directory this `SKILL.md` lives in. Use it for the bundled `rules/` beside
+  it (`rules_root`, below); the runtime extras — schemas, gates, and helper scripts — are resolved
+  from `extras_root`, not from here.
+- **extras_root**: the installer's state root `~/.claude/at`, the single source of truth the
+  installer stages a package's extras into — `schemas/`, `gates/`, and `scripts/` live here.
+  Resolving them from this one root keeps an install self-contained, with no dependency on a repo
+  checkout; reference each extra by its literal path under it (e.g. `~/.claude/at/gates/<lang>.json`).
 - **rules_root**: the bundled `rules/` directory beside this `SKILL.md` (`<skill_root>/rules`). Use
   it for the rule files the agents read.
 - **target_cwd**: the absolute path to the repository being changed. Run every target-repo
@@ -77,7 +81,7 @@ Resolve these values before the first dispatch:
 - **Run id**: use the branch name or task id, replacing `/` and whitespace with `_`.
 - **Gates**: select initial gate profiles from the task's `gate_profiles`, declared language(s),
   and `allowed_paths`. After workers change files, expand the selected profiles from
-  `git diff --name-only <base>...HEAD`. Match paths against each `<skill_root>/gates/*.json`
+  `git diff --name-only <base>...HEAD`. Match paths against each `~/.claude/at/gates/*.json`
   profile's `triggers` globs; both root and nested paths must match. If a changed language has
   no gate, stop and report the missing gate instead of declaring done.
 - **Rules**: resolve rule files to **absolute** paths (the bundled `rules/` directory beside this
@@ -92,7 +96,7 @@ Resolve these values before the first dispatch:
   `<run-id>.<role>.json` return files you write for validation). Do not edit production source, tests,
   rules, or gates directly while acting as architect; route every code or test change to `worker-coder`.
 - Use `Bash` only for `git`, `date`, JSONL validation, the schema validator
-  (`<skill_root>/scripts/validate_return.py`), **re-running a worker's reported verification (e.g. the
+  (`~/.claude/at/scripts/validate_return.py`), **re-running a worker's reported verification (e.g. the
   named GREEN test) to confirm its result**, the task-provided baseline command, and the selected
   gate `setup`/`run` commands. Run all target-repo commands in `target_cwd`. Do not run gate
   `fix` commands directly; route fixes to `worker-coder`.
@@ -143,7 +147,7 @@ Resolve these values before the first dispatch:
       with `mode: refactor`; tests must stay green and unchanged.
    Log every dispatch (see JSONL contract).
 5. **Gate (objective — run before any LLM judgment).** Run the selected gates from
-   `<skill_root>/gates/<lang>.json`. Each gate file is
+   `~/.claude/at/gates/<lang>.json`. Each gate file is
    `{"setup": <cmd>, "triggers": [<glob>], "gates": [{"name","run","fix"}]}` where `fix` may be
    `null` for checks that need a human/coder change rather than a mechanical command. Run `setup`
    once, then each `gates[].run` in order. If setup fails because the repo does not use the


### PR DESCRIPTION
## Slice 7.4 — Skill path resolution (issue #74)

Makes the affected skills read their package **extras** from the installer's state root `~/.claude/at` instead of `<skill_root>`/a repo checkout. Slice 7.3 stages each package's extras at `state_root/<relpath>`, so this is the clean "same-relpath / different-root" reading-side swap that completes the self-contained install: once a package is installed, its skill resolves schemas/gates/helper-scripts from `~/.claude/at`, with no dependency on the cloned repo.

### What changed
- **`skills/make-pr/SKILL.md`** — `schemas`, `gates`, and `scripts/validate_return.py` references cut over from `<skill_root>/…` to literal `~/.claude/at/…`; `skill_root` reworded (now only for the bundled `rules/`) and a new `extras_root` definition added.
- **`skills/make-pr-lite/SKILL.md`** — `gates` cut over to `~/.claude/at/gates/…`; same prose treatment.
- **`installer/tests/test_skill_extras_paths.py`** (new guard) — catalog-driven: for every package that declares `extras`, asserts each skill unit resolves each extra from `~/.claude/at` and that no stale `<skill_root>/<extra>` reference survives. The expected root is derived from the installer's own `paths.STATE_ROOT`, so the skill text and the stager cannot drift.

### Scope discipline
- `rules_root` / `<skill_root>/rules` left untouched — rules are installed **units** (under `~/.claude/rules/`), not package extras.
- In-skill bundled copies (`skills/*/schemas|gates|scripts`) left in place — retiring them is slice **7.6**; `installer/tests/test_skill_bundles.py` still passes.
- No installer `.py` or `catalog.toml` changes.

### Verification
- New guard test witnessed RED (missing `~/.claude/at/schemas`) → GREEN.
- Full gate green in `installer/`: `ruff format --check`, `ruff check`, `mypy --strict`, `pytest -W error` (129 passed).
- Reviewer 96 (no findings; independently confirmed the test fails on a simulated stale-reference regression, i.e. it is a real guard, not tautological). Critic 96 — **achieved**, no gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
