### PR TITLE
feat(installer): e2e — bundle expands to its full unit set; status/validate goldens (slice 8.e2e)

### DIFF
--- a/installer/tests/e2e/fixtures/catalog.toml
+++ b/installer/tests/e2e/fixtures/catalog.toml
@@ -1,7 +1,17 @@
 # Frozen fixture catalog for installer e2e scenarios. Deliberately minimal and
 # stable so goldens change only when installer BEHAVIOUR changes, never when a
 # real skill under ../../skills is edited.
-bundles = []
+
+# One bundle so e2e can pin the coarsest install tier expanding to its full unit set:
+# installing demo-bundle pulls in every unit of demo-pack-a (skill/demo-skill,
+# agent/demo-agent) and demo-pack-extras (rule/demo-rule + the schemas/ extra). It
+# deliberately omits demo-pack-b, leaving demo-skill-two / demo-pack-b / hook/demo-hook
+# as the not-installed rows the status grid needs. Bundles are never recorded in
+# state.json — bundle-installed is derived from its members' refcounts — so adding it
+# drifts no existing install/uninstall golden.
+[[bundles]]
+name = "demo-bundle"
+packages = ["demo-pack-a", "demo-pack-extras"]
 
 # Two packages that deliberately SHARE agent/demo-agent so e2e can pin the refcount
 # rule: a unit pulled in by both survives uninstalling one package and is removed only

--- a/installer/tests/e2e/goldens/install_bundle_expands.golden
+++ b/installer/tests/e2e/goldens/install_bundle_expands.golden
@@ -1,0 +1,18 @@
+dir .claude/agents
+link .claude/agents/demo-agent.md -> .claude/at/staged/agent/demo-agent
+dir .claude/at
+dir .claude/at/schemas
+file .claude/at/schemas/demo-schema.json 0caf2bd5dfff062ff9d07d6123ce36e1fc5a4f02677f2e913b27c04c6075f98e
+dir .claude/at/staged
+dir .claude/at/staged/agent
+file .claude/at/staged/agent/demo-agent b5ab887c16f11fd42f38c3972bb7019d601a4686b12069ba3e4ef87ac5c5f831
+dir .claude/at/staged/rule
+file .claude/at/staged/rule/demo-rule 94b4fcca183f1a395b2231260530d3d608b66d70206d8eff1d0000d680d65d6a
+dir .claude/at/staged/skill
+dir .claude/at/staged/skill/demo-skill
+file .claude/at/staged/skill/demo-skill/SKILL.md 25706be2cbf11d3e92d1cadb63751d482723dbcd91b3f32dc9931859308e1674
+json .claude/at/state.json {"extra_hashes":{"schemas":"e8224ef72a3b8e9463978953355c1fc546f9b5a093e20f0ca8169a2ab20fc752"},"extras":{"schemas":["demo-pack-extras"]},"requesters":{"agent/demo-agent":["demo-pack-a"],"rule/demo-rule":["demo-pack-extras"],"skill/demo-skill":["demo-pack-a"]},"units":{"agent/demo-agent":"b5ab887c16f11fd42f38c3972bb7019d601a4686b12069ba3e4ef87ac5c5f831","rule/demo-rule":"94b4fcca183f1a395b2231260530d3d608b66d70206d8eff1d0000d680d65d6a","skill/demo-skill":"763e7d2a3620743afe13cecae56bafec01e4346e8aa945bc63262e24b4ff4248"},"version":1}
+dir .claude/rules
+link .claude/rules/demo-rule.md -> .claude/at/staged/rule/demo-rule
+dir .claude/skills
+link .claude/skills/demo-skill -> .claude/at/staged/skill/demo-skill

--- a/installer/tests/e2e/goldens/status_dashboard.golden
+++ b/installer/tests/e2e/goldens/status_dashboard.golden
@@ -1,0 +1,19 @@
+Agent Templates — status
+Bundles
+  ✅ demo-bundle  (demo-pack-a, demo-pack-extras)
+Packages
+  ✅ demo-pack-a  (skill/demo-skill, agent/demo-agent)
+  ❌ demo-pack-b  (skill/demo-skill-two, agent/demo-agent)
+  ✅ demo-pack-extras  (rule/demo-rule)
+Skills
+  ✅ demo-skill
+  ❌ demo-skill-two
+Agents
+  ✅ demo-agent
+Rules
+  ✅ demo-rule
+Hooks
+  ❌ demo-hook
+Drift
+  demo-skill — up to date
+<SOURCE_ROOT>

