### PR TITLE
feat(installer): non-interactive `--bundle` CLI for install/uninstall (slice 8.2)

### DIFF
--- a/installer/at.py
+++ b/installer/at.py
@@ -18,6 +18,7 @@ from catalog import (
     agent_unit_id,
     hook_unit_id,
     list_agents,
+    list_bundles,
     list_hooks,
     list_packages,
     list_rules,
@@ -30,12 +31,15 @@ from paths import CATALOG_PATH, CLAUDE_ROOT, REPO_ROOT, STATE_ROOT
 from reconcile import (
     ReconcilePlan,
     apply_agent_reconcile,
+    apply_bundle_reconcile,
     apply_hook_reconcile,
     apply_package_reconcile,
     apply_rule_reconcile,
     apply_skill_reconcile,
+    bundle_installed,
     package_installed,
     plan_agent_reconcile,
+    plan_bundle_reconcile,
     plan_hook_reconcile,
     plan_package_reconcile,
     plan_rule_reconcile,
@@ -274,6 +278,49 @@ def _run_packages(*, names: tuple[str, ...], additive: bool) -> int:
     return 0
 
 
+def _run_bundles(*, names: tuple[str, ...], additive: bool) -> int:
+    """Install or uninstall the named bundles non-interactively through the refcount
+    engine — the bundle-tier analogue of `_run_packages`, kept a parallel duplicate
+    (not a shared runner) until a third refcount tier makes dedup pay off. `additive`
+    picks the ticked set the same way `_run_packages` does: install joins the named
+    bundles to those already installed (`installed | names`), uninstall drops them
+    (`installed - names`). That same `ticked` is threaded into apply_bundle_reconcile,
+    which apply_package_reconcile does not need: it names every still-selected bundle so
+    a package shared with a bundle that survives is kept, not withdrawn."""
+    catalog: Catalog = load_catalog(_catalog_path())
+    rejection: int | None = _reject_unknown(
+        names=list(names),
+        label="bundle",
+        known=frozenset(list_bundles(catalog=catalog)),
+    )
+    if rejection is not None:
+        return rejection
+    state: State = load_state(STATE_ROOT)
+    installed: set[str] = {
+        name
+        for name in list_bundles(catalog=catalog)
+        if bundle_installed(catalog=catalog, name=name, state=state)
+    }
+    selected: set[str] = set(names)
+    ticked: frozenset[str] = frozenset(
+        installed | selected if additive else installed - selected
+    )
+    plan: ReconcilePlan = plan_bundle_reconcile(
+        ticked=ticked, catalog=catalog, state=state
+    )
+    # State return ignored: lone apply persists via save_state; no inter-kind threading.
+    apply_bundle_reconcile(
+        plan=plan,
+        ticked=ticked,
+        catalog=catalog,
+        source_root=_source_root(),
+        state_root=STATE_ROOT,
+        claude_root=CLAUDE_ROOT,
+        state=state,
+    )
+    return 0
+
+
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(
     AT_VERSION, "--version", prog_name="at", message="%(prog)s %(version)s"
@@ -288,6 +335,7 @@ def cli() -> None:
 @click.option("--rule", "rules", multiple=True, metavar="<name>")
 @click.option("--hook", "hooks", multiple=True, metavar="<name>")
 @click.option("--package", "packages", multiple=True, metavar="<name>")
+@click.option("--bundle", "bundles", multiple=True, metavar="<name>")
 @click.option("--all", "install_all", is_flag=True)
 # Accepted so a scripted `install --all` can pass it, but it changes nothing: the
 # --all path never opens the menu, so the flag never needs to reach the callback.
@@ -298,12 +346,15 @@ def install(
     rules: tuple[str, ...],
     hooks: tuple[str, ...],
     packages: tuple[str, ...],
+    bundles: tuple[str, ...],
     install_all: bool,
 ) -> int:
-    """Install named units (--skill/--agent/--rule/--hook) or packages (--package),
-    or every skill (--all), without the menu; else open it."""
+    """Install named units (--skill/--agent/--rule/--hook), packages (--package), or
+    bundles (--bundle), or every skill (--all), without the menu; else open it."""
     if packages:
         return _run_packages(names=packages, additive=True)
+    if bundles:
+        return _run_bundles(names=bundles, additive=True)
     if skills or agents or rules or hooks:
         requested: tuple[tuple[_Kind, tuple[str, ...]], ...] = (
             (_SKILL, skills),
@@ -326,22 +377,33 @@ def install(
 @click.option("--rule", "rules", multiple=True, metavar="<name>")
 @click.option("--hook", "hooks", multiple=True, metavar="<name>")
 @click.option("--package", "packages", multiple=True, metavar="<name>")
+@click.option("--bundle", "bundles", multiple=True, metavar="<name>")
 def uninstall(
     skills: tuple[str, ...],
     agents: tuple[str, ...],
     rules: tuple[str, ...],
     hooks: tuple[str, ...],
     packages: tuple[str, ...],
+    bundles: tuple[str, ...],
 ) -> int:
-    """Uninstall named units (--skill/--agent/--rule/--hook) or packages (--package);
-    at least one is required."""
-    if not skills and not agents and not rules and not hooks and not packages:
+    """Uninstall named units (--skill/--agent/--rule/--hook), packages (--package), or
+    bundles (--bundle); at least one is required."""
+    if (
+        not skills
+        and not agents
+        and not rules
+        and not hooks
+        and not packages
+        and not bundles
+    ):
         raise click.UsageError(
             "uninstall requires at least one "
-            "--skill/--agent/--rule/--hook/--package <name>"
+            "--skill/--agent/--rule/--hook/--package/--bundle <name>"
         )
     if packages:
         return _run_packages(names=packages, additive=False)
+    if bundles:
+        return _run_bundles(names=bundles, additive=False)
     requested: tuple[tuple[_Kind, tuple[str, ...]], ...] = (
         (_SKILL, skills),
         (_AGENT, agents),

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -1792,6 +1792,85 @@ def test_install_unknown_package_errors_with_exit_two_and_installs_nothing(
     assert skill_unit_id("demo-skill") not in final_state.units
 
 
+def test_uninstall_bundle_flag_decrements_refcount_keeping_shared_unit(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # Real skill sources for the shared unit and each package's exclusive unit, so the
+    # pre-install can place live symlinks and staging before the uninstall runs.
+    for name in ("shared", "only-a", "only-b"):
+        source: Path = repo_root / "skills" / name / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(f"# {name}\n", encoding="utf-8")
+
+    # Two bundles, each wrapping one package; the packages share one common unit. So a
+    # bundle-tier uninstall must thread the still-selected bundle (bundle-b) through the
+    # apply, keeping the shared unit that its package still claims.
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        '[[units]]\nkind = "skill"\nname = "shared"\n\n'
+        '[[units]]\nkind = "skill"\nname = "only-a"\n\n'
+        '[[units]]\nkind = "skill"\nname = "only-b"\n\n'
+        '[[packages]]\nname = "pack-a"\nunits = ["skill/shared", "skill/only-a"]\n\n'
+        '[[packages]]\nname = "pack-b"\nunits = ["skill/shared", "skill/only-b"]\n\n'
+        '[[bundles]]\nname = "bundle-a"\npackages = ["pack-a"]\n\n'
+        '[[bundles]]\nname = "bundle-b"\npackages = ["pack-b"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # Pre-install both bundles by installing each member package through the real public
+    # install action, so the shared unit carries both packages as requesters and each
+    # exclusive unit carries its own — the state a bundle-tier uninstall decrements.
+    catalog: Catalog = load_catalog(catalog_file)
+    state: State = load_state(state_root)
+    for package_name in ("pack-a", "pack-b"):
+        state = install_package(
+            name=package_name,
+            catalog=catalog,
+            source_root=repo_root,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=state,
+        )
+
+    # Uninstalling a bundle must withdraw its claim without ever opening the TUI: route
+    # every questionary prompt to a factory that fails loudly, so a regression that
+    # falls back through launch_tui's select/checkbox/confirm trips this guard.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["uninstall", "--bundle", "bundle-a"])
+
+    # `uninstall --bundle bundle-a` is a refcount decrement threading the still-selected
+    # bundle-b into apply: bundle-a's package pack-a is withdrawn, reclaiming its
+    # exclusive unit only-a, while the shared unit survives on pack-b's remaining credit
+    # — still linked and now requested by pack-b alone — and bundle-b's exclusive unit
+    # only-b stays installed.
+    final_state: State = load_state(state_root)
+    only_a_link: Path = claude_root / "skills" / "only-a"
+    shared_link: Path = claude_root / "skills" / "shared"
+    only_b_link: Path = claude_root / "skills" / "only-b"
+    assert exit_code == 0
+    assert skill_unit_id("only-a") not in final_state.units
+    assert not only_a_link.exists() and not only_a_link.is_symlink()
+    assert skill_unit_id("shared") in final_state.units
+    assert shared_link.is_symlink()
+    assert final_state.requesters[skill_unit_id("shared")] == ("pack-b",)
+    assert skill_unit_id("only-b") in final_state.units
+    assert only_b_link.is_symlink()
+
+
 @pytest.mark.parametrize(
     "argv",
     [["install", "--skill"], ["uninstall", "--skill"], ["uninstall"]],
@@ -2189,3 +2268,105 @@ def test_uninstall_package_flag_decrements_refcount_keeping_shared_unit(
     assert final_state.requesters[skill_unit_id("shared")] == ("pack-b",)
     assert skill_unit_id("only-b") in final_state.units
     assert only_b_link.is_symlink()
+
+
+def test_install_bundle_flag_installs_named_bundle_non_interactively(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # A real skill source on disk is the only input the non-interactive install needs;
+    # nothing is installed up front, so installing demo-bundle must place its member
+    # package's skill through the refcount-aware bundle install and credit the package
+    # as that unit's requester — the bundle-tier analogue of the --package flag.
+    source: Path = repo_root / "skills" / "demo-skill" / "SKILL.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("# demo-skill\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        '[[units]]\nkind = "skill"\nname = "demo-skill"\n\n'
+        '[[packages]]\nname = "demo-pack"\nunits = ["skill/demo-skill"]\n\n'
+        '[[bundles]]\nname = "demo-bundle"\npackages = ["demo-pack"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # The --bundle path must place the bundle without ever opening the TUI: route every
+    # questionary prompt to a factory that fails loudly, so a regression that falls back
+    # through launch_tui's select/checkbox/confirm trips this guard.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["install", "--bundle", "demo-bundle"])
+
+    # Installing demo-bundle resolves to its member package demo-pack and places that
+    # package's member skill live, recording demo-pack as the unit's sole requester, so
+    # the package's refcount credit — not a @direct marker — holds the skill installed.
+    final_state: State = load_state(state_root)
+    skill_link: Path = claude_root / "skills" / "demo-skill"
+    assert exit_code == 0
+    assert skill_link.is_symlink()
+    assert final_state.requesters[skill_unit_id("demo-skill")] == ("demo-pack",)
+
+
+def test_install_unknown_bundle_errors_with_exit_two_and_installs_nothing(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # The catalog declares a real bundle (demo-bundle -> demo-pack -> demo-skill) but
+    # never 'nonesuch', so the request names an unknown bundle while the catalog still
+    # holds a valid, stage-able one. The member skill source is staged so that a
+    # mistaken install of demo-bundle would succeed — making a no-op the only landing.
+    source: Path = repo_root / "skills" / "demo-skill" / "SKILL.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("# demo-skill\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        '[[units]]\nkind = "skill"\nname = "demo-skill"\n\n'
+        '[[packages]]\nname = "demo-pack"\nunits = ["skill/demo-skill"]\n\n'
+        '[[bundles]]\nname = "demo-bundle"\npackages = ["demo-pack"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # The error path must stay non-interactive: route every questionary prompt to a
+    # factory that fails loudly, so a regression that falls back into launch_tui's
+    # select/checkbox/confirm trips this guard instead of silently prompting.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLI must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["install", "--bundle", "nonesuch"])
+
+    # An unknown --bundle name is rejected atomically before any apply: main exits 2 and
+    # names the bad bundle ('nonesuch') on stderr, and nothing is installed — the real
+    # bundle's member skill never lands (no link, no state entry), so a typo fails
+    # loudly instead of silently no-opping.
+    captured_err: str = capsys.readouterr().err
+    final_state: State = load_state(state_root)
+    skill_link: Path = claude_root / "skills" / "demo-skill"
+    assert exit_code == 2
+    assert captured_err != ""
+    assert "nonesuch" in captured_err
+    assert not skill_link.exists() and not skill_link.is_symlink()
+    assert skill_unit_id("demo-skill") not in final_state.units


### PR DESCRIPTION
## Slice 8.2 — non-interactive `--bundle` CLI (issue #74)

Wires the coarsest install tier into the scriptable CLI, so bundles are non-interactive exactly like `--skill/--agent/--rule/--hook/--package`. Pure arg-routing over the **already-merged 8.1 bundle engine** — no new state-mutation or refcount logic.

(`--all` and `--package` from the slice headline already landed in 4.5.1 / 7.e2e; `--bundle` is the genuinely-new tier here.)

### What changed
- `installer/at.py`:
  - New `_run_bundles(*, names, additive)` — a deliberate parallel of `_run_packages` that additionally threads the still-selected `ticked` set into `apply_bundle_reconcile` (unlike the package apply, the bundle apply needs it to keep a package a *surviving* bundle shares).
  - `--bundle` click option/param/routing on both `install` and `uninstall`; reuses the shared `_reject_unknown` guard (`label="bundle"`) for atomic unknown-name rejection.
  - `uninstall` "at least one required" guard + `UsageError` message now include `--bundle`; both command docstrings updated.
- `installer/tests/test_at.py`: 3 behavior tests through the public `main(argv)` boundary.

### Behaviors (each RED→GREEN, tested through `at.main(argv)`)
- **B1** `install --bundle <name>` installs the bundle's member package's unit non-interactively (linked live, credited to its package in `state.requesters`), never opening the TUI.
- **B2** `install --bundle nonesuch` → exit 2, names it on stderr, installs nothing (atomic, mirrors `--package`).
- **B3** `uninstall --bundle <one-of-two>` is a bundle-tier refcount decrement — two bundles share a package; uninstalling one keeps the shared unit alive (credited to the survivor) and removes the dropped bundle's exclusive unit. Pins `_run_bundles` threading `ticked`.

### Verification
`pytest -W error` **157 passed** (154 baseline + 3) · `ruff format --check` clean · `ruff check` clean · `mypy --strict` clean.

### Review
lite panel: reviewers 92 / 95 / 89 · critic 96 achieved · 0 blockers. Two non-blocking MINOR advisories, both consistent with accepted precedent: `_run_bundles`/`_run_packages` duplication (documented n=2 tradeoff, revisit at a third refcount tier) and mixed `--package`+`--bundle` running only packages (the same silent-precedence pattern `--package` already has over unit flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)