### PR TITLE
feat(installer): add read-only `at validate` catalog lint (slice 8.4)

### DIFF
--- a/installer/at.py
+++ b/installer/at.py
@@ -436,6 +436,24 @@ def status() -> int:
     return 0
 
 
+@cli.command()
+def validate() -> int:
+    """Lint the catalog's content and shape by loading it through the shared loader, so
+    a dangling reference, a missing required key, or a wrong-shaped or syntactically bad
+    catalog surfaces as a clean error line and exit 1, all while staying read-only — no
+    mutation, no git, no menu."""
+    try:
+        catalog: Catalog = load_catalog(_catalog_path())
+    except (ValueError, KeyError, TypeError) as problem:
+        print(f"error: {problem}", file=sys.stderr)
+        return 1
+    print(
+        f"catalog OK — {len(catalog.units)} units, "
+        f"{len(catalog.packages)} packages, {len(catalog.bundles)} bundles"
+    )
+    return 0
+
+
 def main(argv: list[str]) -> int:
     """The stable int-returning entry every test and the `at` wrapper call: run the
     click group without its process-exiting shell and translate the outcome to an exit

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -2613,3 +2613,96 @@ def test_status_on_empty_install_shows_all_uninstalled_and_drift_placeholder(
     # ...and with no installed skill to report on, drift falls back to a placeholder.
     assert "Drift" in lines
     assert "(none installed)" in captured
+
+
+def test_validate_reports_ok_with_counts_on_a_valid_catalog(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    # A well-formed catalog whose every package/bundle ref resolves: two units, one
+    # package, one bundle, so the OK line's counts are small and exactly assertable.
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        '[[units]]\nkind = "skill"\nname = "alpha"\n\n'
+        '[[units]]\nkind = "skill"\nname = "beta"\n\n'
+        '[[packages]]\nname = "pack"\nunits = ["skill/alpha"]\n\n'
+        '[[bundles]]\nname = "bund"\npackages = ["pack"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    # A read-only lint must never open the menu: route every questionary prompt to a
+    # factory that fails loudly, so a regression that opens the TUI trips this guard.
+    def forbid_interactive(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("validate must be non-interactive")
+
+    monkeypatch.setattr("questionary.select", forbid_interactive)
+    monkeypatch.setattr("questionary.checkbox", forbid_interactive)
+    monkeypatch.setattr("questionary.confirm", forbid_interactive)
+
+    exit_code: int = main(["validate"])
+
+    output: str = capsys.readouterr().out
+    assert exit_code == 0
+    assert output == "catalog OK — 2 units, 1 packages, 1 bundles\n"
+
+
+def test_validate_reports_error_and_exit_one_on_dangling_reference(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    # A package names a unit that is never declared, so the loader rejects the dangling
+    # ref and validate must surface that as a clean error naming the offending ref.
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        "bundles = []\n\n"
+        '[[units]]\nkind = "skill"\nname = "alpha"\n\n'
+        '[[packages]]\nname = "pack"\nunits = ["skill/ghost"]\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    exit_code: int = main(["validate"])
+
+    errors: str = capsys.readouterr().err
+    assert exit_code == 1
+    assert "error:" in errors
+    assert "ghost" in errors
+
+
+def test_validate_reports_error_not_traceback_on_schema_violation(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    # A unit row is missing its required `name`, so the loader raises on the schema
+    # violation; validate must surface it as a clean error, not an uncaught traceback.
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        'packages = []\nbundles = []\n\n[[units]]\nkind = "skill"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    exit_code: int = main(["validate"])
+
+    errors: str = capsys.readouterr().err
+    assert exit_code == 1
+    assert "error:" in errors
+    assert "name" in errors
+
+
+def test_validate_reports_error_not_traceback_on_malformed_shape(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str], tmp_path: Path
+) -> None:
+    # `[units]` as a single table instead of the array-of-tables `[[units]]` is a common
+    # TOML authoring slip; the loader trips over the wrong shape (a TypeError), and
+    # validate must surface it as a clean error line, not let the traceback escape.
+    catalog_file: Path = tmp_path / "catalog.toml"
+    catalog_file.write_text(
+        'packages = []\nbundles = []\n\n[units]\nkind = "skill"\nname = "alpha"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("at.CATALOG_PATH", catalog_file)
+
+    exit_code: int = main(["validate"])
+
+    errors: str = capsys.readouterr().err
+    assert exit_code == 1
+    assert "error:" in errors


### PR DESCRIPTION
## Slice 8.4 — `at validate` (lint `catalog.toml`)

Adds a read-only `at validate` subcommand that lints the catalog and reports the outcome without mutating the install, running git, or opening the menu.

### Behavior
- **Valid catalog** → stdout `catalog OK — <N> units, <M> packages, <K> bundles`, exit `0`.
- **Malformed catalog** → stderr `error: <message>`, exit `1`, as a clean line (never an uncaught traceback), for every content/shape class:
  - dangling reference (package → missing unit, or bundle → missing package),
  - missing required key,
  - wrong-shaped or syntactically bad TOML.
- A missing/unreadable catalog **file** is intentionally out of scope (an environment error, consistent with `status`/`update`).

### Design
Reuses the existing, already-tested `load_catalog` as the single source of truth (fail-fast, reports the first problem) rather than a standalone collect-all linter that would duplicate the loader's parsing/reference rules. The command mirrors `status`: a thin `@cli.command` with an EAFP single-statement `try` body and an inline OK line — `validate` catches the loader's real content/shape raise surface `(ValueError, KeyError, TypeError)` and prints `error: {problem}`. The `catalog OK — …` format is stable for the later 8.e2e golden.

### Tests (all through the public `main(["validate"])` boundary)
Four behavior slices, each built test-first with a witnessed right-reason RED: valid → exact OK+counts line; dangling reference → `error:` + exit 1; missing-key schema violation → clean error; malformed shape (`[units]` vs `[[units]]`, a common TOML slip that raises `TypeError`) → clean error. Suite 161 → 165; `ruff format`/`ruff check`/`mypy --strict`/`pytest -W error` all green.

Part of #74 (slice 8 → 4/6). Next: 8.5 shims + CI cutover (architect), then 8.e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
