### PR TITLE
feat(metrics): skill_version — installer SHA stamp + extractor resolution (#126, PR 1.5)

### DIFF
--- a/installer/actions.py
+++ b/installer/actions.py
@@ -1,6 +1,7 @@
 """Compose the placement primitives into whole installs, so callers ask for
 "install this skill" rather than wiring stage + link + record themselves."""
 
+from dataclasses import replace
 from pathlib import Path
 from typing import Final, Protocol
 
@@ -74,12 +75,10 @@ def _install_unit(
         }
     )
     sha: str = source_sha_of(source_root=source_root)
-    new_state: State = State(
-        version=state.version,
+    new_state: State = replace(
+        state,
         units={**state.units, installed_id: content_hash},
         requesters=new_requesters,
-        extras=state.extras,
-        extra_hashes=state.extra_hashes,
         source_sha=sha or state.source_sha,
     )
     save_state(new_state, state_root)
@@ -102,8 +101,8 @@ def _uninstall_unit(
     unlink_unit(link_path=link_path)
     unstage_unit(unit=unit, staged_root=state_root / STAGED_DIRNAME)
     removed_id: str = unit_id(unit)
-    new_state: State = State(
-        version=state.version,
+    new_state: State = replace(
+        state,
         units={
             existing_id: content
             for existing_id, content in state.units.items()
@@ -114,8 +113,6 @@ def _uninstall_unit(
             for existing_id, tokens in state.requesters.items()
             if existing_id != removed_id
         },
-        extras=state.extras,
-        extra_hashes=state.extra_hashes,
     )
     save_state(new_state, state_root)
     return new_state
@@ -352,57 +349,38 @@ def _drop_requester_token(*, tokens: tuple[str, ...], token: str) -> tuple[str, 
 
 
 def _set_requesters(*, state: State, unit: str, tokens: tuple[str, ...]) -> State:
-    """Replace one unit's requester set on a brand-new immutable State, carrying
-    units, extras, extra hashes, and the other units' requesters forward untouched, so
-    threading a package install never disturbs unrelated bookkeeping."""
-    return State(
-        version=state.version,
-        units=state.units,
-        requesters={**state.requesters, unit: tokens},
-        extras=state.extras,
-        extra_hashes=state.extra_hashes,
-    )
+    """Replace one unit's requester set on a brand-new immutable State, carrying every
+    other field — units, extras, extra hashes, the source stamp, and the other units'
+    requesters — forward untouched, so threading a package install never disturbs
+    unrelated bookkeeping."""
+    return replace(state, requesters={**state.requesters, unit: tokens})
 
 
 def _set_extras(*, state: State, extra: str, tokens: tuple[str, ...]) -> State:
-    """Replace one extra's requester set on a brand-new immutable State, carrying
-    units, requesters, extra hashes, and the other extras forward untouched, so
-    recording one extra never disturbs unrelated bookkeeping — the extras analogue of
-    _set_requesters."""
-    return State(
-        version=state.version,
-        units=state.units,
-        requesters=state.requesters,
-        extras={**state.extras, extra: tokens},
-        extra_hashes=state.extra_hashes,
-    )
+    """Replace one extra's requester set on a brand-new immutable State, carrying every
+    other field — units, requesters, extra hashes, the source stamp, and the other
+    extras — forward untouched, so recording one extra never disturbs unrelated
+    bookkeeping — the extras analogue of _set_requesters."""
+    return replace(state, extras={**state.extras, extra: tokens})
 
 
 def _set_extra_hash(*, state: State, extra: str, content_hash: str) -> State:
     """Replace one extra's recorded content hash on a brand-new immutable State,
-    carrying units, requesters, and the other extras' hashes forward untouched, so
-    recording one extra's hash never disturbs unrelated bookkeeping — the content-hash
-    analogue of _set_extras."""
-    return State(
-        version=state.version,
-        units=state.units,
-        requesters=state.requesters,
-        extras=state.extras,
-        extra_hashes={**state.extra_hashes, extra: content_hash},
-    )
+    carrying every other field — units, requesters, extras, the source stamp, and the
+    other extras' hashes — forward untouched, so recording one extra's hash never
+    disturbs unrelated bookkeeping — the content-hash analogue of _set_extras."""
+    return replace(state, extra_hashes={**state.extra_hashes, extra: content_hash})
 
 
 def _forget_extra(*, state: State, extra: str) -> State:
-    """Drop one extra key entirely from a brand-new immutable State, carrying units,
-    requesters, and the other extras forward untouched, so removing an extra whose last
-    requester is gone never disturbs unrelated bookkeeping — the extras analogue of how
-    the unit loop rebuilds state without the removed unit. Drops both the extra's
-    requester entry and its content-hash entry, so a forgotten extra leaves no orphaned
-    hash behind."""
-    return State(
-        version=state.version,
-        units=state.units,
-        requesters=state.requesters,
+    """Drop one extra key entirely from a brand-new immutable State, carrying every
+    other field — units, requesters, the source stamp, and the other extras — forward
+    untouched, so removing an extra whose last requester is gone never disturbs
+    unrelated bookkeeping — the extras analogue of how the unit loop rebuilds state
+    without the removed unit. Drops both the extra's requester entry and its
+    content-hash entry, so a forgotten extra leaves no orphaned hash behind."""
+    return replace(
+        state,
         extras={
             relpath: tokens
             for relpath, tokens in state.extras.items()

--- a/installer/actions.py
+++ b/installer/actions.py
@@ -33,13 +33,14 @@ from placement import (
     unstage_unit,
 )
 from settings import merge_hook_settings, unmerge_hook_settings
-from state import State, save_state
+from state import State, save_state, source_sha_of
 
 
 def _install_unit(
     *,
     unit: Unit,
     source: Path,
+    source_root: Path,
     link_path: Path,
     state_root: Path,
     state: State,
@@ -53,7 +54,9 @@ def _install_unit(
     mutated. When requester is given, the SAME write also credits that requester to the
     unit, so a package install records the unit and its requester atomically and a crash
     can never leave the unit present-but-uncredited. A direct install (requester None)
-    carries the existing requesters forward untouched, adding no token."""
+    carries the existing requesters forward untouched, adding no token. Also stamps the
+    source repo's HEAD sha (read from source_root via source_sha_of) onto the returned
+    State, keeping the prior stamp when the source is not a git repo."""
     staged_path: Path = stage_unit(
         unit=unit, source=source, staged_root=state_root / STAGED_DIRNAME
     )
@@ -70,12 +73,14 @@ def _install_unit(
             ),
         }
     )
+    sha: str = source_sha_of(source_root=source_root)
     new_state: State = State(
         version=state.version,
         units={**state.units, installed_id: content_hash},
         requesters=new_requesters,
         extras=state.extras,
         extra_hashes=state.extra_hashes,
+        source_sha=sha or state.source_sha,
     )
     save_state(new_state, state_root)
     return new_state
@@ -130,6 +135,7 @@ def install_skill(
     return _install_unit(
         unit=skill_unit(name),
         source=source_root / SKILLS_DIRNAME / name,
+        source_root=source_root,
         link_path=claude_root / SKILLS_DIRNAME / name,
         state_root=state_root,
         state=state,
@@ -152,6 +158,7 @@ def install_agent(
     return _install_unit(
         unit=agent_unit(name),
         source=source_root / AGENTS_DIRNAME / f"{name}.md",
+        source_root=source_root,
         link_path=claude_root / AGENTS_DIRNAME / f"{name}.md",
         state_root=state_root,
         state=state,
@@ -174,6 +181,7 @@ def install_rule(
     return _install_unit(
         unit=rule_unit(name),
         source=source_root / RULES_DIRNAME / f"{name}.md",
+        source_root=source_root,
         link_path=claude_root / RULES_DIRNAME / f"{name}.md",
         state_root=state_root,
         state=state,
@@ -201,6 +209,7 @@ def install_hook(
     new_state: State = _install_unit(
         unit=hook_unit(name),
         source=source_root / HOOKS_DIRNAME / f"{name}.sh",
+        source_root=source_root,
         link_path=claude_root / HOOKS_DIRNAME / f"{name}.sh",
         state_root=state_root,
         state=state,

--- a/installer/state.py
+++ b/installer/state.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -27,11 +28,35 @@ class State:
     # last with a default so existing State(version=..., units=..., requesters=...,
     # extras=...) call sites keep working.
     extra_hashes: dict[str, str] = field(default_factory=dict)
+    # the HEAD sha of the source repo this store was installed from, or "" when the
+    # source was not a git repo; declared last with a default so existing State(...)
+    # call sites keep working.
+    source_sha: str = ""
 
 
 def default_state() -> State:
     """The starting point for a root that has never been installed into."""
     return State(version=STATE_VERSION, units={})
+
+
+def source_sha_of(*, source_root: Path) -> str:
+    """Report which source revision an install came from by reading the source repo's
+    HEAD sha, so a store can record it. Requires source_root to be the repo root
+    itself: returns "" when it holds no ".git", so a non-repo source (a fixture tree
+    nested inside an unrelated repo) never picks up the enclosing repo's sha. Also
+    returns "" when git is unavailable or has no commit yet."""
+    if not (source_root / ".git").exists():
+        return ""
+    try:
+        completed: subprocess.CompletedProcess[str] = subprocess.run(
+            ["git", "-C", str(source_root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+    return completed.stdout.strip()
 
 
 def save_state(state: State, root: Path) -> None:
@@ -51,6 +76,10 @@ def save_state(state: State, root: Path) -> None:
     # so no tuple handling is needed unlike requesters/extras above.
     if state.extra_hashes:
         payload["extra_hashes"] = state.extra_hashes
+    # Omit an empty source_sha for the same reason; a store installed from a non-repo
+    # source stamps nothing, so committed e2e goldens stay byte-identical.
+    if state.source_sha:
+        payload["source_sha"] = state.source_sha
     # Write a sibling temp file and atomically swap it in, so a failed write
     # leaves the prior store intact rather than a half-written file.
     with tempfile.NamedTemporaryFile(
@@ -97,12 +126,15 @@ def load_state(root: Path) -> State:
         extra_hashes: dict[str, str] = cast(
             "dict[str, str]", raw.get("extra_hashes", {})
         )
+        # A store written before this field has no "source_sha" key; default to "".
+        source_sha: str = cast("str", raw.get("source_sha", ""))
         return State(
             version=version,
             units=units,
             requesters=requesters,
             extras=extras,
             extra_hashes=extra_hashes,
+            source_sha=source_sha,
         )
     root.mkdir(parents=True, exist_ok=True)
     return default_state()

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -1,5 +1,6 @@
 import json
 import stat
+import subprocess
 from pathlib import Path
 
 from actions import (
@@ -17,7 +18,7 @@ from actions import (
 from catalog import Catalog, agent_unit_id, load_catalog, rule_unit_id, skill_unit_id
 from constants import DIRECT_REQUESTER
 from hashing import hash_unit
-from state import State, load_state
+from state import State, default_state, load_state
 
 
 def test_install_skill_stages_source_and_links_into_claude_skills(
@@ -104,6 +105,49 @@ def test_install_skill_records_staged_content_hash_as_unit_value(
     recorded_hash: str = result.units[skill_unit_id("demo-skill")]
     assert recorded_hash == hash_unit(skill_source)
     assert recorded_hash != ""
+
+
+def test_install_from_git_repo_source_stamps_head_sha_into_state(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "demo-skill"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text("# Demo Skill\n", encoding="utf-8")
+
+    # Make the source root a real git repo and commit it, so install has a HEAD to
+    # stamp. The -c config flags keep the commit independent of any global git config.
+    subprocess.run(["git", "init"], cwd=source_root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "add", "-A"], cwd=source_root, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "x"],
+        cwd=source_root,
+        check=True,
+        capture_output=True,
+    )
+    head: subprocess.CompletedProcess[str] = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=source_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    expected_sha: str = head.stdout.strip()
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    install_skill(
+        name="demo-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=default_state(),
+    )
+
+    assert load_state(state_root).source_sha == expected_sha
 
 
 def test_install_skill_preserves_existing_requesters_of_other_units(

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -18,7 +18,7 @@ from actions import (
 from catalog import Catalog, agent_unit_id, load_catalog, rule_unit_id, skill_unit_id
 from constants import DIRECT_REQUESTER
 from hashing import hash_unit
-from state import State, default_state, load_state
+from state import STATE_FILENAME, State, default_state, load_state
 
 
 def test_install_skill_stages_source_and_links_into_claude_skills(
@@ -148,6 +148,34 @@ def test_install_from_git_repo_source_stamps_head_sha_into_state(
     )
 
     assert load_state(state_root).source_sha == expected_sha
+
+
+def test_install_from_plain_source_root_writes_state_without_source_sha_key(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "demo-skill"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text("# Demo Skill\n", encoding="utf-8")
+
+    # No `git init`: the source is a plain tree with no HEAD to stamp. The on-disk
+    # store must stay byte-compatible with stores written before the stamp existed —
+    # so the key is omitted entirely, never written as an empty "source_sha": "".
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    install_skill(
+        name="demo-skill",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=default_state(),
+    )
+
+    payload: dict[str, object] = json.loads(
+        (state_root / STATE_FILENAME).read_text(encoding="utf-8")
+    )
+    assert "source_sha" not in payload
 
 
 def test_install_skill_preserves_existing_requesters_of_other_units(

--- a/installer/tests/test_actions.py
+++ b/installer/tests/test_actions.py
@@ -178,6 +178,70 @@ def test_install_from_plain_source_root_writes_state_without_source_sha_key(
     assert "source_sha" not in payload
 
 
+def test_source_sha_stamp_survives_uninstall_state_write(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    for skill_name in ("alpha", "beta"):
+        skill_source: Path = source_root / "skills" / skill_name
+        skill_source.mkdir(parents=True)
+        (skill_source / "SKILL.md").write_text(
+            f"# {skill_name} Skill\n", encoding="utf-8"
+        )
+
+    # Make the source root a real git repo and commit it, so install has a HEAD to
+    # stamp. The -c config flags keep the commit independent of any global git config.
+    subprocess.run(["git", "init"], cwd=source_root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "add", "-A"], cwd=source_root, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "x"],
+        cwd=source_root,
+        check=True,
+        capture_output=True,
+    )
+    head: subprocess.CompletedProcess[str] = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=source_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    expected_sha: str = head.stdout.strip()
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+
+    # Install two skills so the store still holds a unit after one is removed; the
+    # install stamps the source repo's HEAD sha into the persisted store.
+    state_after_alpha: State = install_skill(
+        name="alpha",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=default_state(),
+    )
+    state_after_beta: State = install_skill(
+        name="beta",
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state_after_alpha,
+    )
+
+    uninstall_skill(
+        name="beta",
+        state_root=state_root,
+        claude_root=claude_root,
+        state=state_after_beta,
+    )
+
+    # Uninstalling one unit rewrites the store; that rewrite must carry the stamp
+    # forward rather than silently dropping it.
+    assert load_state(state_root).source_sha == expected_sha
+
+
 def test_install_skill_preserves_existing_requesters_of_other_units(
     tmp_path: Path,
 ) -> None:

--- a/metrics/extractor.py
+++ b/metrics/extractor.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Final
 
 _TRACKED_VARIANTS: Final[frozenset[str]] = frozenset({"make-pr", "make-pr-lite"})
+_DEFAULT_CLAUDE_ROOT: Final[Path] = Path.home() / ".claude"
 
 # Anthropic list prices cached 2026-06-24, USD per 1,000,000 tokens as (input, output).
 # An unknown model id is absent here and contributes $0 to the cost estimate.
@@ -221,13 +222,36 @@ class RunRecord:
     detail: dict[str, object] = field(default_factory=dict)
 
 
-def extract_run(*, transcript_path: Path) -> RunRecord | None:
+def _resolve_skill_version(*, variant: str, claude_root: Path) -> str:
+    """Resolve the skill version stamped for a tracked run, empty when unknown.
+
+    Reads the installer's `at/state.json` and returns its top-level `source_sha`
+    when present as a non-empty string; a missing file or unparsable JSON resolves
+    to "" rather than raising.
+    """
+    state_path: Path = claude_root / "at" / "state.json"
+    try:
+        state: object = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    if isinstance(state, dict):
+        source_sha: object = state.get("source_sha")
+        if isinstance(source_sha, str) and source_sha:
+            return source_sha
+    return ""
+
+
+def extract_run(
+    *, transcript_path: Path, claude_root: Path = _DEFAULT_CLAUDE_ROOT
+) -> RunRecord | None:
     """Read a JSONL transcript into its run record, or None for an untracked run.
 
     Streams line by line so header lines that lack `attributionSkill`/`timestamp` are
     tolerated. A run is attributed only when its `attributionSkill` is in
     `_TRACKED_VARIANTS`; `started_at` is the earliest `timestamp` anywhere in the file
-    and `active_sec` sums the non-idle gaps between all parsed timestamps.
+    and `active_sec` sums the non-idle gaps between all parsed timestamps. For a
+    tracked run, `skill_version` comes from `claude_root/at/state.json`'s
+    `source_sha` stamp, or stays empty when that stamp is absent or unreadable.
     """
     line_timestamps: list[datetime] = []
     variant: str | None = None
@@ -328,8 +352,12 @@ def extract_run(*, transcript_path: Path) -> RunRecord | None:
     if outcome == "":
         outcome = "blocked" if blocked_reason is not None else _UNKNOWN_OUTCOME
     started_at: datetime | None = min(line_timestamps) if line_timestamps else None
+    skill_version: str = _resolve_skill_version(
+        variant=variant, claude_root=claude_root
+    )
     return RunRecord(
         variant=variant,
+        skill_version=skill_version,
         session_id=session_id,
         started_at=started_at,
         active_sec=_active_sec(timestamps=line_timestamps),

--- a/metrics/extractor.py
+++ b/metrics/extractor.py
@@ -12,6 +12,7 @@ from typing import Final
 
 _TRACKED_VARIANTS: Final[frozenset[str]] = frozenset({"make-pr", "make-pr-lite"})
 _DEFAULT_CLAUDE_ROOT: Final[Path] = Path.home() / ".claude"
+_UNKNOWN_SKILL_VERSION: Final[str] = "unknown"
 
 # Anthropic list prices cached 2026-06-24, USD per 1,000,000 tokens as (input, output).
 # An unknown model id is absent here and contributes $0 to the cost estimate.
@@ -224,12 +225,12 @@ class RunRecord:
 
 
 def _resolve_skill_version(*, variant: str, claude_root: Path) -> str:
-    """Resolve the skill version for a tracked run, empty only when nothing is readable.
+    """Resolve a tracked run's skill version, "unknown" only when nothing is readable.
 
     Prefers the installer's `at/state.json` `source_sha` stamp (a non-empty string);
     when that stamp is absent or the file is unparsable, falls back to a short content
     hash of the installed `skills/<variant>/SKILL.md`. A missing or unreadable skill
-    file leaves the result "".
+    file leaves the result "unknown".
     """
     state_path: Path = claude_root / "at" / "state.json"
     try:
@@ -244,7 +245,7 @@ def _resolve_skill_version(*, variant: str, claude_root: Path) -> str:
     try:
         data: bytes = skill_path.read_bytes()
     except OSError:
-        return ""
+        return _UNKNOWN_SKILL_VERSION
     return "installed:" + hashlib.sha256(data).hexdigest()[:8]
 
 
@@ -259,7 +260,8 @@ def extract_run(
     and `active_sec` sums the non-idle gaps between all parsed timestamps. For a
     tracked run, `skill_version` comes from `claude_root/at/state.json`'s
     `source_sha` stamp, falling back to a short content hash of the installed
-    `skills/<variant>/SKILL.md` (see `_resolve_skill_version`).
+    `skills/<variant>/SKILL.md`, and finally to "unknown" when neither is readable
+    (see `_resolve_skill_version`).
     """
     line_timestamps: list[datetime] = []
     variant: str | None = None

--- a/metrics/extractor.py
+++ b/metrics/extractor.py
@@ -228,14 +228,16 @@ def _resolve_skill_version(*, variant: str, claude_root: Path) -> str:
     """Resolve a tracked run's skill version, "unknown" only when nothing is readable.
 
     Prefers the installer's `at/state.json` `source_sha` stamp (a non-empty string);
-    when that stamp is absent or the file is unparsable, falls back to a short content
-    hash of the installed `skills/<variant>/SKILL.md`. A missing or unreadable skill
-    file leaves the result "unknown".
+    when that stamp is absent or the file is unreadable or unparsable, falls back to a
+    short content hash of the installed `skills/<variant>/SKILL.md`. A missing or
+    unreadable skill file leaves the result "unknown".
     """
     state_path: Path = claude_root / "at" / "state.json"
     try:
+        # ValueError subsumes json.JSONDecodeError and the UnicodeDecodeError that
+        # read_text raises on invalid UTF-8, so bad bytes degrade instead of raising.
         state: object = json.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, ValueError):
         state = None
     if isinstance(state, dict):
         source_sha: object = state.get("source_sha")

--- a/metrics/extractor.py
+++ b/metrics/extractor.py
@@ -1,5 +1,6 @@
 """Turn a Claude Code session transcript into one run-level metrics row."""
 
+import hashlib
 import json
 import re
 from collections.abc import Iterator
@@ -223,22 +224,28 @@ class RunRecord:
 
 
 def _resolve_skill_version(*, variant: str, claude_root: Path) -> str:
-    """Resolve the skill version stamped for a tracked run, empty when unknown.
+    """Resolve the skill version for a tracked run, empty only when nothing is readable.
 
-    Reads the installer's `at/state.json` and returns its top-level `source_sha`
-    when present as a non-empty string; a missing file or unparsable JSON resolves
-    to "" rather than raising.
+    Prefers the installer's `at/state.json` `source_sha` stamp (a non-empty string);
+    when that stamp is absent or the file is unparsable, falls back to a short content
+    hash of the installed `skills/<variant>/SKILL.md`. A missing or unreadable skill
+    file leaves the result "".
     """
     state_path: Path = claude_root / "at" / "state.json"
     try:
         state: object = json.loads(state_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
-        return ""
+        state = None
     if isinstance(state, dict):
         source_sha: object = state.get("source_sha")
         if isinstance(source_sha, str) and source_sha:
             return source_sha
-    return ""
+    skill_path: Path = claude_root / "skills" / variant / "SKILL.md"
+    try:
+        data: bytes = skill_path.read_bytes()
+    except OSError:
+        return ""
+    return "installed:" + hashlib.sha256(data).hexdigest()[:8]
 
 
 def extract_run(
@@ -251,7 +258,8 @@ def extract_run(
     `_TRACKED_VARIANTS`; `started_at` is the earliest `timestamp` anywhere in the file
     and `active_sec` sums the non-idle gaps between all parsed timestamps. For a
     tracked run, `skill_version` comes from `claude_root/at/state.json`'s
-    `source_sha` stamp, or stays empty when that stamp is absent or unreadable.
+    `source_sha` stamp, falling back to a short content hash of the installed
+    `skills/<variant>/SKILL.md` (see `_resolve_skill_version`).
     """
     line_timestamps: list[datetime] = []
     variant: str | None = None

--- a/metrics/tests/test_extractor.py
+++ b/metrics/tests/test_extractor.py
@@ -176,6 +176,26 @@ def test_skill_version_falls_back_to_installed_skill_content_hash(
     assert record.skill_version == expected
 
 
+def test_corrupt_state_json_degrades_to_installed_hash_instead_of_raising(
+    tmp_path: Path,
+) -> None:
+    state_dir: Path = tmp_path / "at"
+    state_dir.mkdir()
+    (state_dir / "state.json").write_bytes(b'\xff\xfe{"version": 1}')
+    skill_bytes: bytes = b"# make-pr\n\nInstalled skill body under test.\n"
+    skill_dir: Path = tmp_path / "skills" / "make-pr"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_bytes(skill_bytes)
+
+    record: RunRecord | None = extract_run(
+        transcript_path=_MAKE_PR_TRANSCRIPT, claude_root=tmp_path
+    )
+
+    expected: str = "installed:" + hashlib.sha256(skill_bytes).hexdigest()[:8]
+    assert record is not None
+    assert record.skill_version == expected
+
+
 def test_skill_version_is_unknown_when_no_stamp_and_no_installed_skill(
     tmp_path: Path,
 ) -> None:

--- a/metrics/tests/test_extractor.py
+++ b/metrics/tests/test_extractor.py
@@ -1,5 +1,6 @@
 """Spec: a make-pr session transcript yields a populated run record."""
 
+import hashlib
 import json
 import random
 from datetime import UTC, datetime
@@ -156,6 +157,23 @@ def test_run_record_carries_installer_source_sha_as_skill_version(
 
     assert record is not None
     assert record.skill_version == _SOURCE_SHA
+
+
+def test_skill_version_falls_back_to_installed_skill_content_hash(
+    tmp_path: Path,
+) -> None:
+    skill_bytes: bytes = b"# make-pr\n\nInstalled skill body under test.\n"
+    skill_dir: Path = tmp_path / "skills" / "make-pr"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_bytes(skill_bytes)
+
+    record: RunRecord | None = extract_run(
+        transcript_path=_MAKE_PR_TRANSCRIPT, claude_root=tmp_path
+    )
+
+    expected: str = "installed:" + hashlib.sha256(skill_bytes).hexdigest()[:8]
+    assert record is not None
+    assert record.skill_version == expected
 
 
 def test_token_sums_survive_line_shuffle(tmp_path: Path) -> None:

--- a/metrics/tests/test_extractor.py
+++ b/metrics/tests/test_extractor.py
@@ -176,6 +176,17 @@ def test_skill_version_falls_back_to_installed_skill_content_hash(
     assert record.skill_version == expected
 
 
+def test_skill_version_is_unknown_when_no_stamp_and_no_installed_skill(
+    tmp_path: Path,
+) -> None:
+    record: RunRecord | None = extract_run(
+        transcript_path=_MAKE_PR_TRANSCRIPT, claude_root=tmp_path
+    )
+
+    assert record is not None
+    assert record.skill_version == "unknown"
+
+
 def test_token_sums_survive_line_shuffle(tmp_path: Path) -> None:
     lines: list[str] = _TOKEN_COST_TRANSCRIPT.read_text(encoding="utf-8").splitlines()
     random.Random(20260624).shuffle(lines)

--- a/metrics/tests/test_extractor.py
+++ b/metrics/tests/test_extractor.py
@@ -50,6 +50,9 @@ _EXPECTED_COST_USD: Final[float] = 0.052
 # 3450 s gap (09:02:30 -> 10:00:00) exceeds the 300 s idle threshold and is excluded.
 _EXPECTED_ACTIVE_SEC: Final[float] = 160.0
 
+# A fixed 40-hex commit sha the installer stamps into state.json as "source_sha".
+_SOURCE_SHA: Final[str] = "0123abcd4567ef890123abcd4567ef890123abcd"
+
 
 def test_make_pr_transcript_yields_populated_run_record() -> None:
     record: RunRecord | None = extract_run(transcript_path=_MAKE_PR_TRANSCRIPT)
@@ -133,6 +136,26 @@ def test_fix_mode_dispatches_counted_as_fix_loops() -> None:
     assert record is not None
     assert record.n_fix_loops == 2
     assert record.outcome == "achieved"
+
+
+def test_run_record_carries_installer_source_sha_as_skill_version(
+    tmp_path: Path,
+) -> None:
+    state_dir: Path = tmp_path / "at"
+    state_dir.mkdir()
+    state: dict[str, object] = {
+        "version": 1,
+        "units": {},
+        "source_sha": _SOURCE_SHA,
+    }
+    (state_dir / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+    record: RunRecord | None = extract_run(
+        transcript_path=_MAKE_PR_TRANSCRIPT, claude_root=tmp_path
+    )
+
+    assert record is not None
+    assert record.skill_version == _SOURCE_SHA
 
 
 def test_token_sums_survive_line_shuffle(tmp_path: Path) -> None:


### PR DESCRIPTION
PR 1.5 of #126 (slice 1 — extractor core): every extracted metrics record now carries a non-null `skill_version`, the column that separates skill changes on the timeline.

## What

**Installer** (`installer/state.py`, `installer/actions.py`)
- `State.source_sha` — new field, default `""`, omitted from `state.json` when empty so pre-stamp stores and the committed e2e goldens stay byte-identical.
- `source_sha_of(*, source_root)` — the repo HEAD SHA, only when the source root is itself a git repo root (`.git` file or dir, so worktrees count); `""` for non-repo roots (the e2e fixture trees) and on any git failure.
- Stamping happens in `_install_unit`, the single seam every install path converges on (CLI per-kind, packages, bundles, TUI, `at update`).
- All six `State` rebuilds in `actions.py` switched to `dataclasses.replace`, so the stamp (and any future field) survives uninstall/refcount rewrites instead of being silently reset by an explicit field list.

**Extractor** (`metrics/extractor.py`)
- `extract_run` gains keyword-only `claude_root` (default `~/.claude`); untracked transcripts never touch it.
- `skill_version` resolution for tracked runs: installer stamp from `<claude_root>/at/state.json` → `installed:<hash8>` (first 8 hex of sha256 of the installed `skills/<variant>/SKILL.md`) → `unknown`. Resolution never raises — unreadable/undecodable/unparsable state files degrade to the next tier.

## Evidence (7 TDD cycles, all right-reason RED first)

| Behavior | Test |
|---|---|
| install from a git-repo source stamps HEAD SHA | `test_install_from_git_repo_source_stamps_head_sha_into_state` |
| non-repo source leaves `state.json` without the key (golden byte-compat) | `test_install_from_plain_source_root_writes_state_without_source_sha_key` |
| stamp survives uninstall's state rewrite | `test_source_sha_stamp_survives_uninstall_state_write` |
| record carries the stamp as `skill_version` | `test_run_record_carries_installer_source_sha_as_skill_version` |
| fallback `installed:<hash8>` | `test_skill_version_falls_back_to_installed_skill_content_hash` |
| last resort `unknown` | `test_skill_version_is_unknown_when_no_stamp_and_no_installed_skill` |
| corrupt (non-UTF8) state.json degrades instead of raising | `test_corrupt_state_json_degrades_to_installed_hash_instead_of_raising` |

- Gates green in both packages: ruff format/check, mypy `--strict`, pytest `-W error` (installer **177 passed**, metrics **12 passed**); `./validate.sh` catalog OK; e2e goldens byte-identical.
- Done-when confirmed on real data: 27 transcripts under `~/.claude/projects` scanned with the default `claude_root`, all 12 tracked runs carry non-null `skill_version` (`installed:9bf9a8c8` make-pr / `installed:3dbf6e9c` lite — fallback tier, correct since the live install predates the stamp; the first post-merge `at install`/`at update` will start stamping real SHAs).
- Review: one MAJOR finding (UnicodeDecodeError escaping the never-raise contract) fixed in-branch with a RED-witnessed regression test; scoped re-review clean. Critic: **achieved, 92**.

## Non-blocking review notes (surfaced, not fixed here)

- `source_sha_of` could let a `PermissionError` from the git spawn escape (git present but non-executable — extreme edge; MINOR 32).
- The metrics package encodes the installer's `at/state.json` + `source_sha` contract in one private helper — inherent to the two-package split (MINOR 28).
- The two installer git-fixture tests share ~15 lines of setup boilerplate that could become a helper (MINOR 20).

Run log: `.v1-runs/feat_metrics-1.5-skill-version.jsonl` (23 rows: 7 RED, 7 GREEN, 1 non-behavioral, 3 gates, 3 review, 2 critic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
