### PR TITLE
feat(installer): Packages tab — browse + refcount install/uninstall (slice 7.5)

### DIFF
--- a/installer/catalog.py
+++ b/installer/catalog.py
@@ -135,6 +135,12 @@ def list_hooks(catalog: Catalog) -> list[str]:
     return sorted(unit.name for unit in catalog.units if unit.kind == _HOOK_KIND)
 
 
+def list_packages(*, catalog: Catalog) -> list[str]:
+    """Surface the installable packages by name in a stable order, so a UI
+    listing doesn't depend on declaration order in the toml."""
+    return sorted(package.name for package in catalog.packages)
+
+
 def _resolve(ref: str, by_id: dict[str, Unit], package: str) -> Unit:
     """Turn a package's unit id into the declared Unit, failing loudly at parse
     time with the dangling ref named rather than silently dropping it."""

--- a/installer/reconcile.py
+++ b/installer/reconcile.py
@@ -15,14 +15,17 @@ from actions import (
 )
 from catalog import (
     Catalog,
+    Package,
     agent_unit_id,
     hook_unit_id,
     list_agents,
     list_hooks,
     list_rules,
     list_skills,
+    resolve_package,
     rule_unit_id,
     skill_unit_id,
+    unit_id,
 )
 from state import State
 
@@ -109,6 +112,18 @@ def plan_hook_reconcile(
         names=list_hooks(catalog),
         unit_id_of=hook_unit_id,
         state=state,
+    )
+
+
+def package_installed(*, catalog: Catalog, name: str, state: State) -> bool:
+    """Report a package as installed iff every unit it declares credits it in
+    state.requesters — the exact bookkeeping install_package writes and
+    uninstall_package withdraws — so the view reads the refcount rather than
+    guessing from loose unit presence; a package that declares no units is never
+    installed, never vacuously true."""
+    package: Package = resolve_package(catalog, name)
+    return bool(package.units) and all(
+        name in state.requesters.get(unit_id(unit), ()) for unit in package.units
     )
 
 

--- a/installer/reconcile.py
+++ b/installer/reconcile.py
@@ -6,10 +6,12 @@ from typing import Protocol
 from actions import (
     install_agent,
     install_hook,
+    install_package,
     install_rule,
     install_skill,
     uninstall_agent,
     uninstall_hook,
+    uninstall_package,
     uninstall_rule,
     uninstall_skill,
 )
@@ -292,3 +294,36 @@ def apply_hook_reconcile(
         claude_root=claude_root,
         state=state,
     )
