### PR TITLE
feat(installer): bundle model + Bundles tab (slice 8.1)

### DIFF
--- a/installer/catalog.py
+++ b/installer/catalog.py
@@ -33,9 +33,10 @@ class Package:
 
 @dataclass(frozen=True)
 class Bundle:
-    """An opinionated pick of packages (by name), the coarsest install choice.
-    Package names are kept raw here; resolving and validating bundle->package
-    refs is deferred to the slice that makes the bundle tier load-bearing."""
+    """An opinionated pick of packages by name, the coarsest install choice; the
+    names are kept raw (consumers want names, not resolved Packages) while
+    load_catalog still rejects a bundle naming an undeclared package at parse
+    time."""
 
     name: str
     packages: tuple[str, ...]
@@ -141,6 +142,12 @@ def list_packages(*, catalog: Catalog) -> list[str]:
     return sorted(package.name for package in catalog.packages)
 
 
+def list_bundles(*, catalog: Catalog) -> list[str]:
+    """Surface the installable bundles by name in a stable order, so a UI
+    listing doesn't depend on declaration order in the toml."""
+    return sorted(bundle.name for bundle in catalog.bundles)
+
+
 def _resolve(ref: str, by_id: dict[str, Unit], package: str) -> Unit:
     """Turn a package's unit id into the declared Unit, failing loudly at parse
     time with the dangling ref named rather than silently dropping it."""
@@ -163,6 +170,17 @@ def _build_package(row: dict[str, object], by_id: dict[str, Unit]) -> Package:
     )
 
 
