### PR TITLE
feat(skills): make-pr and make-pr-lite always push and open the PR on done

### DIFF
--- a/skills/make-pr-lite/SKILL.md
+++ b/skills/make-pr-lite/SKILL.md
@@ -126,8 +126,11 @@ gate output, and the reviewers' findings. Each reviewer finding carries a 1–10
 7. **Done.** When all behaviors and gates are green, no CRITICAL / `>=70` / aggregate blocker, and
    critic `achieved`. **Squash to one commit:**
    `git reset --soft <base> && git commit -m "<conventional subject>"` (no AI attribution).
-   Confirm only boundary files changed (`git diff --name-only <base>...HEAD`). Summarize, ask the
-   human to confirm done — never push or open a PR unless asked.
+   Confirm only boundary files changed (`git diff --name-only <base>...HEAD`). Then ship it
+   without asking: branch first if still on the default branch, `git push -u origin <branch>`
+   (`--force-with-lease` only if this run already pushed the branch before the squash), and
+   `gh pr create` against the default branch (or the task-named target), referencing the
+   task/issue in the body. Summarize with the PR URL — done needs no human confirmation.
 
 ## Status table
 

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -197,7 +197,8 @@ Resolve these values before the first dispatch:
 8. **Done** → only when: all behaviors green, all gates green, no CRITICAL review finding, no
    unwaived review finding with `score >= 70` (a black-letter language-rule violation always scores
    `>= 70` and is never waivable), critic `achieved`, and any step-7 fix has been re-verified per
-   the proportional rule above. Summarize and hand back.
+   the proportional rule above. Ship it without asking (see Decisions you own): push the branch,
+   open the PR, and summarize with the PR URL.
 
 ## JSONL logging contract (mandatory)
 
@@ -240,8 +241,10 @@ After review + critic you choose one:
   change (step 7).
 - **stop / re-scope** — task is mis-scoped, blocked, or spans modules; report up with why.
 
-You ask the human to confirm a **done** or a **stop**; you do not push or open PRs yourself
-unless asked.
+A **done** you ship yourself — never ask the human to confirm it. Branch first if still on the
+default branch, `git push -u origin <branch>`, then `gh pr create` against the default branch (or
+the task-named target), referencing the task/issue in the body, and report the PR URL. Only a
+**stop / re-scope** goes back to the human.
 
 ## Hard rules
 


### PR DESCRIPTION
## What

Both PR-driving skills used to end their run by asking the human to confirm a **done** and explicitly forbade pushing or opening a PR unless asked. Per owner direction, a **done** now ships itself:

- **make-pr** — step 8 (Done) and *Decisions you own*: push the branch (branching first if still on the default branch), `gh pr create` against the default branch or the task-named target, reference the task/issue, report the PR URL. Only **stop / re-scope** still goes back to the human.
- **make-pr-lite** — step 7 (Done): same ship step after the squash, with `--force-with-lease` allowed only when the run already pushed the branch before squashing.

## Why

The confirmation gate added a blocking round-trip on every finished PR; the owner always answers "ship it".

Non-behavioral (skill prose only) — no code paths changed; both skills reinstalled and verified via `at status` (no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)