--- a/installer/tests/e2e/goldens/uninstall_bundle.golden
+++ b/installer/tests/e2e/goldens/uninstall_bundle.golden
@@ -1,0 +1,9 @@
+dir .claude/agents
+dir .claude/at
+dir .claude/at/staged
+dir .claude/at/staged/agent
+dir .claude/at/staged/rule
+dir .claude/at/staged/skill
+json .claude/at/state.json {"units":{},"version":1}
+dir .claude/rules
+dir .claude/skills

--- a/installer/tests/e2e/goldens/validate_summary.golden
+++ b/installer/tests/e2e/goldens/validate_summary.golden
@@ -1,0 +1,1 @@
+catalog OK — 5 units, 3 packages, 1 bundles

--- a/installer/tests/e2e/test_bundles.py
+++ b/installer/tests/e2e/test_bundles.py
@@ -1,0 +1,63 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+from harness import FIXTURES_DIR, GOLDENS_DIR, assert_matches_golden, run_at, snapshot
+
+
+@pytest.mark.e2e
+def test_bundle_install_expands_to_full_unit_set(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    # demo-bundle groups demo-pack-a (skill/demo-skill, agent/demo-agent) and
+    # demo-pack-extras (rule/demo-rule + the schemas/ extra). Installing it
+    # expands to both packages' full unit sets: every unit staged and linked,
+    # each refcount credited to its member package, and demo-pack-extras'
+    # extra staged. The golden pins the whole expanded tree.
+    install_result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--bundle", "demo-bundle", "--non-interactive"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+    assert_matches_golden(
+        name="install_bundle_expands",
+        actual=snapshot(home),
+        goldens_dir=GOLDENS_DIR,
+    )
+
+
+@pytest.mark.e2e
+def test_bundle_uninstall_tears_down_full_unit_set(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    install_result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--bundle", "demo-bundle", "--non-interactive"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    # Uninstalling the bundle withdraws every member package's refcount; with
+    # nothing else claiming them, all the expanded units and the staged extra are
+    # torn back down. The golden pins that emptied end-state — staged dirs remain,
+    # but no units, links, or extras — the uninstall leg of the install/uninstall
+    # pair the suite pins per bundle.
+    uninstall_result: subprocess.CompletedProcess[str] = run_at(
+        args=["uninstall", "--bundle", "demo-bundle"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert uninstall_result.returncode == 0, uninstall_result.stderr
+    assert_matches_golden(
+        name="uninstall_bundle",
+        actual=snapshot(home),
+        goldens_dir=GOLDENS_DIR,
+    )

--- a/installer/tests/e2e/test_shims.py
+++ b/installer/tests/e2e/test_shims.py
@@ -25,9 +25,9 @@ def test_validate_sh_reports_catalog_lint_summary(tmp_path: Path) -> None:
         catalog=FIXTURES_DIR / "catalog.toml",
     )
 
-    # The fixture catalog declares 5 units, 3 packages, 0 bundles; the Python engine's
+    # The fixture catalog declares 5 units, 3 packages, 1 bundles; the Python engine's
     # catalog lint prints exactly that one-line summary and exits 0.
-    assert result.stdout.strip() == "catalog OK — 5 units, 3 packages, 0 bundles"
+    assert result.stdout.strip() == "catalog OK — 5 units, 3 packages, 1 bundles"
     assert result.returncode == 0, result.stderr
 
 

--- a/installer/tests/e2e/test_status.py
+++ b/installer/tests/e2e/test_status.py
@@ -1,0 +1,52 @@
+import subprocess
+from pathlib import Path
+from typing import Final
+
+import pytest
+from harness import FIXTURES_DIR, GOLDENS_DIR, assert_matches_golden, run_at
+
+# The dashboard's final line is the active source root — an absolute path that
+# differs per machine/CI — so the scenario folds it to this stable token before
+# pinning the golden.
+_SOURCE_ROOT_PLACEHOLDER: Final[str] = "<SOURCE_ROOT>"
+
+
+@pytest.mark.e2e
+def test_status_dashboard_reports_mixed_install_and_skill_drift(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    # Seed a deliberately non-trivial state: installing demo-bundle credits
+    # demo-pack-a and demo-pack-extras, so those two packages and demo-bundle read
+    # as installed while demo-pack-b, demo-skill-two, and demo-hook stay not
+    # installed. The staged demo-skill matches its source, so Drift reads "up to
+    # date" — exercising every dashboard section with real content, not just empty
+    # placeholders.
+    install_result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--bundle", "demo-bundle", "--non-interactive"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+
+    status_result: subprocess.CompletedProcess[str] = run_at(
+        args=["status"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=catalog,
+    )
+    assert status_result.returncode == 0, status_result.stderr
+
+    normalized: str = status_result.stdout.replace(
+        str(FIXTURES_DIR), _SOURCE_ROOT_PLACEHOLDER
+    )
+    # Guard the golden against silently pinning an un-normalized machine path: the
+    # fold must have fired, so the placeholder line is present in what we gate.
+    assert _SOURCE_ROOT_PLACEHOLDER in normalized, status_result.stdout
+    assert_matches_golden(
+        name="status_dashboard",
+        actual=normalized,
+        goldens_dir=GOLDENS_DIR,
+    )

--- a/installer/tests/e2e/test_validate.py
+++ b/installer/tests/e2e/test_validate.py
@@ -1,0 +1,28 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+from harness import FIXTURES_DIR, GOLDENS_DIR, assert_matches_golden, run_at
+
+
+@pytest.mark.e2e
+def test_validate_reports_fixture_catalog_counts(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+
+    # `at validate` loads the fixture catalog through the shared loader and, for a
+    # clean catalog, prints one counts line and exits 0. The golden pins that exact
+    # stdout — the direct-CLI counterpart to the validate.sh shim path that
+    # test_shims pins with an assert.
+    result: subprocess.CompletedProcess[str] = run_at(
+        args=["validate"],
+        home=home,
+        source_root=FIXTURES_DIR,
+        catalog=FIXTURES_DIR / "catalog.toml",
+    )
+    assert result.returncode == 0, result.stderr
+    assert_matches_golden(
+        name="validate_summary",
+        actual=result.stdout,
+        goldens_dir=GOLDENS_DIR,
+    )


### PR DESCRIPTION
Part of #74 (slice 8.e2e: E2E scenarios — a bundle expands to its full unit set; `at status` and `at validate` golden output). Routed to **lite** as planned (e2e via the tested harness — `--bundle` already shipped in 8.2/#120, so no CLI scope-bump was needed). Closes out slice 8.

## What changed

**Slice 8's shipped behavior is now pinned end to end through the real `at` subprocess against the frozen fixture catalog — tests + fixtures + goldens only, zero production code.**

- **Fixture catalog** gains its first bundle: `demo-bundle = [demo-pack-a, demo-pack-extras]` — witnesses multi-package expansion plus extras staging, while `demo-pack-b`/`demo-hook` stay uninstalled as the ❌ rows for the status grid. Ripple handled: `test_shims.py`'s pinned lint line moves `0 bundles` → `1 bundles` in lockstep. All 16 pre-existing goldens are byte-identical (bundles are derived from package refcounts, never recorded in `state.json`).
- **`test_bundles.py`**: `at install --bundle demo-bundle --non-interactive` expands to both member packages' full unit sets — staged copies, live symlinks, refcounts credited to the member packages (not the bundle), and the `schemas` extra staged with its content hash — pinned by `install_bundle_expands.golden`; `at uninstall --bundle` tears the whole expansion back down to `{"units":{},"version":1}` (`uninstall_bundle.golden`), matching the suite's install→uninstall pair grammar.
- **`test_status.py`**: `at status` renders a non-trivial dashboard — mixed ✅/❌ availability, the Bundles section, a `demo-skill — up to date` drift row — pinned by `status_dashboard.golden`. The machine-dependent final source-root line is folded test-locally to `<SOURCE_ROOT>` with a containment guard, so a failed fold dies loudly instead of committing a CI-breaking golden.
- **`test_validate.py`**: `at validate` via the direct CLI prints exactly `catalog OK — 5 units, 3 packages, 1 bundles`, exit 0 (`validate_summary.golden`) — the direct-CLI counterpart to the existing `validate.sh` shim pin (two front doors, parallel to the shim-install vs direct-install split).

## How it was built

Test-first, 4 RED→GREEN behaviors through the public boundary (the real `uv run at.py` subprocess + on-disk tree + stdout), each with a witnessed right-reason RED: bundle-install-expands (unknown bundle → exit 2 → `assert 2 == 0`), then three honest missing-golden AssertionErrors (validate deliberately uses a golden pin rather than an inline assert precisely so its RED is real). Goldens blessed with `AT_BLESS=1` and eyeballed; suite green **without** `AT_BLESS`, proving they match live output. Suite 170 → **174 passed** (`-W error`); gates green (`ruff format --check`, `ruff check`, `mypy --strict`).

Reviewer panel (correctness+security / rules+test-form / quality) unanimous **95/95/94 with zero findings** — all three independently cross-verified the new goldens' provenance against sibling goldens' hashes (member units present, non-members excluded, teardown state exact) · critic **96 achieved, zero gaps**. No fix round needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)