### PR TITLE
feat(installer): package e2e — refcount lifecycle + staged extras, wire `at --package` (slice 7.e2e)

### DIFF
--- a/installer/at.py
+++ b/installer/at.py
@@ -19,6 +19,7 @@ from catalog import (
     hook_unit_id,
     list_agents,
     list_hooks,
+    list_packages,
     list_rules,
     list_skills,
     load_catalog,
@@ -30,10 +31,13 @@ from reconcile import (
     ReconcilePlan,
     apply_agent_reconcile,
     apply_hook_reconcile,
+    apply_package_reconcile,
     apply_rule_reconcile,
     apply_skill_reconcile,
+    package_installed,
     plan_agent_reconcile,
     plan_hook_reconcile,
+    plan_package_reconcile,
     plan_rule_reconcile,
     plan_skill_reconcile,
 )
@@ -219,6 +223,34 @@ def _run_per_kind(
     return 0
 
 
+def _run_packages(*, names: tuple[str, ...]) -> int:
+    """Install the named packages non-interactively through the refcount engine — the
+    packages-tier analogue of `_run_per_kind`. It is kept out of the `_Kind` dispatch
+    because apply_package_reconcile threads the `catalog` that the `_ApplyReconcile`
+    protocol the per-kind path shares cannot carry. Ticks the union of already-installed
+    packages and the named ones, so installing one never withdraws another."""
+    catalog: Catalog = load_catalog(_catalog_path())
+    state: State = load_state(STATE_ROOT)
+    installed: set[str] = {
+        name
+        for name in list_packages(catalog=catalog)
+        if package_installed(catalog=catalog, name=name, state=state)
+    }
+    ticked: frozenset[str] = frozenset(installed | set(names))
+    plan: ReconcilePlan = plan_package_reconcile(
+        ticked=ticked, catalog=catalog, state=state
+    )
+    apply_package_reconcile(
+        plan=plan,
+        catalog=catalog,
+        source_root=_source_root(),
+        state_root=STATE_ROOT,
+        claude_root=CLAUDE_ROOT,
+        state=state,
+    )
+    return 0
+
+
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(
     AT_VERSION, "--version", prog_name="at", message="%(prog)s %(version)s"
@@ -232,6 +264,7 @@ def cli() -> None:
 @click.option("--agent", "agents", multiple=True, metavar="<name>")
 @click.option("--rule", "rules", multiple=True, metavar="<name>")
 @click.option("--hook", "hooks", multiple=True, metavar="<name>")
+@click.option("--package", "packages", multiple=True, metavar="<name>")
 @click.option("--all", "install_all", is_flag=True)
 # Accepted so a scripted `install --all` can pass it, but it changes nothing: the
 # --all path never opens the menu, so the flag never needs to reach the callback.
@@ -241,10 +274,13 @@ def install(
     agents: tuple[str, ...],
     rules: tuple[str, ...],
     hooks: tuple[str, ...],
+    packages: tuple[str, ...],
     install_all: bool,
 ) -> int:
-    """Install named units (--skill/--agent/--rule/--hook/--all) without the menu,
-    else open it."""
+    """Install named units (--skill/--agent/--rule/--hook) or packages (--package),
+    or every skill (--all), without the menu; else open it."""
+    if packages:
+        return _run_packages(names=packages)
     if skills or agents or rules or hooks:
         requested: tuple[tuple[_Kind, tuple[str, ...]], ...] = (
             (_SKILL, skills),

--- a/installer/at.py
+++ b/installer/at.py
@@ -223,12 +223,15 @@ def _run_per_kind(
     return 0
 
 
-def _run_packages(*, names: tuple[str, ...]) -> int:
-    """Install the named packages non-interactively through the refcount engine — the
-    packages-tier analogue of `_run_per_kind`. It is kept out of the `_Kind` dispatch
-    because apply_package_reconcile threads the `catalog` that the `_ApplyReconcile`
-    protocol the per-kind path shares cannot carry. Ticks the union of already-installed
-    packages and the named ones, so installing one never withdraws another."""
+def _run_packages(*, names: tuple[str, ...], additive: bool) -> int:
+    """Install or uninstall the named packages non-interactively through the refcount
+    engine — the packages-tier analogue of `_run_per_kind`. It is kept out of the
+    `_Kind` dispatch because apply_package_reconcile threads the `catalog` that the
+    `_ApplyReconcile` protocol the per-kind path shares cannot carry. `additive` picks
+    the ticked set the same way `_run_per_kind` does: install joins the named packages
+    to those already installed (`installed | names`, so installing one never withdraws
+    another), uninstall drops them (`installed - names`), leaving units a still-claiming
+    package needs in place by refcount."""
     catalog: Catalog = load_catalog(_catalog_path())
     state: State = load_state(STATE_ROOT)
     installed: set[str] = {
@@ -236,7 +239,10 @@ def _run_packages(*, names: tuple[str, ...]) -> int:
         for name in list_packages(catalog=catalog)
         if package_installed(catalog=catalog, name=name, state=state)
     }
-    ticked: frozenset[str] = frozenset(installed | set(names))
+    selected: set[str] = set(names)
+    ticked: frozenset[str] = frozenset(
+        installed | selected if additive else installed - selected
+    )
     plan: ReconcilePlan = plan_package_reconcile(
         ticked=ticked, catalog=catalog, state=state
     )
@@ -280,7 +286,7 @@ def install(
     """Install named units (--skill/--agent/--rule/--hook) or packages (--package),
     or every skill (--all), without the menu; else open it."""
     if packages:
-        return _run_packages(names=packages)
+        return _run_packages(names=packages, additive=True)
     if skills or agents or rules or hooks:
         requested: tuple[tuple[_Kind, tuple[str, ...]], ...] = (
             (_SKILL, skills),
@@ -302,18 +308,23 @@ def install(
 @click.option("--agent", "agents", multiple=True, metavar="<name>")
 @click.option("--rule", "rules", multiple=True, metavar="<name>")
 @click.option("--hook", "hooks", multiple=True, metavar="<name>")
+@click.option("--package", "packages", multiple=True, metavar="<name>")
 def uninstall(
     skills: tuple[str, ...],
     agents: tuple[str, ...],
     rules: tuple[str, ...],
     hooks: tuple[str, ...],
+    packages: tuple[str, ...],
 ) -> int:
-    """Uninstall named units (--skill/--agent/--rule/--hook); at least one is
-    required."""
-    if not skills and not agents and not rules and not hooks:
+    """Uninstall named units (--skill/--agent/--rule/--hook) or packages (--package);
+    at least one is required."""
+    if not skills and not agents and not rules and not hooks and not packages:
         raise click.UsageError(
-            "uninstall requires at least one --skill/--agent/--rule/--hook <name>"
+            "uninstall requires at least one "
+            "--skill/--agent/--rule/--hook/--package <name>"
         )
+    if packages:
+        return _run_packages(names=packages, additive=False)
     requested: tuple[tuple[_Kind, tuple[str, ...]], ...] = (
         (_SKILL, skills),
         (_AGENT, agents),

--- a/installer/at.py
+++ b/installer/at.py
@@ -262,6 +262,7 @@ def _run_packages(*, names: tuple[str, ...], additive: bool) -> int:
     plan: ReconcilePlan = plan_package_reconcile(
         ticked=ticked, catalog=catalog, state=state
     )
+    # State return ignored: lone apply persists via save_state; no inter-kind threading.
     apply_package_reconcile(
         plan=plan,
         catalog=catalog,

--- a/installer/at.py
+++ b/installer/at.py
@@ -161,20 +161,29 @@ _HOOK: Final[_Kind] = _Kind(
 )
 
 
-def _reject_unknown_units(
-    names: list[str], *, kind: _Kind, catalog: Catalog
+def _reject_unknown(
+    *, names: list[str], label: str, known: frozenset[str]
 ) -> int | None:
-    """Reject a name the catalog doesn't list for this kind before any reconcile runs,
-    so a typo fails atomically instead of silently no-opping; names the unknowns on
-    stderr and returns exit code 2, or None when every name is known."""
-    known: frozenset[str] = frozenset(kind.list_names(catalog))
+    """Reject any requested name the catalog doesn't list before reconcile runs, so a
+    typo fails atomically instead of silently no-opping; the one rejection rule shared
+    by the per-kind units path and the packages path. Names the unknowns on stderr and
+    returns exit code 2, or None when every name is known."""
     unknown: list[str] = [name for name in names if name not in known]
     if not unknown:
         return None
     for name in unknown:
-        print(f"error: unknown {kind.label} '{name}'", file=sys.stderr)
+        print(f"error: unknown {label} '{name}'", file=sys.stderr)
     print("Try 'at --help' for usage.", file=sys.stderr)
     return 2
+
+
+def _reject_unknown_units(
+    *, names: list[str], kind: _Kind, catalog: Catalog
+) -> int | None:
+    """Reject a name the catalog doesn't list for this kind before reconcile runs."""
+    return _reject_unknown(
+        names=names, label=kind.label, known=frozenset(kind.list_names(catalog))
+    )
 
 
 def _run_per_kind(
@@ -195,7 +204,7 @@ def _run_per_kind(
         if not names:
             continue
         rejection: int | None = _reject_unknown_units(
-            list(names), kind=kind, catalog=catalog
+            names=list(names), kind=kind, catalog=catalog
         )
         if rejection is not None:
             return rejection
@@ -233,6 +242,13 @@ def _run_packages(*, names: tuple[str, ...], additive: bool) -> int:
     another), uninstall drops them (`installed - names`), leaving units a still-claiming
     package needs in place by refcount."""
     catalog: Catalog = load_catalog(_catalog_path())
+    rejection: int | None = _reject_unknown(
+        names=list(names),
+        label="package",
+        known=frozenset(list_packages(catalog=catalog)),
+    )
+    if rejection is not None:
+        return rejection
     state: State = load_state(STATE_ROOT)
     installed: set[str] = {
         name

--- a/installer/tests/e2e/fixtures/catalog.toml
+++ b/installer/tests/e2e/fixtures/catalog.toml
@@ -15,6 +15,15 @@ units = ["skill/demo-skill", "agent/demo-agent"]
 name = "demo-pack-b"
 units = ["skill/demo-skill-two", "agent/demo-agent"]
 
+# A standalone package that declares an extra so e2e can pin the staging rule:
+# installing it copies the source-relative schemas/ directory to ~/.claude/at/schemas
+# and records the extra (with its content hash) in state. It shares nothing with
+# demo-pack-a / demo-pack-b, so adding it leaves their goldens untouched.
+[[packages]]
+name = "demo-pack-extras"
+units = ["rule/demo-rule"]
+extras = ["schemas"]
+
 [[units]]
 kind = "skill"
 name = "demo-skill"

--- a/installer/tests/e2e/fixtures/catalog.toml
+++ b/installer/tests/e2e/fixtures/catalog.toml
@@ -1,8 +1,19 @@
 # Frozen fixture catalog for installer e2e scenarios. Deliberately minimal and
 # stable so goldens change only when installer BEHAVIOUR changes, never when a
 # real skill under ../../skills is edited.
-packages = []
 bundles = []
+
+# Two packages that deliberately SHARE agent/demo-agent so e2e can pin the refcount
+# rule: a unit pulled in by both survives uninstalling one package and is removed only
+# when its last requester package goes. demo-skill / demo-skill-two are each exclusive
+# to one package, so they witness the non-shared side of the same uninstall.
+[[packages]]
+name = "demo-pack-a"
+units = ["skill/demo-skill", "agent/demo-agent"]
+
+[[packages]]
+name = "demo-pack-b"
+units = ["skill/demo-skill-two", "agent/demo-agent"]
 
 [[units]]
 kind = "skill"

--- a/installer/tests/e2e/fixtures/schemas/demo-schema.json
+++ b/installer/tests/e2e/fixtures/schemas/demo-schema.json
@@ -1,0 +1,1 @@
+{"demo": "schema"}

--- a/installer/tests/e2e/goldens/install_package_with_extras.golden
+++ b/installer/tests/e2e/goldens/install_package_with_extras.golden
@@ -1,0 +1,9 @@
+dir .claude/at
+dir .claude/at/schemas
+file .claude/at/schemas/demo-schema.json 0caf2bd5dfff062ff9d07d6123ce36e1fc5a4f02677f2e913b27c04c6075f98e
+dir .claude/at/staged
+dir .claude/at/staged/rule
+file .claude/at/staged/rule/demo-rule 94b4fcca183f1a395b2231260530d3d608b66d70206d8eff1d0000d680d65d6a
+json .claude/at/state.json {"extra_hashes":{"schemas":"e8224ef72a3b8e9463978953355c1fc546f9b5a093e20f0ca8169a2ab20fc752"},"extras":{"schemas":["demo-pack-extras"]},"requesters":{"rule/demo-rule":["demo-pack-extras"]},"units":{"rule/demo-rule":"94b4fcca183f1a395b2231260530d3d608b66d70206d8eff1d0000d680d65d6a"},"version":1}
+dir .claude/rules
+link .claude/rules/demo-rule.md -> .claude/at/staged/rule/demo-rule

--- a/installer/tests/e2e/goldens/uninstall_package_keeps_shared.golden
+++ b/installer/tests/e2e/goldens/uninstall_package_keeps_shared.golden
@@ -1,0 +1,12 @@
+dir .claude/agents
+link .claude/agents/demo-agent.md -> .claude/at/staged/agent/demo-agent
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/agent
+file .claude/at/staged/agent/demo-agent b5ab887c16f11fd42f38c3972bb7019d601a4686b12069ba3e4ef87ac5c5f831
+dir .claude/at/staged/skill
+dir .claude/at/staged/skill/demo-skill-two
+file .claude/at/staged/skill/demo-skill-two/SKILL.md ff3436a0c12035b4212dc3a83fa396ab7f1135f50314e0490715d0848bf8b460
+json .claude/at/state.json {"requesters":{"agent/demo-agent":["demo-pack-b"],"skill/demo-skill-two":["demo-pack-b"]},"units":{"agent/demo-agent":"b5ab887c16f11fd42f38c3972bb7019d601a4686b12069ba3e4ef87ac5c5f831","skill/demo-skill-two":"112a14a7446a409b98435238e9dfdc915640e3aa94434ace60644531e0e09bf5"},"version":1}
+dir .claude/skills
+link .claude/skills/demo-skill-two -> .claude/at/staged/skill/demo-skill-two

--- a/installer/tests/e2e/goldens/uninstall_package_removes_at_refcount_zero.golden
+++ b/installer/tests/e2e/goldens/uninstall_package_removes_at_refcount_zero.golden
@@ -1,0 +1,7 @@
+dir .claude/agents
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/agent
+dir .claude/at/staged/skill
+json .claude/at/state.json {"units":{},"version":1}
+dir .claude/skills

--- a/installer/tests/e2e/test_packages.py
+++ b/installer/tests/e2e/test_packages.py
@@ -1,0 +1,58 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+from harness import FIXTURES_DIR, GOLDENS_DIR, assert_matches_golden, run_at, snapshot
+
+
+@pytest.mark.e2e
+def test_package_refcount_governs_shared_unit_lifecycle(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    install_result: subprocess.CompletedProcess[str] = run_at(
+        args=[
+            "install",
+            "--package",
+            "demo-pack-a",
+            "--package",
+            "demo-pack-b",
+            "--non-interactive",
+        ],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    # demo-pack-a and demo-pack-b both pull in agent/demo-agent. Uninstalling one
+    # must leave the shared agent (still claimed by the other) and the survivor's own
+    # demo-skill-two in place while dropping demo-pack-a's exclusive demo-skill.
+    keep_result: subprocess.CompletedProcess[str] = run_at(
+        args=["uninstall", "--package", "demo-pack-a"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert keep_result.returncode == 0, keep_result.stderr
+    assert_matches_golden(
+        name="uninstall_package_keeps_shared",
+        actual=snapshot(home),
+        goldens_dir=GOLDENS_DIR,
+    )
+
+    # demo-pack-b is the last requester of the shared agent, so uninstalling it drops
+    # the refcount to zero and the agent is finally removed.
+    remove_result: subprocess.CompletedProcess[str] = run_at(
+        args=["uninstall", "--package", "demo-pack-b"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert remove_result.returncode == 0, remove_result.stderr
+    assert_matches_golden(
+        name="uninstall_package_removes_at_refcount_zero",
+        actual=snapshot(home),
+        goldens_dir=GOLDENS_DIR,
+    )

--- a/installer/tests/e2e/test_packages.py
+++ b/installer/tests/e2e/test_packages.py
@@ -56,3 +56,27 @@ def test_package_refcount_governs_shared_unit_lifecycle(tmp_path: Path) -> None:
         actual=snapshot(home),
         goldens_dir=GOLDENS_DIR,
     )
+
+
+@pytest.mark.e2e
+def test_package_install_stages_declared_extras(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    # demo-pack-extras declares extras = ["schemas"], so installing it must copy the
+    # source-relative schemas/ directory to ~/.claude/at/schemas and record the extra
+    # (with its content hash) in state — the golden pins both the staged file and the
+    # state bookkeeping.
+    install_result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--package", "demo-pack-extras", "--non-interactive"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+    assert_matches_golden(
+        name="install_package_with_extras",
+        actual=snapshot(home),
+        goldens_dir=GOLDENS_DIR,
+    )

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -1968,3 +1968,76 @@ def test_install_rejects_unknown_name_in_any_kind_before_applying_any(
     assert not skill_link.exists() and not skill_link.is_symlink()
     assert not skill_staging.exists()
     assert skill_unit_id("good-skill") not in final_state.units
+
+
+def test_uninstall_package_flag_decrements_refcount_keeping_shared_unit(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # Real skill sources for the shared unit and each package's exclusive unit, so the
+    # pre-install can place live symlinks and staging before the uninstall runs.
+    for name in ("shared", "only-a", "only-b"):
+        source: Path = repo_root / "skills" / name / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(f"# {name}\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "bundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "shared"\n\n'
+        '[[units]]\nkind = "skill"\nname = "only-a"\n\n'
+        '[[units]]\nkind = "skill"\nname = "only-b"\n\n'
+        '[[packages]]\nname = "pack-a"\nunits = ["skill/shared", "skill/only-a"]\n\n'
+        '[[packages]]\nname = "pack-b"\nunits = ["skill/shared", "skill/only-b"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # Pre-install both packages through the real public install action, so the shared
+    # unit carries both packages as requesters and each exclusive unit carries its own.
+    catalog: Catalog = load_catalog(catalog_file)
+    state: State = load_state(state_root)
+    for package_name in ("pack-a", "pack-b"):
+        state = install_package(
+            name=package_name,
+            catalog=catalog,
+            source_root=repo_root,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=state,
+        )
+
+    # Uninstalling a package must withdraw its claim without ever opening the TUI:
+    # route every questionary prompt to a factory that fails loudly, so a regression
+    # that falls back through launch_tui's select/checkbox/confirm trips this guard.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["uninstall", "--package", "pack-a"])
+
+    # `uninstall --package pack-a` is a refcount decrement: pack-a's exclusive unit
+    # only-a is reclaimed (its link, staging, and state entry go), while the shared unit
+    # survives on pack-b's remaining credit — still linked and now requested by pack-b
+    # alone — and pack-b's own exclusive unit only-b stays installed.
+    final_state: State = load_state(state_root)
+    only_a_link: Path = claude_root / "skills" / "only-a"
+    shared_link: Path = claude_root / "skills" / "shared"
+    only_b_link: Path = claude_root / "skills" / "only-b"
+    assert exit_code == 0
+    assert skill_unit_id("only-a") not in final_state.units
+    assert not only_a_link.exists() and not only_a_link.is_symlink()
+    assert skill_unit_id("shared") in final_state.units
+    assert shared_link.is_symlink()
+    assert final_state.requesters[skill_unit_id("shared")] == ("pack-b",)
+    assert skill_unit_id("only-b") in final_state.units
+    assert only_b_link.is_symlink()

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -1644,6 +1644,60 @@ def test_install_unknown_skill_errors_with_exit_two_and_installs_nothing(
     assert skill_unit_id("nonesuch") not in final_state.units
 
 
+def test_install_unknown_package_errors_with_exit_two_and_installs_nothing(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # The catalog declares a real package (demo-pack -> demo-skill) but never
+    # 'nonesuch', so the request names an unknown package while the catalog still
+    # holds a valid one. The package's member skill source is staged so that a
+    # mistaken install of demo-pack would succeed — making a no-op the only way
+    # nothing lands.
+    source: Path = repo_root / "skills" / "demo-skill" / "SKILL.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("# demo-skill\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "bundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-skill"\n\n'
+        '[[packages]]\nname = "demo-pack"\nunits = ["skill/demo-skill"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # The error path must stay non-interactive: route every questionary prompt to a
+    # factory that fails loudly, so a regression that falls back into launch_tui's
+    # select/checkbox/confirm trips this guard instead of silently prompting.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["install", "--package", "nonesuch"])
+
+    # An unknown --package name is rejected atomically before any apply: main exits 2
+    # and names the bad package ('nonesuch') on stderr, and nothing is installed — the
+    # real package's member skill never lands (no link, no state entry), so a typo
+    # fails loudly instead of silently no-opping.
+    captured_err: str = capsys.readouterr().err
+    final_state: State = load_state(state_root)
+    skill_link: Path = claude_root / "skills" / "demo-skill"
+    assert exit_code == 2
+    assert captured_err != ""
+    assert "nonesuch" in captured_err
+    assert not skill_link.exists() and not skill_link.is_symlink()
+    assert skill_unit_id("demo-skill") not in final_state.units
+
+
 @pytest.mark.parametrize(
     "argv",
     [["install", "--skill"], ["uninstall", "--skill"], ["uninstall"]],

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -1257,6 +1257,55 @@ def test_install_skill_flag_installs_named_skill_non_interactively(
     assert skill_unit_id("demo-skill") in final_state.units
 
 
+def test_install_package_flag_installs_named_package_non_interactively(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # A real skill source on disk is the only input the non-interactive install needs;
+    # nothing is installed up front, so installing demo-pack must place its member skill
+    # through the refcount-aware package install and credit the package as that unit's
+    # requester — the packages-tier analogue of the --skill flag.
+    source: Path = repo_root / "skills" / "demo-skill" / "SKILL.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("# demo-skill\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "bundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "demo-skill"\n\n'
+        '[[packages]]\nname = "demo-pack"\nunits = ["skill/demo-skill"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # The --package path must place the package without ever opening the TUI: route
+    # every questionary prompt to a factory that fails loudly, so a regression that
+    # falls back through launch_tui's select/checkbox/confirm trips this guard.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["install", "--package", "demo-pack"])
+
+    # Installing demo-pack places its member skill live and records demo-pack as that
+    # unit's sole requester, so the package's refcount credit — not a @direct marker —
+    # is what holds the skill installed.
+    final_state: State = load_state(state_root)
+    skill_link: Path = claude_root / "skills" / "demo-skill"
+    assert exit_code == 0
+    assert skill_link.is_symlink()
+    assert final_state.requesters[skill_unit_id("demo-skill")] == ("demo-pack",)
+
+
 def test_multiple_skill_flags_install_all_named_skills_additively(
     monkeypatch: MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Slice 7.e2e — Packages e2e: refcount lifecycle + staged extras (closes slice 7)

Wires the **package tier into the non-interactive `at` CLI** and pins the package refcount + staged-extras behavior with committed **golden e2e scenarios** driven by the real `at` subprocess.

Like the earlier **5.e2e** slice (which first had to wire `at --agent/--rule`), the e2e harness drives only the real `at` subprocess — the package refcount engine was previously reachable only through the interactive TUI — so this slice first enables `at install/uninstall --package`, then proves the behavior end-to-end.

### What changed

- **`installer/at.py`** — `at install --package <name>` and `at uninstall --package <name>`, routed through the **existing** refcount engine (`plan_package_reconcile` / `apply_package_reconcile` — not reimplemented) via a new `_run_packages(*, names, additive)` that mirrors `tui.py`'s `_run_packages_tab`. Unknown package names are rejected atomically (exit 2) through a shared `_reject_unknown` helper (extracted from `_reject_unknown_units`, no duplication).
- **`installer/tests/test_at.py`** — in-process CLI coverage: install credits the requester; uninstall decrements refcount keeping a shared unit; unknown `--package` rejected.
- **`installer/tests/e2e/test_packages.py`** + fixtures + **3 committed goldens** — driving the real `at --package`:
  - `uninstall_package_keeps_shared.golden` — a unit two packages share survives uninstalling one (requester updated to the survivor), the uninstalled package's exclusive unit is removed.
  - `uninstall_package_removes_at_refcount_zero.golden` — the shared unit is removed only when its **last** requester package is uninstalled.
  - `install_package_with_extras.golden` — a package's declared `extras` are staged under `~/.claude/at/<relpath>` and recorded in `state.json` (`extras` + `extra_hashes`).

### Behaviors (all built test-first, RED→GREEN)

| # | Behavior |
|---|----------|
| B1 | `at install --package` installs units, credits requester |
| B2 | `at uninstall --package` decrements refcount; shared unit survives |
| B3 | unknown `--package` rejected atomically (exit 2, nothing applied) |
| B4 | e2e: shared unit survives one uninstall, removed at refcount 0 (2 goldens) |
| B5 | e2e: declared `extras` staged + recorded in state (1 golden) |

### Verification

- `ruff format --check` ✓ · `ruff check` ✓ · `mypy --strict` ✓ · **`pytest -W error` = 144 passed** (incl. the real-`at` e2e subprocess tests).
- Scope held to packages: no production refcounting reimplemented; bundles, `--bundle`/`--package` in `at status`/`--all`, and slice 8 CLI work are out of scope.

Relates to #74 (slice 7 → 7/7 complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
