### PR TITLE
feat(installer): read-only `at status` dashboard (slice 8.3)

### DIFF
--- a/installer/at.py
+++ b/installer/at.py
@@ -46,7 +46,7 @@ from reconcile import (
     plan_skill_reconcile,
 )
 from state import State, load_state
-from tui import launch_tui
+from tui import launch_tui, status_lines
 from update import update_installed_skills
 
 AT_VERSION: Final[str] = "0.2.0"
@@ -417,6 +417,23 @@ def uninstall(
 def update() -> int:
     """Pull the repo, then refresh every installed skill from its updated source."""
     return _run_update()
+
+
+@cli.command()
+def status() -> int:
+    """Print a read-only dashboard of the installation — the availability grid, skill
+    drift, and the active source root — without mutating the install, running git, or
+    opening the menu."""
+    catalog: Catalog = load_catalog(_catalog_path())
+    state: State = load_state(STATE_ROOT)
+    lines: list[str] = status_lines(
+        catalog=catalog,
+        state=state,
+        source_root=_source_root(),
+        state_root=STATE_ROOT,
+    )
+    print("\n".join(lines))
+    return 0
 
 
 def main(argv: list[str]) -> int:

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -2370,3 +2370,246 @@ def test_install_unknown_bundle_errors_with_exit_two_and_installs_nothing(
     assert "nonesuch" in captured_err
     assert not skill_link.exists() and not skill_link.is_symlink()
     assert skill_unit_id("demo-skill") not in final_state.units
+
+
+def test_status_renders_availability_grid_without_opening_the_tui(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # Real skill sources for the two skills the setup actually installs (alpha
+    # directly, gamma through a package); beta and delta are catalog-only, so status
+    # renders them unchecked without ever reading their source.
+    for name in ("alpha", "gamma"):
+        source: Path = repo_root / "skills" / name / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(f"# {name}\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        '[[units]]\nkind = "skill"\nname = "alpha"\n\n'
+        '[[units]]\nkind = "skill"\nname = "beta"\n\n'
+        '[[units]]\nkind = "skill"\nname = "gamma"\n\n'
+        '[[units]]\nkind = "skill"\nname = "delta"\n\n'
+        '[[packages]]\nname = "demo-pack"\nunits = ["skill/gamma"]\n\n'
+        '[[packages]]\nname = "other-pack"\nunits = ["skill/delta"]\n\n'
+        '[[bundles]]\nname = "demo-bundle"\npackages = ["other-pack"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # An installed skill (alpha, direct) and an installed package (demo-pack, which
+    # pulls in gamma) give the grid a mix of checked and unchecked rows; other-pack and
+    # demo-bundle stay uninstalled.
+    catalog: Catalog = load_catalog(catalog_file)
+    state: State = install_skill(
+        name="alpha",
+        source_root=repo_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=load_state(state_root),
+    )
+    install_package(
+        name="demo-pack",
+        catalog=catalog,
+        source_root=repo_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state,
+    )
+
+    # A read-only status must never open the menu: route every questionary prompt to a
+    # factory that fails loudly, so a regression that opens the TUI trips this guard.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("status must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["status"])
+
+    captured: str = capsys.readouterr().out
+    lines: list[str] = captured.splitlines()
+    assert exit_code == 0
+    # Every kind titles its own section, in the fixed grid order, under one header.
+    assert "Agent Templates — status" in lines
+    for title in ("Bundles", "Packages", "Skills", "Agents", "Rules", "Hooks"):
+        assert title in lines
+    # Representative checked/unchecked rows come straight from the *_rows helpers
+    # (indent aside), so an installed unit reads the installed marker and an
+    # uninstalled one the not-installed marker.
+    assert f"{MARKER_INSTALLED} alpha" in captured
+    assert f"{MARKER_NOT_INSTALLED} beta" in captured
+    assert f"{MARKER_INSTALLED} demo-pack  (skill/gamma)" in captured
+    assert f"{MARKER_NOT_INSTALLED} demo-bundle  (other-pack)" in captured
+    # The trailing line names the active source root that drives drift.
+    assert lines[-1] == str(repo_root)
+
+
+def test_status_drift_reports_locally_edited_and_up_to_date_per_installed_skill(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # Install two skills from real sources so both record an install-time hash; alpha's
+    # staged copy is then hand-edited on disk so its content diverges from what was
+    # recorded, while beta and both upstream sources are left untouched.
+    state: State = load_state(state_root)
+    for name in ("alpha", "beta"):
+        source: Path = repo_root / "skills" / name / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(f"# {name}\n", encoding="utf-8")
+        state = install_skill(
+            name=name,
+            source_root=repo_root,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=state,
+        )
+    staged_alpha: Path = state_root / "staged" / "skill" / "alpha" / "SKILL.md"
+    staged_alpha.write_text("# alpha edited locally\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "alpha"\n\n'
+        '[[units]]\nkind = "skill"\nname = "beta"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("status must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["status"])
+
+    captured: str = capsys.readouterr().out
+    lines: list[str] = captured.splitlines()
+    assert exit_code == 0
+    # The edited staged copy drifts from its recorded hash while upstream is unchanged,
+    # so alpha reads locally edited; beta, untouched on both sides, reads up to date.
+    assert "Drift" in lines
+    assert "alpha — locally edited" in captured
+    assert "beta — up to date" in captured
+
+
+def test_status_drift_reports_upstream_changed_and_combined_per_installed_skill(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # Install two skills from real sources so both record an install-time hash. gamma's
+    # upstream source is then bumped on disk without re-staging, so only its source
+    # diverges from what was recorded; delta's upstream source AND staged copy are both
+    # edited, so it diverges on both axes at once.
+    state: State = load_state(state_root)
+    for name in ("gamma", "delta"):
+        source: Path = repo_root / "skills" / name / "SKILL.md"
+        source.parent.mkdir(parents=True)
+        source.write_text(f"# {name}\n", encoding="utf-8")
+        state = install_skill(
+            name=name,
+            source_root=repo_root,
+            state_root=state_root,
+            claude_root=claude_root,
+            state=state,
+        )
+    (repo_root / "skills" / "gamma" / "SKILL.md").write_text(
+        "# gamma upstream bumped\n", encoding="utf-8"
+    )
+    (repo_root / "skills" / "delta" / "SKILL.md").write_text(
+        "# delta upstream bumped\n", encoding="utf-8"
+    )
+    staged_delta: Path = state_root / "staged" / "skill" / "delta" / "SKILL.md"
+    staged_delta.write_text("# delta edited locally\n", encoding="utf-8")
+
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "packages = []\nbundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "gamma"\n\n'
+        '[[units]]\nkind = "skill"\nname = "delta"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("status must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["status"])
+
+    captured: str = capsys.readouterr().out
+    captured_lines: list[str] = captured.splitlines()
+    assert exit_code == 0
+    # gamma's upstream source alone diverges from its recorded hash, so it reads the
+    # upstream-only phrase; delta diverges on both axes, so it reads the combined one.
+    # Assert the exact two-space-indented line, not a substring, so the combined
+    # superstring "gamma — upstream changed, locally edited" cannot satisfy the
+    # upstream-only check.
+    assert "  gamma — upstream changed" in captured_lines
+    assert "  delta — upstream changed, locally edited" in captured_lines
+
+
+def test_status_on_empty_install_shows_all_uninstalled_and_drift_placeholder(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    repo_root: Path = tmp_path / "repo"
+    monkeypatch.setattr("at.STATE_ROOT", state_root)
+    monkeypatch.setattr("at.CLAUDE_ROOT", claude_root)
+    monkeypatch.setattr("at.REPO_ROOT", repo_root)
+
+    # A catalog with a unit at each tier but a state root that has never been installed
+    # into, so every grid row must read uninstalled and no skill is installed to drift.
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        '[[units]]\nkind = "skill"\nname = "orphan"\n\n'
+        '[[packages]]\nname = "pack"\nunits = ["skill/orphan"]\n\n'
+        '[[bundles]]\nname = "bund"\npackages = ["pack"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("status must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["status"])
+
+    captured: str = capsys.readouterr().out
+    lines: list[str] = captured.splitlines()
+    assert exit_code == 0
+    # Nothing is installed, so no row carries the installed marker and the lone unit
+    # at each tier reads uninstalled...
+    assert MARKER_INSTALLED not in captured
+    assert f"{MARKER_NOT_INSTALLED} orphan" in captured
+    # ...and with no installed skill to report on, drift falls back to a placeholder.
+    assert "Drift" in lines
+    assert "(none installed)" in captured

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -1,6 +1,6 @@
-"""The interactive installer menu: the whole TUI concern (tab rendering, the
-checkbox/confirm reconcile loop, and Esc handling) lives here so at.py stays the
-CLI/entry dispatcher."""
+"""The installer's view layer: the whole interactive TUI concern (tab rendering, the
+checkbox/confirm reconcile loop, and Esc handling) plus the non-interactive `at status`
+dashboard rendering live here so at.py stays the CLI/entry dispatcher."""
 
 import sys
 from collections.abc import Callable
@@ -38,6 +38,7 @@ from catalog import (
     skill_unit_id,
     unit_id,
 )
+from hashing import Drift
 from paths import CATALOG_PATH, CLAUDE_ROOT, REPO_ROOT, STATE_ROOT
 from reconcile import (
     ReconcilePlan,
@@ -57,6 +58,7 @@ from reconcile import (
     plan_skill_reconcile,
 )
 from state import State, load_state
+from update import skill_drift
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -220,6 +222,75 @@ def bundle_rows(*, catalog: Catalog, state: State) -> list[str]:
         members: str = ", ".join(bundle.packages)
         rows.append(f"{marker} {name}  ({members})")
     return rows
+
+
+# ---------------------------------------------------------------------------
+# Status dashboard
+# ---------------------------------------------------------------------------
+
+
+def _section(*, title: str, rows: list[str]) -> list[str]:
+    """Render one dashboard section as its title line followed by two-space-indented
+    rows, so every availability kind formats a title-and-rows block the same way and
+    the indent decision lives in one place."""
+    return [title, *(f"  {row}" for row in rows)]
+
+
+def _drift_label(*, drift: Drift) -> str:
+    """Collapse the two independent drift axes into the one phrase a user reads, so the
+    dashboard tells them at a glance whether a skill is current, updatable, or carries a
+    local edit worth preserving."""
+    if drift.upstream_changed and drift.locally_edited:
+        return "upstream changed, locally edited"
+    if drift.upstream_changed:
+        return "upstream changed"
+    if drift.locally_edited:
+        return "locally edited"
+    return "up to date"
+
+
+def _drift_row(*, name: str, source_root: Path, state_root: Path, state: State) -> str:
+    """Report how one installed skill diverges from its recorded install hash via the
+    shared update.skill_drift, so the dashboard's drift view reads divergence from the
+    same source/staged/recorded inputs an `at update` would act on."""
+    drift: Drift = skill_drift(
+        name=name, source_root=source_root, state_root=state_root, state=state
+    )
+    return f"{name} — {_drift_label(drift=drift)}"
+
+
+def status_lines(
+    *, catalog: Catalog, state: State, source_root: Path, state_root: Path
+) -> list[str]:
+    """Build the read-only status dashboard as text lines so `at status` can render an
+    installation at a glance — the per-kind availability grid (reusing the tab row
+    helpers), a skills-only drift section, and the active source root — without mutating
+    anything. state_root and source_root locate the staged copies and upstream sources
+    the drift section reads."""
+    lines: list[str] = ["Agent Templates — status"]
+    grid: list[tuple[str, list[str]]] = [
+        (BUNDLES_CHOICE, bundle_rows(catalog=catalog, state=state)),
+        (PACKAGES_CHOICE, package_rows(catalog=catalog, state=state)),
+        ("Skills", skill_rows(catalog=catalog, state=state)),
+        ("Agents", agent_rows(catalog=catalog, state=state)),
+        ("Rules", rule_rows(catalog=catalog, state=state)),
+        ("Hooks", hook_rows(catalog=catalog, state=state)),
+    ]
+    for title, rows in grid:
+        lines.extend(_section(title=title, rows=rows))
+    # Drift is skills-only, as in update.py: agents/rules/hooks carry no drift wiring.
+    drift_rows: list[str] = [
+        _drift_row(
+            name=name, source_root=source_root, state_root=state_root, state=state
+        )
+        for name in list_skills(catalog)
+        if skill_unit_id(name) in state.units
+    ]
+    # No installed skill has any drift to report, so stand in a placeholder rather than
+    # leave the section a bare title.
+    lines.extend(_section(title="Drift", rows=drift_rows or ["(none installed)"]))
+    lines.append(str(source_root))
+    return lines
 
 
 # ---------------------------------------------------------------------------

--- a/installer/update.py
+++ b/installer/update.py
@@ -8,6 +8,22 @@ from placement import backup_staged_unit, staged_unit_path
 from state import State
 
 
+def skill_drift(
+    *, name: str, source_root: Path, state_root: Path, state: State
+) -> Drift:
+    """Single source of truth for a skill's drift inputs, so the status view and the
+    update reconcile read divergence the same way instead of each re-deriving where a
+    skill's source and staged copies live and how its drift is computed. `name` must be
+    an installed skill (its unit id present in `state.units`); otherwise the
+    recorded-hash lookup raises KeyError, so callers must guard."""
+    source: Path = source_root / SKILLS_DIRNAME / name
+    staged: Path = staged_unit_path(
+        unit=skill_unit(name), staged_root=state_root / STAGED_DIRNAME
+    )
+    recorded: str = state.units[skill_unit_id(name)]
+    return detect_drift(source=source, staged=staged, recorded=recorded)
+
+
 def update_skill(
     *,
     name: str,
@@ -19,12 +35,9 @@ def update_skill(
     """Reconcile a skill against its upstream source: leave a local edit to the
     staged copy untouched when upstream is unchanged, otherwise rescue it to
     "<name>.bak" before re-staging the new source, so an edit is never lost."""
-    source: Path = source_root / SKILLS_DIRNAME / name
-    staged: Path = staged_unit_path(
-        unit=skill_unit(name), staged_root=state_root / STAGED_DIRNAME
+    drift: Drift = skill_drift(
+        name=name, source_root=source_root, state_root=state_root, state=state
     )
-    recorded: str = state.units[skill_unit_id(name)]
-    drift: Drift = detect_drift(source=source, staged=staged, recorded=recorded)
     if not drift.upstream_changed:
         return state
     if drift.locally_edited:


### PR DESCRIPTION
## Slice 8.3 — `at status` dashboard (issue #74)

Adds a read-only `at status` subcommand that renders the installation at a glance. Pure view — it loads catalog + state, prints, and mutates nothing (no file writes, no git, no TUI).

The dashboard has three parts:
1. **Availability grid** — one section per kind (Bundles, Packages, Skills, Agents, Rules, Hooks), each catalog item marked ✅ installed / ❌ not — reusing the existing `tui.py` `*_rows` helpers verbatim (packages/bundles rows keep their member-id suffix).
2. **Drift** — skills-only (consistent with `update.py`; agents/rules/hooks have no drift wiring), one of `up to date` / `upstream changed` / `locally edited` / `upstream changed, locally edited` per installed skill, derived from `detect_drift` **exactly** as `update.update_skill` computes it.
3. **Source line** — the active source root that drives drift.

Scope calls (owner-chosen): full availability grid (not installed-only); deterministic drift (no live `git`), so the output is stable for the later 8.e2e golden.

### What changed
- `installer/tui.py`: `status_lines(*, catalog, state, source_root, state_root)` composes the six `*_rows` helpers + a drift section (`_section` / `_drift_label` / `_drift_row`). Module docstring widened to note it now also owns non-interactive status rendering.
- `installer/at.py`: thin `status` click command (load catalog + state → `status_lines` → print → 0), mirroring the `update` command.
- `installer/update.py`: extracted `skill_drift(*, name, source_root, state_root, state) -> Drift` as the **single source of truth** for a skill's drift inputs; `update_skill` and the status view both delegate (removes a cross-module duplication the panel flagged).
- `installer/tests/test_at.py`: 4 behavior tests through the public `at.main(["status"])` boundary.

### Verification
`pytest -W error` **161 passed** (157 baseline + 4) · `ruff format --check` clean · `ruff check` clean · `mypy --strict` clean.

### Review
lite panel: reviewers 83/88/80 → after a fix round, quality **92** (duplication MAJOR resolved) · test-form resolved · critic **90** achieved · 0 blockers. Two fix rounds, both net-positive: (1) extracted `skill_drift` to kill an information-leakage MAJOR + added upstream-drift coverage; (2) tightened an under-constrained substring assertion to an exact full-line match (mutation-proven) and documented `skill_drift`'s KeyError precondition. The missing-source/staged `FileNotFoundError` is deliberate, now-shared parity with `at update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)