+
+
+def apply_package_reconcile(
+    *,
+    plan: ReconcilePlan,
+    catalog: Catalog,
+    source_root: Path,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Carry out a planned package diff via the refcount-aware install_package /
+    uninstall_package, threading the persisted State through so the final return
+    reflects every action."""
+    current: State = state
+    for name in plan.to_install:
+        current = install_package(
+            name=name,
+            catalog=catalog,
+            source_root=source_root,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=current,
+        )
+    for name in plan.to_remove:
+        current = uninstall_package(
+            name=name,
+            catalog=catalog,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=current,
+        )
+    return current

--- a/installer/reconcile.py
+++ b/installer/reconcile.py
@@ -20,6 +20,7 @@ from catalog import (
     hook_unit_id,
     list_agents,
     list_hooks,
+    list_packages,
     list_rules,
     list_skills,
     resolve_package,
@@ -125,6 +126,27 @@ def package_installed(*, catalog: Catalog, name: str, state: State) -> bool:
     return bool(package.units) and all(
         name in state.requesters.get(unit_id(unit), ()) for unit in package.units
     )
+
+
+def plan_package_reconcile(
+    *, ticked: frozenset[str], catalog: Catalog, state: State
+) -> ReconcilePlan:
+    """Diff the ticked selection against the catalog's packages, taking "installed"
+    from the refcount predicate rather than loose unit presence, so the apply step
+    works from a decided plan instead of re-deriving the diff."""
+    names: list[str] = list_packages(catalog=catalog)
+    installed: set[str] = {
+        name
+        for name in names
+        if package_installed(catalog=catalog, name=name, state=state)
+    }
+    to_install: tuple[str, ...] = tuple(
+        name for name in names if name in ticked and name not in installed
+    )
+    to_remove: tuple[str, ...] = tuple(
+        name for name in names if name in installed and name not in ticked
+    )
+    return ReconcilePlan(to_install=to_install, to_remove=to_remove)
 
 
 class _InstallAction(Protocol):

--- a/installer/reconcile.py
+++ b/installer/reconcile.py
@@ -45,6 +45,21 @@ class ReconcilePlan:
         return not self.to_install and not self.to_remove
 
 
+def _diff_selection(
+    *, names: list[str], ticked: frozenset[str], installed: set[str]
+) -> ReconcilePlan:
+    """Diff a ticked selection against an already-decided installed set into a
+    sorted ReconcilePlan, so every kind/tier shares one diff and differs only in
+    how it decides what counts as installed."""
+    to_install: tuple[str, ...] = tuple(
+        name for name in names if name in ticked and name not in installed
+    )
+    to_remove: tuple[str, ...] = tuple(
+        name for name in names if name in installed and name not in ticked
+    )
+    return ReconcilePlan(to_install=to_install, to_remove=to_remove)
+
+
 def _plan_reconcile(
     *,
     ticked: frozenset[str],
@@ -55,13 +70,7 @@ def _plan_reconcile(
     """Diff the ticked selection against installed state over one kind's units, so
     both public plan wrappers share one diff instead of re-deriving it per kind."""
     installed: set[str] = {name for name in names if unit_id_of(name) in state.units}
-    to_install: tuple[str, ...] = tuple(
-        name for name in names if name in ticked and name not in installed
-    )
-    to_remove: tuple[str, ...] = tuple(
-        name for name in names if name in installed and name not in ticked
-    )
-    return ReconcilePlan(to_install=to_install, to_remove=to_remove)
+    return _diff_selection(names=names, ticked=ticked, installed=installed)
 
 
 def plan_skill_reconcile(
@@ -140,13 +149,7 @@ def plan_package_reconcile(
         for name in names
         if package_installed(catalog=catalog, name=name, state=state)
     }
-    to_install: tuple[str, ...] = tuple(
-        name for name in names if name in ticked and name not in installed
-    )
-    to_remove: tuple[str, ...] = tuple(
-        name for name in names if name in installed and name not in ticked
-    )
-    return ReconcilePlan(to_install=to_install, to_remove=to_remove)
+    return _diff_selection(names=names, ticked=ticked, installed=installed)
 
 
 class _InstallAction(Protocol):

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -420,6 +420,69 @@ def test_hooks_tab_installs_ticked_hook_through_reconcile(
     assert TAB_PLACEHOLDER not in captured
 
 
+def test_packages_tab_installs_ticked_package_through_reconcile(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("tui.STATE_ROOT", state_root)
+    monkeypatch.setattr("tui.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("tui.REPO_ROOT", repo_root)
+
+    # A real skill source on disk is the only input the install needs; nothing is
+    # installed up front, so ticking demo-pack through the Packages tab must place its
+    # member skill via the refcount-aware package reconcile and credit the package as
+    # that unit's requester — the packages-tier analogue of how the Agents tab installs
+    # a ticked agent.
+    skill_source: Path = repo_root / "skills" / "demo-skill" / "SKILL.md"
+    skill_source.parent.mkdir(parents=True)
+    skill_source.write_text("# demo-skill\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "bundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-skill"\n\n'
+        '[[packages]]\nname = "demo-pack"\nunits = ["skill/demo-skill"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("tui.CATALOG_PATH", catalog_file)
+    # The tab menu opens the Packages tab, then closes it after the reconcile applies.
+    select_answers: Iterator[str] = iter(["Packages", "Exit"])
+
+    class FakeSelect:
+        def ask(self) -> str:
+            return next(select_answers)
+
+    # Tick the lone catalog package by name so the desired set installs demo-pack.
+    class FakeCheckbox:
+        def ask(self) -> list[str]:
+            return ["demo-pack"]
+
+    class ConfirmPrompt:
+        def ask(self) -> bool:
+            return True
+
+    monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakeSelect())
+    monkeypatch.setattr("questionary.checkbox", lambda *args, **kwargs: FakeCheckbox())
+    monkeypatch.setattr("questionary.confirm", lambda *args, **kwargs: ConfirmPrompt())
+
+    exit_code: int = main(["install"])
+
+    # Ticking demo-pack applies plan_package_reconcile then apply_package_reconcile, so
+    # the package's member skill ends up linked live and credited to demo-pack in state,
+    # and the package rows re-render with the installed marker.
+    captured: str = capsys.readouterr().out
+    final_state: State = load_state(state_root)
+    skill_link: Path = claude_root / "skills" / "demo-skill"
+    assert exit_code == 0
+    assert skill_link.is_symlink()
+    assert final_state.requesters[skill_unit_id("demo-skill")] == ("demo-pack",)
+    assert f"{MARKER_INSTALLED} demo-pack" in captured
+    assert TAB_PLACEHOLDER not in captured
+
+
 def test_skills_tab_unticking_skill_removes_it_while_ticked_stays_installed(
     monkeypatch: MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -13,6 +13,7 @@ from actions import install_agent, install_hook, install_rule, install_skill
 from at import main
 from catalog import (
     Catalog,
+    Package,
     Unit,
     agent_unit_id,
     hook_unit_id,
@@ -30,6 +31,7 @@ from tui import (
     abort_on_esc,
     agent_rows,
     hook_rows,
+    package_rows,
     rule_rows,
     skill_rows,
 )
@@ -162,6 +164,38 @@ def test_hook_rows_marks_installed_sorted_and_excludes_non_hooks() -> None:
     rows: list[str] = hook_rows(catalog=catalog, state=state)
 
     assert rows == [f"{MARKER_INSTALLED} alpha", f"{MARKER_NOT_INSTALLED} zeta"]
+
+
+def test_package_rows_marks_installed_by_refcount_sorted_with_member_ids() -> None:
+    catalog: Catalog = Catalog(
+        units=(
+            Unit(kind="skill", name="alpha"),
+            Unit(kind="agent", name="helper"),
+            Unit(kind="skill", name="beta"),
+        ),
+        packages=(
+            Package(
+                name="pack-z",
+                units=(
+                    Unit(kind="skill", name="alpha"),
+                    Unit(kind="agent", name="helper"),
+                ),
+            ),
+            Package(name="pack-a", units=(Unit(kind="skill", name="beta"),)),
+        ),
+        bundles=(),
+    )
+    # Credit every unit of pack-a (only skill/beta) with "pack-a" so the refcount
+    # predicate reports it installed; leave pack-z's units uncredited. units stays
+    # empty so a passing row can only come from requesters, not from state.units.
+    state: State = State(version=1, units={}, requesters={"skill/beta": ("pack-a",)})
+
+    rows: list[str] = package_rows(catalog=catalog, state=state)
+
+    assert rows == [
+        f"{MARKER_INSTALLED} pack-a  (skill/beta)",
+        f"{MARKER_NOT_INSTALLED} pack-z  (skill/alpha, agent/helper)",
+    ]
 
 
 def test_skills_tab_renders_skill_rows_instead_of_placeholder(

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -9,7 +9,13 @@ from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.output import DummyOutput
 from pytest import CaptureFixture, MonkeyPatch
 
-from actions import install_agent, install_hook, install_rule, install_skill
+from actions import (
+    install_agent,
+    install_hook,
+    install_package,
+    install_rule,
+    install_skill,
+)
 from at import main
 from catalog import (
     Catalog,
@@ -481,6 +487,87 @@ def test_packages_tab_installs_ticked_package_through_reconcile(
     assert final_state.requesters[skill_unit_id("demo-skill")] == ("demo-pack",)
     assert f"{MARKER_INSTALLED} demo-pack" in captured
     assert TAB_PLACEHOLDER not in captured
+
+
+def test_packages_tab_unticking_one_package_keeps_a_shared_unit(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("tui.STATE_ROOT", state_root)
+    monkeypatch.setattr("tui.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("tui.REPO_ROOT", repo_root)
+
+    # Real skill sources for the shared unit and each package's exclusive unit, so the
+    # pre-install can place live symlinks and staging before the reconcile runs.
+    for name in ("shared", "only-a", "only-b"):
+        source: Path = repo_root / "skills" / name / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(f"# {name}\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "bundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "shared"\n\n'
+        '[[units]]\nkind = "skill"\nname = "only-a"\n\n'
+        '[[units]]\nkind = "skill"\nname = "only-b"\n\n'
+        '[[packages]]\nname = "pack-a"\nunits = ["skill/shared", "skill/only-a"]\n\n'
+        '[[packages]]\nname = "pack-b"\nunits = ["skill/shared", "skill/only-b"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("tui.CATALOG_PATH", catalog_file)
+
+    # Pre-install both packages through the real public install action, so the shared
+    # unit carries both packages as requesters and each exclusive unit carries its own.
+    catalog: Catalog = load_catalog(catalog_file)
+    state: State = load_state(state_root)
+    for package_name in ("pack-a", "pack-b"):
+        state = install_package(
+            name=package_name,
+            catalog=catalog,
+            source_root=repo_root,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=state,
+        )
+
+    # The tab menu opens the Packages tab, then closes it after the reconcile.
+    select_answers: Iterator[str] = iter(["Packages", "Exit"])
+
+    class FakeSelect:
+        def ask(self) -> str:
+            return next(select_answers)
+
+    # pack-b is left unticked; only pack-a stays in the desired set.
+    class FakeCheckbox:
+        def ask(self) -> list[str]:
+            return ["pack-a"]
+
+    class ConfirmPrompt:
+        def ask(self) -> bool:
+            return True
+
+    monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakeSelect())
+    monkeypatch.setattr("questionary.checkbox", lambda *args, **kwargs: FakeCheckbox())
+    monkeypatch.setattr("questionary.confirm", lambda *args, **kwargs: ConfirmPrompt())
+
+    exit_code: int = main(["install"])
+
+    # Reconciling to the desired set {pack-a} runs a refcount-correct uninstall of
+    # pack-b: only its exclusive unit is reclaimed, while the shared unit survives on
+    # pack-a's remaining credit and pack-a's own exclusive unit stays installed.
+    final_state: State = load_state(state_root)
+    only_b_link: Path = claude_root / "skills" / "only-b"
+    shared_link: Path = claude_root / "skills" / "shared"
+    assert exit_code == 0
+    assert skill_unit_id("only-b") not in final_state.units
+    assert not only_b_link.exists() and not only_b_link.is_symlink()
+    assert skill_unit_id("shared") in final_state.units
+    assert shared_link.is_symlink()
+    assert final_state.requesters[skill_unit_id("shared")] == ("pack-a",)
+    assert skill_unit_id("only-a") in final_state.units
 
 
 def test_skills_tab_unticking_skill_removes_it_while_ticked_stays_installed(

--- a/installer/tests/test_catalog.py
+++ b/installer/tests/test_catalog.py
@@ -10,6 +10,7 @@ from catalog import (
     Unit,
     list_agents,
     list_hooks,
+    list_packages,
     list_rules,
     list_skills,
     load_catalog,
@@ -250,6 +251,22 @@ def test_list_hooks_returns_only_hook_names_sorted(tmp_path: Path) -> None:
     # Only hook-kind units, and sorted (declaration order is zeta, alpha); the
     # skill and agent units must not leak into the hook listing.
     assert list_hooks(catalog) == ["alpha", "zeta"]
+
+
+def test_list_packages_returns_package_names_sorted() -> None:
+    # Packages are listed by name in a stable sorted order, independent of their
+    # declaration order in the catalog (here zeta is declared before alpha).
+    shared: Unit = Unit(kind="skill", name="alpha")
+    catalog: Catalog = Catalog(
+        units=(shared,),
+        packages=(
+            Package(name="zeta", units=(shared,)),
+            Package(name="alpha", units=(shared,)),
+        ),
+        bundles=(),
+    )
+
+    assert list_packages(catalog=catalog) == ["alpha", "zeta"]
 
 
 def test_skill_unit_id_joins_kind_and_name() -> None:

--- a/installer/tests/test_reconcile.py
+++ b/installer/tests/test_reconcile.py
@@ -1,6 +1,12 @@
 from pathlib import Path
 
-from actions import install_agent, install_hook, install_rule, install_skill
+from actions import (
+    install_agent,
+    install_hook,
+    install_package,
+    install_rule,
+    install_skill,
+)
 from catalog import (
     Catalog,
     Package,
@@ -8,6 +14,7 @@ from catalog import (
     agent_unit,
     agent_unit_id,
     hook_unit_id,
+    load_catalog,
     rule_unit_id,
     skill_unit,
     skill_unit_id,
@@ -16,6 +23,7 @@ from reconcile import (
     ReconcilePlan,
     apply_agent_reconcile,
     apply_hook_reconcile,
+    apply_package_reconcile,
     apply_rule_reconcile,
     apply_skill_reconcile,
     package_installed,
@@ -353,3 +361,74 @@ def test_apply_installs_planned_hooks_and_uninstalls_removed_ones(
     assert not (state_root / "staged" / "hook" / "old-hook").exists()
     assert old_id not in result.units
     assert old_id not in persisted.units
+
+
+def test_apply_package_reconcile_installs_added_and_removes_dropped_packages(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    for skill_name in ("alpha", "beta"):
+        skill_source: Path = source_root / "skills" / skill_name
+        skill_source.mkdir(parents=True)
+        (skill_source / "SKILL.md").write_text(
+            f"# {skill_name} Skill\n", encoding="utf-8"
+        )
+
+    # Two single-unit packages, loaded through the real boundary so the package
+    # reconcile resolves each package's member unit exactly as production will.
+    catalog_body: str = """
+[[units]]
+kind = "skill"
+name = "alpha"
+
+[[units]]
+kind = "skill"
+name = "beta"
+
+[[packages]]
+name = "pack-a"
+units = ["skill/alpha"]
+
+[[packages]]
+name = "pack-b"
+units = ["skill/beta"]
+
+[[bundles]]
+name = "everything"
+packages = ["pack-a", "pack-b"]
+"""
+    catalog_path: Path = tmp_path / "catalog.toml"
+    catalog_path.write_text(catalog_body, encoding="utf-8")
+    catalog: Catalog = load_catalog(catalog_path)
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    # Pre-install pack-a so the plan has a real package to drop while it adds pack-b.
+    installed_state: State = install_package(
+        name="pack-a",
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    plan: ReconcilePlan = ReconcilePlan(to_install=("pack-b",), to_remove=("pack-a",))
+    result: State = apply_package_reconcile(
+        plan=plan,
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=installed_state,
+    )
+
+    # pack-b is now installed: its unit is recorded, credits pack-b, and is live.
+    assert skill_unit_id("beta") in result.units
+    assert result.requesters[skill_unit_id("beta")] == ("pack-b",)
+    assert (claude_root / "skills" / "beta").is_symlink()
+
+    # pack-a is now removed: its unit is gone from state and from disk.
+    assert skill_unit_id("alpha") not in result.units
+    assert not (claude_root / "skills" / "alpha").exists()

--- a/installer/tests/test_reconcile.py
+++ b/installer/tests/test_reconcile.py
@@ -3,10 +3,13 @@ from pathlib import Path
 from actions import install_agent, install_hook, install_rule, install_skill
 from catalog import (
     Catalog,
+    Package,
     Unit,
+    agent_unit,
     agent_unit_id,
     hook_unit_id,
     rule_unit_id,
+    skill_unit,
     skill_unit_id,
 )
 from reconcile import (
@@ -15,12 +18,46 @@ from reconcile import (
     apply_hook_reconcile,
     apply_rule_reconcile,
     apply_skill_reconcile,
+    package_installed,
     plan_agent_reconcile,
     plan_hook_reconcile,
     plan_rule_reconcile,
     plan_skill_reconcile,
 )
 from state import State, load_state
+
+
+def test_package_installed_requires_every_declared_unit_to_credit_the_package() -> None:
+    catalog: Catalog = Catalog(
+        units=(skill_unit("alpha"), agent_unit("helper")),
+        packages=(
+            Package(name="pack", units=(skill_unit("alpha"), agent_unit("helper"))),
+        ),
+        bundles=(),
+    )
+
+    # Both declared units credit "pack" in the refcount map, and units stays empty so
+    # the predicate can only be reading requesters bookkeeping, not loose unit presence.
+    fully_credited: State = State(
+        version=1,
+        units={},
+        requesters={
+            skill_unit_id("alpha"): ("pack",),
+            agent_unit_id("helper"): ("pack",),
+        },
+    )
+    assert package_installed(catalog=catalog, name="pack", state=fully_credited) is True
+
+    # Drop the helper's credit: one declared unit no longer names "pack", so the
+    # package is not fully installed even though the other unit still credits it.
+    helper_uncredited: State = State(
+        version=1,
+        units={},
+        requesters={skill_unit_id("alpha"): ("pack",)},
+    )
+    assert (
+        package_installed(catalog=catalog, name="pack", state=helper_uncredited) is False
+    )
 
 
 def test_plan_classifies_skills_by_tick_against_installed_state() -> None:

--- a/installer/tests/test_reconcile.py
+++ b/installer/tests/test_reconcile.py
@@ -57,7 +57,8 @@ def test_package_installed_requires_every_declared_unit_to_credit_the_package() 
         requesters={skill_unit_id("alpha"): ("pack",)},
     )
     assert (
-        package_installed(catalog=catalog, name="pack", state=helper_uncredited) is False
+        package_installed(catalog=catalog, name="pack", state=helper_uncredited)
+        is False
     )
 
 

--- a/installer/tests/test_reconcile.py
+++ b/installer/tests/test_reconcile.py
@@ -21,6 +21,7 @@ from reconcile import (
     package_installed,
     plan_agent_reconcile,
     plan_hook_reconcile,
+    plan_package_reconcile,
     plan_rule_reconcile,
     plan_skill_reconcile,
 )
@@ -58,6 +59,33 @@ def test_package_installed_requires_every_declared_unit_to_credit_the_package() 
     assert (
         package_installed(catalog=catalog, name="pack", state=helper_uncredited) is False
     )
+
+
+def test_plan_classifies_packages_by_refcount_install_not_unit_presence() -> None:
+    catalog: Catalog = Catalog(
+        units=(skill_unit("alpha"), skill_unit("beta")),
+        packages=(
+            Package(name="pack-a", units=(skill_unit("alpha"),)),
+            Package(name="pack-b", units=(skill_unit("beta"),)),
+        ),
+        bundles=(),
+    )
+
+    # pack-a's only unit credits "pack-a", so the refcount predicate reads pack-a as
+    # installed; pack-b stays uncredited and so is not installed. units is empty so the
+    # diff can only be reading requesters bookkeeping, not loose unit presence.
+    state: State = State(
+        version=1,
+        units={},
+        requesters={skill_unit_id("alpha"): ("pack-a",)},
+    )
+
+    plan: ReconcilePlan = plan_package_reconcile(
+        ticked=frozenset({"pack-b"}), catalog=catalog, state=state
+    )
+
+    assert plan.to_install == ("pack-b",)
+    assert plan.to_remove == ("pack-a",)
 
 
 def test_plan_classifies_skills_by_tick_against_installed_state() -> None:

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -21,15 +21,19 @@ from rich.panel import Panel
 
 from catalog import (
     Catalog,
+    Package,
     agent_unit_id,
     hook_unit_id,
     list_agents,
     list_hooks,
+    list_packages,
     list_rules,
     list_skills,
     load_catalog,
+    resolve_package,
     rule_unit_id,
     skill_unit_id,
+    unit_id,
 )
 from paths import CATALOG_PATH, CLAUDE_ROOT, REPO_ROOT, STATE_ROOT
 from reconcile import (
@@ -38,6 +42,7 @@ from reconcile import (
     apply_hook_reconcile,
     apply_rule_reconcile,
     apply_skill_reconcile,
+    package_installed,
     plan_agent_reconcile,
     plan_hook_reconcile,
     plan_rule_reconcile,
@@ -165,6 +170,23 @@ def hook_rows(*, catalog: Catalog, state: State) -> list[str]:
     return _unit_rows(
         names=list_hooks, unit_id_of=hook_unit_id, catalog=catalog, state=state
     )
+
+
+def package_rows(*, catalog: Catalog, state: State) -> list[str]:
+    """Pair each catalog package with its refcount-derived install marker (via
+    package_installed) so the Packages tab renders status, and show the member
+    units the package pulls in alongside it."""
+    rows: list[str] = []
+    for name in list_packages(catalog=catalog):
+        package: Package = resolve_package(catalog, name)
+        marker: str = (
+            MARKER_INSTALLED
+            if package_installed(catalog=catalog, name=name, state=state)
+            else MARKER_NOT_INSTALLED
+        )
+        members: str = ", ".join(unit_id(unit) for unit in package.units)
+        rows.append(f"{marker} {name}  ({members})")
+    return rows
 
 
 # ---------------------------------------------------------------------------

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -40,11 +40,13 @@ from reconcile import (
     ReconcilePlan,
     apply_agent_reconcile,
     apply_hook_reconcile,
+    apply_package_reconcile,
     apply_rule_reconcile,
     apply_skill_reconcile,
     package_installed,
     plan_agent_reconcile,
     plan_hook_reconcile,
+    plan_package_reconcile,
     plan_rule_reconcile,
     plan_skill_reconcile,
 )
@@ -62,8 +64,12 @@ NON_TTY_NOTICE: Final[str] = (
     "The interactive menu needs a terminal; run 'at install' in one to use it."
 )
 TAB_PLACEHOLDER: Final[str] = "(empty — populated in a later PR)"
+PACKAGES_CHOICE: Final[str] = "Packages"
+PACKAGES_SELECT_PROMPT: Final[str] = "Select installed packages"
+PACKAGES_CONFIRM_PROMPT: Final[str] = "Apply package changes?"
 MENU_CHOICES: Final[tuple[str, ...]] = (
     "Bundles",
+    PACKAGES_CHOICE,
     "Skills",
     "Agents",
     "Rules",
@@ -306,6 +312,48 @@ def _run_unit_tab(*, tab: _UnitTab, console: Console) -> None:
         console.print(row, markup=False)
 
 
+def _run_packages_tab(*, console: Console) -> None:
+    """Drive the Packages tab end to end — render status, take the ticked selection,
+    plan the refcount diff, confirm, apply, then re-render. It is not a `_UnitTab` under
+    `_run_unit_tab` because apply_package_reconcile threads the `catalog` that the
+    `_ApplyFn` protocol the unit tabs share does not carry."""
+    catalog: Catalog = load_catalog(CATALOG_PATH)
+    state: State = load_state(STATE_ROOT)
+    for row in package_rows(catalog=catalog, state=state):
+        console.print(row, markup=False)
+    choices: list[questionary.Choice] = [
+        questionary.Choice(
+            name, checked=package_installed(catalog=catalog, name=name, state=state)
+        )
+        for name in list_packages(catalog=catalog)
+    ]
+    ticked: list[str] | None = abort_on_esc(
+        questionary.checkbox(PACKAGES_SELECT_PROMPT, choices=choices)
+    ).ask()
+    if ticked is None:
+        return
+    plan: ReconcilePlan = plan_package_reconcile(
+        ticked=frozenset(ticked), catalog=catalog, state=state
+    )
+    if plan.is_empty:
+        return
+    confirmed: bool | None = abort_on_esc(
+        questionary.confirm(PACKAGES_CONFIRM_PROMPT)
+    ).ask()
+    if not confirmed:
+        return
+    state = apply_package_reconcile(
+        plan=plan,
+        catalog=catalog,
+        source_root=REPO_ROOT,
+        state_root=STATE_ROOT,
+        claude_root=CLAUDE_ROOT,
+        state=state,
+    )
+    for row in package_rows(catalog=catalog, state=state):
+        console.print(row, markup=False)
+
+
 def launch_tui() -> int:
     """Bail out on non-interactive stdin: questionary's prompt would otherwise
     block forever waiting on input no CI session can supply."""
@@ -321,6 +369,9 @@ def launch_tui() -> int:
             ).ask()
             if choice is None or choice == "Exit":
                 return 0
+            if choice == PACKAGES_CHOICE:
+                _run_packages_tab(console=console)
+                continue
             tab: _UnitTab | None = _UNIT_TABS.get(choice)
             if tab is not None:
                 _run_unit_tab(tab=tab, console=console)


### PR DESCRIPTION
## Slice 7.5 — Packages view (TUI browse + install/uninstall)

Closes the packages TUI piece of #74. Adds a **Packages** tab so a user can browse catalog packages, see what each pulls in, and tick/untick to install/uninstall — driven entirely by the already-merged refcount primitives (`install_package`/`uninstall_package`, `state.requesters`) from 7.1–7.3.

### What it does
- **Browse** — the new `Packages` tab lists every catalog package with an installed/not-installed marker.
- **Shows what each pulls in** — each row renders its member unit ids, e.g. `✅ architect-pr  (skill/make-pr, agent/tdd-runner, …)`.
- **Install / uninstall** — ticking a package installs it, unticking uninstalls it, through the tested refcount engine, so a unit shared by two packages survives until its last requester is gone.
- **"Installed" is read from the refcount** (`state.requesters`), never guessed from `state.units`.

### How it's built
- `catalog.list_packages(*, catalog)` — package names, sorted.
- `reconcile.package_installed(*, catalog, name, state)` — a package is installed iff every declared unit credits it (guards `bool(package.units)` so a no-units package is never vacuously installed).
- `reconcile.plan_package_reconcile` / `apply_package_reconcile` — diff ticked vs installed packages, then carry it out via `install_package`/`uninstall_package`.
- Refactor: extracted `_diff_selection` shared by `_plan_reconcile` (units) and `plan_package_reconcile` (packages).
- `tui.package_rows` + a dedicated `_run_packages_tab` runner (it threads a `catalog` the unit-tab `_ApplyFn` protocol doesn't carry) + `PACKAGES_CHOICE` wired into `MENU_CHOICES`/`launch_tui`.

### Tests
Built test-first (RED→GREEN per behavior). New tests cover `list_packages`, the refcount predicate, `package_rows`, plan, apply, the end-to-end install-through-menu path, and the marquee **refcount-correct untick through the menu** (two packages sharing a unit → untick one → shared unit survives, credited only to the survivor).

- `ruff format --check` ✅ · `ruff check` ✅ · `mypy --strict` ✅
- **136 tests pass** (124 unit + 12 e2e, run with `-W error`); e2e goldens unaffected.

### Scope
TUI view only. Out of scope (later slices): the `--package` CLI (8.2), bundles (8.x), a packages e2e golden scenario (7.e2e), and 7.6's rule/gate dep composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