+def _build_bundle(*, row: dict[str, object], package_names: frozenset[str]) -> Bundle:
+    """Build a bundle, failing loudly at parse time with any dangling package ref
+    named rather than deferring the error to a lazy resolve downstream."""
+    name: str = cast("str", row["name"])
+    refs: tuple[str, ...] = tuple(cast("list[str]", row["packages"]))
+    for ref in refs:
+        if ref not in package_names:
+            raise ValueError(f"bundle {name!r} references undeclared package {ref!r}")
+    return Bundle(name=name, packages=refs)
+
+
 def resolve_package(catalog: Catalog, name: str) -> Package:
     """Turn a package name into its declared Package — the unit set plus extras —
     in one place, so callers select a curated group without re-scanning the
@@ -177,6 +195,18 @@ def resolve_package(catalog: Catalog, name: str) -> Package:
         raise ValueError(
             f"package {name!r} is not declared in the catalog"
         ) from missing
+
+
+def resolve_bundle(*, catalog: Catalog, name: str) -> Bundle:
+    """Turn a bundle name into its declared Bundle — the package set — in one
+    place, so callers select a curated tier without re-scanning the bundle table;
+    an undeclared name fails loudly here rather than silently resolving to nothing
+    downstream."""
+    by_name: dict[str, Bundle] = {bundle.name: bundle for bundle in catalog.bundles}
+    try:
+        return by_name[name]
+    except KeyError as missing:
+        raise ValueError(f"bundle {name!r} is not declared in the catalog") from missing
 
 
 def load_catalog(path: Path) -> Catalog:
@@ -195,12 +225,10 @@ def load_catalog(path: Path) -> Catalog:
         _build_package(row, by_id)
         for row in cast("list[dict[str, object]]", raw["packages"])
     )
+    package_names: frozenset[str] = frozenset(package.name for package in packages)
 
     bundles: tuple[Bundle, ...] = tuple(
-        Bundle(
-            name=cast("str", row["name"]),
-            packages=tuple(cast("list[str]", row["packages"])),
-        )
+        _build_bundle(row=row, package_names=package_names)
         for row in cast("list[dict[str, object]]", raw["bundles"])
     )
 

--- a/installer/reconcile.py
+++ b/installer/reconcile.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
@@ -16,15 +16,18 @@ from actions import (
     uninstall_skill,
 )
 from catalog import (
+    Bundle,
     Catalog,
     Package,
     agent_unit_id,
     hook_unit_id,
     list_agents,
+    list_bundles,
     list_hooks,
     list_packages,
     list_rules,
     list_skills,
+    resolve_bundle,
     resolve_package,
     rule_unit_id,
     skill_unit_id,
@@ -139,6 +142,18 @@ def package_installed(*, catalog: Catalog, name: str, state: State) -> bool:
     )
 
 
+def bundle_installed(*, catalog: Catalog, name: str, state: State) -> bool:
+    """Report a bundle as installed iff every package it declares reads installed
+    by the same refcount predicate the packages tier uses (package_installed), so
+    the bundle view reads its members' state rather than re-deriving it; a bundle
+    that declares no packages is never installed, never vacuously true."""
+    bundle: Bundle = resolve_bundle(catalog=catalog, name=name)
+    return bool(bundle.packages) and all(
+        package_installed(catalog=catalog, name=package, state=state)
+        for package in bundle.packages
+    )
+
+
 def plan_package_reconcile(
     *, ticked: frozenset[str], catalog: Catalog, state: State
 ) -> ReconcilePlan:
@@ -150,6 +165,22 @@ def plan_package_reconcile(
         name
         for name in names
         if package_installed(catalog=catalog, name=name, state=state)
+    }
+    return _diff_selection(names=names, ticked=ticked, installed=installed)
+
+
+def plan_bundle_reconcile(
+    *, ticked: frozenset[str], catalog: Catalog, state: State
+) -> ReconcilePlan:
+    """Diff the ticked selection against the catalog's bundles, taking "installed"
+    from bundle_installed (every member package installed) rather than loose unit
+    presence, so the apply step works from a decided plan instead of re-deriving
+    the diff."""
+    names: list[str] = list_bundles(catalog=catalog)
+    installed: set[str] = {
+        name
+        for name in names
+        if bundle_installed(catalog=catalog, name=name, state=state)
     }
     return _diff_selection(names=names, ticked=ticked, installed=installed)
 
@@ -327,3 +358,53 @@ def apply_package_reconcile(
             state=current,
         )
     return current
+
+
+def _bundle_packages(*, catalog: Catalog, bundles: Iterable[str]) -> set[str]:
+    """Collect the member packages of a set of bundles into one deduped set, the
+    bundle->package join every bundle-tier apply needs to translate a bundle diff
+    into the package diff the tested package engine runs."""
+    return {
+        package
+        for name in bundles
+        for package in resolve_bundle(catalog=catalog, name=name).packages
+    }
+
+
+def apply_bundle_reconcile(
+    *,
+    plan: ReconcilePlan,
+    ticked: frozenset[str],
+    catalog: Catalog,
+    source_root: Path,
+    state_root: Path,
+    claude_root: Path,
+    state: State,
+) -> State:
+    """Carry out a planned bundle diff by translating it into a package diff and
+    delegating to the refcount-aware apply_package_reconcile, so the bundle tier
+    composes the tested package engine rather than reimplementing install/uninstall.
+
+    `ticked` carries every bundle the user left selected — the unchanged-still-installed
+    bundles that `plan` alone cannot name, since `plan` only records the transitions.
+    A package a dropped bundle shares with a still-ticked bundle must survive, so we
+    remove a dropped bundle's package only when no kept bundle still claims it; the
+    package tier's own unit refcount then does the rest of the survival bookkeeping."""
+    to_install: tuple[str, ...] = tuple(
+        sorted(_bundle_packages(catalog=catalog, bundles=plan.to_install))
+    )
+    kept: set[str] = _bundle_packages(catalog=catalog, bundles=ticked)
+    to_remove: tuple[str, ...] = tuple(
+        sorted(_bundle_packages(catalog=catalog, bundles=plan.to_remove) - kept)
+    )
+    package_plan: ReconcilePlan = ReconcilePlan(
+        to_install=to_install, to_remove=to_remove
+    )
+    return apply_package_reconcile(
+        plan=package_plan,
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state,
+    )

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -18,6 +18,7 @@ from actions import (
 )
 from at import main
 from catalog import (
+    Bundle,
     Catalog,
     Package,
     Unit,
@@ -36,6 +37,7 @@ from tui import (
     TAB_PLACEHOLDER,
     abort_on_esc,
     agent_rows,
+    bundle_rows,
     hook_rows,
     package_rows,
     rule_rows,
@@ -201,6 +203,35 @@ def test_package_rows_marks_installed_by_refcount_sorted_with_member_ids() -> No
     assert rows == [
         f"{MARKER_INSTALLED} pack-a  (skill/beta)",
         f"{MARKER_NOT_INSTALLED} pack-z  (skill/alpha, agent/helper)",
+    ]
+
+
+def test_bundle_rows_marks_installed_by_refcount_sorted_with_member_packages() -> None:
+    catalog: Catalog = Catalog(
+        units=(
+            Unit(kind="skill", name="alpha"),
+            Unit(kind="skill", name="beta"),
+        ),
+        packages=(
+            Package(name="pack-x", units=(Unit(kind="skill", name="alpha"),)),
+            Package(name="pack-y", units=(Unit(kind="skill", name="beta"),)),
+        ),
+        bundles=(
+            Bundle(name="bundle-z", packages=("pack-x", "pack-y")),
+            Bundle(name="bundle-a", packages=("pack-x",)),
+        ),
+    )
+    # Credit pack-x's only unit so it reads installed; bundle-a's every member
+    # package (only pack-x) is installed, so bundle-a reads installed. bundle-z also
+    # needs pack-y, which stays uncredited, so bundle-z is not installed. units stays
+    # empty so a passing row can only come from requesters, not loose unit presence.
+    state: State = State(version=1, units={}, requesters={"skill/alpha": ("pack-x",)})
+
+    rows: list[str] = bundle_rows(catalog=catalog, state=state)
+
+    assert rows == [
+        f"{MARKER_INSTALLED} bundle-a  (pack-x)",
+        f"{MARKER_NOT_INSTALLED} bundle-z  (pack-x, pack-y)",
     ]
 
 
@@ -486,6 +517,69 @@ def test_packages_tab_installs_ticked_package_through_reconcile(
     assert skill_link.is_symlink()
     assert final_state.requesters[skill_unit_id("demo-skill")] == ("demo-pack",)
     assert f"{MARKER_INSTALLED} demo-pack" in captured
+    assert TAB_PLACEHOLDER not in captured
+
+
+def test_bundles_tab_installs_ticked_bundle_through_reconcile(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("tui.STATE_ROOT", state_root)
+    monkeypatch.setattr("tui.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("tui.REPO_ROOT", repo_root)
+
+    # A real skill source on disk is the only input the install needs; nothing is
+    # installed up front, so ticking demo-bundle through the Bundles tab must place its
+    # member package's skill via the refcount-aware bundle reconcile and credit the
+    # package as that unit's requester — the bundles-tier analogue of how the Packages
+    # tab installs a ticked package.
+    skill_source: Path = repo_root / "skills" / "demo-skill" / "SKILL.md"
+    skill_source.parent.mkdir(parents=True)
+    skill_source.write_text("# demo-skill\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        '[[units]]\nkind = "skill"\nname = "demo-skill"\n\n'
+        '[[packages]]\nname = "demo-pack"\nunits = ["skill/demo-skill"]\n\n'
+        '[[bundles]]\nname = "demo-bundle"\npackages = ["demo-pack"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("tui.CATALOG_PATH", catalog_file)
+    # The tab menu opens the Bundles tab, then closes it after the reconcile applies.
+    select_answers: Iterator[str] = iter(["Bundles", "Exit"])
+
+    class FakeSelect:
+        def ask(self) -> str:
+            return next(select_answers)
+
+    # Tick the lone catalog bundle by name so the desired set installs demo-bundle.
+    class FakeCheckbox:
+        def ask(self) -> list[str]:
+            return ["demo-bundle"]
+
+    class ConfirmPrompt:
+        def ask(self) -> bool:
+            return True
+
+    monkeypatch.setattr("questionary.select", lambda *args, **kwargs: FakeSelect())
+    monkeypatch.setattr("questionary.checkbox", lambda *args, **kwargs: FakeCheckbox())
+    monkeypatch.setattr("questionary.confirm", lambda *args, **kwargs: ConfirmPrompt())
+
+    exit_code: int = main(["install"])
+
+    # Ticking demo-bundle applies plan_bundle_reconcile then apply_bundle_reconcile, so
+    # the bundle's member package's skill ends up linked live and credited to demo-pack
+    # in state, and the bundle rows re-render with the installed marker.
+    captured: str = capsys.readouterr().out
+    final_state: State = load_state(state_root)
+    skill_link: Path = claude_root / "skills" / "demo-skill"
+    assert exit_code == 0
+    assert skill_link.is_symlink()
+    assert final_state.requesters[skill_unit_id("demo-skill")] == ("demo-pack",)
+    assert f"{MARKER_INSTALLED} demo-bundle" in captured
     assert TAB_PLACEHOLDER not in captured
 
 

--- a/installer/tests/test_catalog.py
+++ b/installer/tests/test_catalog.py
@@ -9,11 +9,13 @@ from catalog import (
     Package,
     Unit,
     list_agents,
+    list_bundles,
     list_hooks,
     list_packages,
     list_rules,
     list_skills,
     load_catalog,
+    resolve_bundle,
     resolve_package,
     skill_unit_id,
 )
@@ -222,6 +224,22 @@ def test_resolve_package_raises_naming_an_undeclared_package(tmp_path: Path) -> 
         resolve_package(catalog, "ghost")
 
 
+def test_resolve_bundle_returns_the_named_bundle(tmp_path: Path) -> None:
+    catalog: Catalog = load_catalog(_write(tmp_path, _FIXTURE))
+
+    bundle: Bundle = resolve_bundle(catalog=catalog, name="everything")
+
+    assert bundle == Bundle(name="everything", packages=("pack",))
+
+
+def test_resolve_bundle_raises_naming_an_undeclared_bundle(tmp_path: Path) -> None:
+    catalog: Catalog = load_catalog(_write(tmp_path, _FIXTURE))
+
+    # A name with no matching bundle fails loudly, naming the missing bundle.
+    with pytest.raises(ValueError, match="ghost"):
+        resolve_bundle(catalog=catalog, name="ghost")
+
+
 def test_list_skills_returns_only_skill_names_sorted(tmp_path: Path) -> None:
     catalog: Catalog = load_catalog(_write(tmp_path, _FIXTURE))
 
@@ -269,6 +287,22 @@ def test_list_packages_returns_package_names_sorted() -> None:
     assert list_packages(catalog=catalog) == ["alpha", "zeta"]
 
 
+def test_list_bundles_returns_bundle_names_sorted() -> None:
+    # Bundles are listed by name in a stable sorted order, independent of their
+    # declaration order in the catalog (here zeta is declared before alpha).
+    shared: Unit = Unit(kind="skill", name="alpha")
+    catalog: Catalog = Catalog(
+        units=(shared,),
+        packages=(Package(name="pack", units=(shared,)),),
+        bundles=(
+            Bundle(name="zeta", packages=("pack",)),
+            Bundle(name="alpha", packages=("pack",)),
+        ),
+    )
+
+    assert list_bundles(catalog=catalog) == ["alpha", "zeta"]
+
+
 def test_skill_unit_id_joins_kind_and_name() -> None:
     # The skill-unit id is the join key install status is keyed by; pin it here
     # so the "<kind>/<name>" format lives in exactly one module.
@@ -286,6 +320,20 @@ def test_load_catalog_rejects_package_referencing_undeclared_unit(
     )
 
     with pytest.raises(ValueError, match="skill/does-not-exist"):
+        load_catalog(broken)
+
+
+def test_load_catalog_rejects_bundle_referencing_undeclared_package(
+    tmp_path: Path,
+) -> None:
+    broken: Path = _write(
+        tmp_path,
+        '[[units]]\nkind = "skill"\nname = "make-pr"\n\n'
+        '[[packages]]\nname = "real"\nunits = ["skill/make-pr"]\n\n'
+        '[[bundles]]\nname = "wide"\npackages = ["ghost-package"]\n',
+    )
+
+    with pytest.raises(ValueError, match="ghost-package"):
         load_catalog(broken)
 
 

--- a/installer/tests/test_reconcile.py
+++ b/installer/tests/test_reconcile.py
@@ -8,6 +8,7 @@ from actions import (
     install_skill,
 )
 from catalog import (
+    Bundle,
     Catalog,
     Package,
     Unit,
@@ -22,12 +23,15 @@ from catalog import (
 from reconcile import (
     ReconcilePlan,
     apply_agent_reconcile,
+    apply_bundle_reconcile,
     apply_hook_reconcile,
     apply_package_reconcile,
     apply_rule_reconcile,
     apply_skill_reconcile,
+    bundle_installed,
     package_installed,
     plan_agent_reconcile,
+    plan_bundle_reconcile,
     plan_hook_reconcile,
     plan_package_reconcile,
     plan_rule_reconcile,
@@ -70,6 +74,50 @@ def test_package_installed_requires_every_declared_unit_to_credit_the_package() 
     )
 
 
+def test_bundle_installed_requires_every_declared_package_to_be_installed() -> None:
+    catalog: Catalog = Catalog(
+        units=(skill_unit("alpha"), agent_unit("helper")),
+        packages=(
+            Package(name="pack-a", units=(skill_unit("alpha"),)),
+            Package(name="pack-b", units=(agent_unit("helper"),)),
+        ),
+        bundles=(
+            Bundle(name="full", packages=("pack-a", "pack-b")),
+            Bundle(name="empty", packages=()),
+        ),
+    )
+
+    # Every unit of both member packages credits its package, so both packages read
+    # installed and the bundle is installed. units stays empty so the predicate can
+    # only be reading requesters bookkeeping, not loose unit presence.
+    fully_installed: State = State(
+        version=1,
+        units={},
+        requesters={
+            skill_unit_id("alpha"): ("pack-a",),
+            agent_unit_id("helper"): ("pack-b",),
+        },
+    )
+    assert bundle_installed(catalog=catalog, name="full", state=fully_installed) is True
+
+    # Drop pack-b's credit: one member package is no longer installed, so the bundle
+    # is not fully installed even though pack-a still is.
+    pack_b_uninstalled: State = State(
+        version=1,
+        units={},
+        requesters={skill_unit_id("alpha"): ("pack-a",)},
+    )
+    assert (
+        bundle_installed(catalog=catalog, name="full", state=pack_b_uninstalled)
+        is False
+    )
+
+    # A bundle that declares no packages is never vacuously installed.
+    assert (
+        bundle_installed(catalog=catalog, name="empty", state=fully_installed) is False
+    )
+
+
 def test_plan_classifies_packages_by_refcount_install_not_unit_presence() -> None:
     catalog: Catalog = Catalog(
         units=(skill_unit("alpha"), skill_unit("beta")),
@@ -95,6 +143,36 @@ def test_plan_classifies_packages_by_refcount_install_not_unit_presence() -> Non
 
     assert plan.to_install == ("pack-b",)
     assert plan.to_remove == ("pack-a",)
+
+
+def test_plan_classifies_bundles_by_installed_state_not_unit_presence() -> None:
+    catalog: Catalog = Catalog(
+        units=(skill_unit("alpha"), skill_unit("beta")),
+        packages=(
+            Package(name="pack-a", units=(skill_unit("alpha"),)),
+            Package(name="pack-b", units=(skill_unit("beta"),)),
+        ),
+        bundles=(
+            Bundle(name="bundle-a", packages=("pack-a",)),
+            Bundle(name="bundle-b", packages=("pack-b",)),
+        ),
+    )
+
+    # pack-a's unit credits "pack-a", so bundle-a reads installed via bundle_installed;
+    # bundle-b's package stays uncredited and so is not installed. units is empty so the
+    # diff can only be reading requesters bookkeeping, not loose unit presence.
+    state: State = State(
+        version=1,
+        units={},
+        requesters={skill_unit_id("alpha"): ("pack-a",)},
+    )
+
+    plan: ReconcilePlan = plan_bundle_reconcile(
+        ticked=frozenset({"bundle-b"}), catalog=catalog, state=state
+    )
+
+    assert plan.to_install == ("bundle-b",)
+    assert plan.to_remove == ("bundle-a",)
 
 
 def test_plan_classifies_skills_by_tick_against_installed_state() -> None:
@@ -432,3 +510,147 @@ packages = ["pack-a", "pack-b"]
     # pack-a is now removed: its unit is gone from state and from disk.
     assert skill_unit_id("alpha") not in result.units
     assert not (claude_root / "skills" / "alpha").exists()
+
+
+def test_apply_bundle_reconcile_installs_a_newly_ticked_bundles_packages(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "alpha"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text("# alpha Skill\n", encoding="utf-8")
+
+    # A bundle over one package over one skill, loaded through the real boundary so the
+    # bundle reconcile resolves the member package and its unit exactly as production.
+    catalog_body: str = """
+[[units]]
+kind = "skill"
+name = "alpha"
+
+[[packages]]
+name = "pack-a"
+units = ["skill/alpha"]
+
+[[bundles]]
+name = "bundle-a"
+packages = ["pack-a"]
+"""
+    catalog_path: Path = tmp_path / "catalog.toml"
+    catalog_path.write_text(catalog_body, encoding="utf-8")
+    catalog: Catalog = load_catalog(catalog_path)
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    plan: ReconcilePlan = ReconcilePlan(to_install=("bundle-a",), to_remove=())
+    result: State = apply_bundle_reconcile(
+        plan=plan,
+        ticked=frozenset({"bundle-a"}),
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    persisted: State = load_state(state_root)
+    alpha_id: str = skill_unit_id("alpha")
+
+    # Installing bundle-a places its member package's unit: recorded in state (and
+    # persisted), credited to the package that pulled it in, and linked live — so the
+    # bundle tier delegates to the tested package engine rather than reimplementing it.
+    assert alpha_id in result.units
+    assert alpha_id in persisted.units
+    assert result.requesters[alpha_id] == ("pack-a",)
+    assert (claude_root / "skills" / "alpha").is_symlink()
+
+
+def test_apply_bundle_reconcile_keeps_a_package_shared_by_a_still_ticked_bundle(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    for skill_name in ("shared", "only-a", "only-b"):
+        skill_source: Path = source_root / "skills" / skill_name
+        skill_source.mkdir(parents=True)
+        (skill_source / "SKILL.md").write_text(f"# {skill_name}\n", encoding="utf-8")
+
+    # Two bundles overlapping on pkg-shared; each also carries its own exclusive
+    # package. Loaded through the real boundary so the bundle reconcile resolves the
+    # bundle->package->unit chain exactly as production will.
+    catalog_body: str = """
+[[units]]
+kind = "skill"
+name = "shared"
+
+[[units]]
+kind = "skill"
+name = "only-a"
+
+[[units]]
+kind = "skill"
+name = "only-b"
+
+[[packages]]
+name = "pkg-shared"
+units = ["skill/shared"]
+
+[[packages]]
+name = "pkg-a"
+units = ["skill/only-a"]
+
+[[packages]]
+name = "pkg-b"
+units = ["skill/only-b"]
+
+[[bundles]]
+name = "bundle-x"
+packages = ["pkg-shared", "pkg-a"]
+
+[[bundles]]
+name = "bundle-y"
+packages = ["pkg-shared", "pkg-b"]
+"""
+    catalog_path: Path = tmp_path / "catalog.toml"
+    catalog_path.write_text(catalog_body, encoding="utf-8")
+    catalog: Catalog = load_catalog(catalog_path)
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    # Pre-install every member package so both bundles read installed before the diff.
+    state: State = State(version=1, units={})
+    for package_name in ("pkg-shared", "pkg-a", "pkg-b"):
+        state = install_package(
+            name=package_name,
+            catalog=catalog,
+            source_root=source_root,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=state,
+        )
+
+    # Untick bundle-y while bundle-x stays ticked: bundle-y's packages are
+    # {pkg-shared, pkg-b}, but pkg-shared is kept by still-ticked bundle-x, so only
+    # pkg-b is reclaimed.
+    plan: ReconcilePlan = ReconcilePlan(to_install=(), to_remove=("bundle-y",))
+    result: State = apply_bundle_reconcile(
+        plan=plan,
+        ticked=frozenset({"bundle-x"}),
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state,
+    )
+
+    shared_id: str = skill_unit_id("shared")
+    only_b_id: str = skill_unit_id("only-b")
+
+    # pkg-shared survives on bundle-x's claim: its unit stays recorded, credited, live.
+    assert shared_id in result.units
+    assert result.requesters[shared_id] == ("pkg-shared",)
+    assert (claude_root / "skills" / "shared").is_symlink()
+
+    # pkg-b is reclaimed: its exclusive unit is gone from state and from disk.
+    assert only_b_id not in result.units
+    assert not (claude_root / "skills" / "only-b").exists()

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -20,16 +20,19 @@ from rich.console import Console
 from rich.panel import Panel
 
 from catalog import (
+    Bundle,
     Catalog,
     Package,
     agent_unit_id,
     hook_unit_id,
     list_agents,
+    list_bundles,
     list_hooks,
     list_packages,
     list_rules,
     list_skills,
     load_catalog,
+    resolve_bundle,
     resolve_package,
     rule_unit_id,
     skill_unit_id,
@@ -39,12 +42,15 @@ from paths import CATALOG_PATH, CLAUDE_ROOT, REPO_ROOT, STATE_ROOT
 from reconcile import (
     ReconcilePlan,
     apply_agent_reconcile,
+    apply_bundle_reconcile,
     apply_hook_reconcile,
     apply_package_reconcile,
     apply_rule_reconcile,
     apply_skill_reconcile,
+    bundle_installed,
     package_installed,
     plan_agent_reconcile,
+    plan_bundle_reconcile,
     plan_hook_reconcile,
     plan_package_reconcile,
     plan_rule_reconcile,
@@ -67,8 +73,11 @@ TAB_PLACEHOLDER: Final[str] = "(empty — populated in a later PR)"
 PACKAGES_CHOICE: Final[str] = "Packages"
 PACKAGES_SELECT_PROMPT: Final[str] = "Select installed packages"
 PACKAGES_CONFIRM_PROMPT: Final[str] = "Apply package changes?"
+BUNDLES_CHOICE: Final[str] = "Bundles"
+BUNDLES_SELECT_PROMPT: Final[str] = "Select installed bundles"
+BUNDLES_CONFIRM_PROMPT: Final[str] = "Apply bundle changes?"
 MENU_CHOICES: Final[tuple[str, ...]] = (
-    "Bundles",
+    BUNDLES_CHOICE,
     PACKAGES_CHOICE,
     "Skills",
     "Agents",
@@ -191,6 +200,24 @@ def package_rows(*, catalog: Catalog, state: State) -> list[str]:
             else MARKER_NOT_INSTALLED
         )
         members: str = ", ".join(unit_id(unit) for unit in package.units)
+        rows.append(f"{marker} {name}  ({members})")
+    return rows
+
+
+def bundle_rows(*, catalog: Catalog, state: State) -> list[str]:
+    """Pair each catalog bundle with its refcount-derived install marker (via
+    bundle_installed) so the Bundles tab renders status, and show the member
+    packages the bundle pulls in alongside it — a bundle is a set of packages,
+    so the members are package names in declared order."""
+    rows: list[str] = []
+    for name in list_bundles(catalog=catalog):
+        bundle: Bundle = resolve_bundle(catalog=catalog, name=name)
+        marker: str = (
+            MARKER_INSTALLED
+            if bundle_installed(catalog=catalog, name=name, state=state)
+            else MARKER_NOT_INSTALLED
+        )
+        members: str = ", ".join(bundle.packages)
         rows.append(f"{marker} {name}  ({members})")
     return rows
 
@@ -354,6 +381,50 @@ def _run_packages_tab(*, console: Console) -> None:
         console.print(row, markup=False)
 
 
+def _run_bundles_tab(*, console: Console) -> None:
+    """Drive the Bundles tab end to end — render status, take the ticked selection,
+    plan the diff over installed bundles, confirm, apply, then re-render. It is not a
+    `_UnitTab` under `_run_unit_tab` because apply_bundle_reconcile drives the package
+    tier: it threads the `catalog` and the still-ticked `ticked` set that the `_ApplyFn`
+    protocol the unit tabs share does not carry."""
+    catalog: Catalog = load_catalog(CATALOG_PATH)
+    state: State = load_state(STATE_ROOT)
+    for row in bundle_rows(catalog=catalog, state=state):
+        console.print(row, markup=False)
+    choices: list[questionary.Choice] = [
+        questionary.Choice(
+            name, checked=bundle_installed(catalog=catalog, name=name, state=state)
+        )
+        for name in list_bundles(catalog=catalog)
+    ]
+    ticked: list[str] | None = abort_on_esc(
+        questionary.checkbox(BUNDLES_SELECT_PROMPT, choices=choices)
+    ).ask()
+    if ticked is None:
+        return
+    plan: ReconcilePlan = plan_bundle_reconcile(
+        ticked=frozenset(ticked), catalog=catalog, state=state
+    )
+    if plan.is_empty:
+        return
+    confirmed: bool | None = abort_on_esc(
+        questionary.confirm(BUNDLES_CONFIRM_PROMPT)
+    ).ask()
+    if not confirmed:
+        return
+    state = apply_bundle_reconcile(
+        plan=plan,
+        ticked=frozenset(ticked),
+        catalog=catalog,
+        source_root=REPO_ROOT,
+        state_root=STATE_ROOT,
+        claude_root=CLAUDE_ROOT,
+        state=state,
+    )
+    for row in bundle_rows(catalog=catalog, state=state):
+        console.print(row, markup=False)
+
+
 def launch_tui() -> int:
     """Bail out on non-interactive stdin: questionary's prompt would otherwise
     block forever waiting on input no CI session can supply."""
@@ -369,6 +440,9 @@ def launch_tui() -> int:
             ).ask()
             if choice is None or choice == "Exit":
                 return 0
+            if choice == BUNDLES_CHOICE:
+                _run_bundles_tab(console=console)
+                continue
             if choice == PACKAGES_CHOICE:
                 _run_packages_tab(console=console)
                 continue


### PR DESCRIPTION
## Slice 8.1 — Bundle model + Bundles tab (issue #74)

Delivers the coarsest install tier. A **bundle** is a named set of **packages**, each a named set of **units**. This wires the dead **Bundles** menu tab and resolves bundle → packages → units, composing the already-merged package refcount engine rather than reimplementing install/uninstall.

### What changed
- **Model** (`catalog.py`): `list_bundles`, `resolve_bundle` (raises `ValueError` on an undeclared bundle), and parse-time rejection of a bundle naming an undeclared package (`_build_bundle`) — closing the validation the `Bundle` docstring had earmarked for this slice, mirroring the existing package→unit boundary check.
- **Reconcile** (`reconcile.py`): `bundle_installed` (installed iff every member package is installed via `package_installed`; an empty bundle is never vacuously installed), `plan_bundle_reconcile`, and `apply_bundle_reconcile` — which translates a bundle-level diff into a package-level `ReconcilePlan` and delegates to the tested `apply_package_reconcile`. A `ticked`-based *kept-subtraction* keeps a package shared by a still-ticked bundle from being reclaimed when a sibling bundle is unticked; the unit-level refcount does the rest.
- **View** (`tui.py`): `bundle_rows` (per-bundle install marker + member package names) and `_run_bundles_tab`, routed into `launch_tui` (was a placeholder). `BUNDLES_*` constants alongside the sibling `PACKAGES_*`.

### Out of scope (deferred by the plan)
- `--bundle` non-interactive CLI → **8.2**
- `catalog.toml` content changes (bundles already declared) — untouched
- bundle e2e golden scenarios → **8.e2e**

### Tests / gates
Built test-first, one vertical slice per behavior (9 new tests; suite 145 → **154**). Every gate green: `ruff format --check`, `ruff check`, `mypy --strict`, `pytest -W error`. `catalog.py` & `reconcile.py` at 100% coverage. The shared-package-survival behavior is pinned by a dedicated test that fails if `apply_bundle_reconcile` naively removed all of a dropped bundle's packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)