### PR TITLE
feat(skills): pr-explain — per-PR explainer page, template extra, catalog wiring (#135, PR 1.1)

### DIFF
--- a/installer/catalog.toml
+++ b/installer/catalog.toml
@@ -48,6 +48,10 @@ name = "pr-breakdown"
 
 [[units]]
 kind = "skill"
+name = "pr-explain"
+
+[[units]]
+kind = "skill"
 name = "pr-make"
 
 [[units]]
@@ -163,10 +167,19 @@ units = [
 name = "pr-ops"
 units = [
   "skill/pr-babysit",
+  "skill/pr-explain",
   "skill/pr-make",
   "skill/pr-make-till-merge",
   "skill/latest-rebase",
 ]
+
+# pr-explain publishes a per-PR explainer page; its page skeleton ships as a package
+# extra so an install is self-contained. The skill degrades to inline styling when
+# installed without it (e.g. via pr-ops alone).
+[[packages]]
+name = "pr-explain"
+units = ["skill/pr-explain"]
+extras = ["templates/pr-explain-page.html"]
 
 # --- bundles (provisional) ---
 [[bundles]]

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: pr-explain
+description: Use when the user invokes /pr-explain or wants a reader-facing explainer page for a pull request — writes a 2-3 minute, word-budgeted story of the change (bottom line, system delta map, author-order story, proof, limits), publishes it as a private claude.ai artifact, and maintains a marker-delimited teaser in the PR body.
+argument-hint: "[#N | PR URL | blank = current branch's PR] [--refresh]"
+---
+
+# PR Explain
+
+Turn one pull request into a page its owner actually reads: the change explained the
+way a teammate would explain it at a whiteboard, in 2-3 minutes, with a picture of how
+the system changed and the evidence it works. The audience is the repo's owner keeping
+a mental model of a codebase agents typed — not a merge gatekeeper hunting defects.
+
+## Arguments
+
+| Form | Meaning |
+|------|---------|
+| *(blank)* | The open PR for the current branch (`gh pr view`) |
+| `#N` or `N` | PR number in the current repo |
+| a PR URL | That PR |
+| `--refresh` | Rebuild the page and update the existing artifact + teaser in place |
+
+## Runtime resolution
+
+- **Template**: `~/.claude/at/templates/pr-explain-page.html` — the page skeleton
+  (design tokens, chapter blocks, delta-map classes, minimap, legend). Staged by the
+  installer with this skill's package extras. If it is missing (skill installed without
+  its package), still ship: build a single-file HTML page with inline CSS following the
+  chapter contract below — visual polish degrades, the contract does not.
+- **Page file**: write the filled page to the session scratch directory (never into the
+  target repo), named `pr-<owner>-<repo>-<number>.html`. A stable name means republishing
+  in the same conversation keeps the same artifact URL.
+- **Target repo**: the git repo of the working directory. Run every `gh` and `git`
+  command there.
+
+## The page contract — six chapters, hard budgets
+
+| Chapter | Job | Budget |
+|---------|-----|--------|
+| Bottom line | What changed, why, impact, risk — the reader can stop here | 40-60 words |
+| The map | How the system changed: one delta-encoded component map + minimap | ≤ 40 words + map |
+| The problem | The concrete failing behavior — real command, error, or number first | 80-120 words + 1 block |
+| The story | One paragraph per design decision, author order, key diffs annotated | 150-200 words + ≤ 2 blocks |
+| The proof | Witnesses, gate numbers, runtime evidence — real, never invented | 40-70 words + evidence |
+| The limits | What deliberately didn't change, non-goals, sharp edges | 40-60 words |
+
+- Total prose 410-550 words; everything essential inside the first 200.
+- Code/output blocks are excluded from the budget and capped at 10 lines each.
+- Budgets are ceilings, not targets. Empty chapters are dropped, never padded.
+- **Scaling**: a non-structural PR (docs, config, formatting, version bumps) gets no map
+  and may shrink to five strong sentences across Bottom line / The story / The limits.
+  A structural PR gets the full page. Conditional diagrams are a quality signal — a
+  forced diagram teaches the reader to stop looking at diagrams.
+
+## Phase 1 — Gather
+
+```bash
+gh pr view <N> --json number,title,body,url,state,baseRefName,headRefName,closingIssuesReferences
+gh pr diff <N>
+gh pr view <N> --json commits --jq '.commits[].messageHeadline'
+gh pr checks <N> || true
+```
+
+- **The why**: read the linked issue (`closingIssuesReferences`) or the issue/PRD the
+  body references. The problem chapter comes from there, not from the diff.
+- **Evidence**: if `<target_repo>/.v1-runs/evidence/` exists for this PR's branch, read
+  it (RED/GREEN witnesses, gate transcript, runtime artifacts). Without it, the proof
+  chapter degrades to `gh pr checks` results and the tests visible in the diff. Never
+  fail for lack of evidence; never invent it either.
+
+## Phase 2 — Understand (before writing a word)
+
+1. **Name the one big thing** — the single decision that drives the diff. If you cannot
+   name it in one sentence, re-read the diff; do not start writing.
+2. **Group hunks into author-order cohorts** — data/schema first, then logic, then call
+   sites, then tests. The story follows this order, never file order.
+3. **Pick the key moments** — at most 3 hunks that carry the decision. Everything else
+   is summarized in prose.
+4. **Derive the delta map** (structural PRs only):
+   - Nodes are the changed components at the granularity a component diagram would show
+     (a module/file, not a function). Classify each from the diff: added, modified,
+     removed. Removed components stay on the map.
+   - Add unchanged 1-hop neighbors (importers/importees of changed files), dimmed —
+     they are the blast radius. Dim, never hide.
+   - Cap ~20 elements: collapse unchanged neighbors into their parent folder as one
+     dimmed node when over.
+5. **Build the minimap**: the repo's top-level directories, alphabetical, equal-width
+   cells, with the directories containing changes marked. Same strip, same order, every
+   PR — recognition over re-parsing.
+
+## Phase 3 — Write the chapters
+
+Draft the prose in a scratch buffer before touching HTML, then verify mechanically:
+
+- `wc -w` each chapter; cut until inside its budget.
+- Grep the draft for every banned word below; rewrite any hit.
+- Read each sentence once more: does it point at a hunk, a number, or an output the
+  page shows? A sentence that cannot cite its evidence gets cut.
+
+### Style contract
+
+1. **Bottom line first.** Change, reason, impact in the first three sentences.
+2. **One PR, one big thing.** Secondary changes get one line each, never their own arc.
+3. **Every claim points at evidence** — a diff hunk, a gate line, a check result, a
+   screenshot. "Faster", "safer", "fixed" each come with a number or output.
+4. **Concrete before abstract.** The failing command, error, or diff appears before any
+   general statement about it. Examples are trimmed from the real diff, never invented.
+5. **Data over adjectives; 25-word sentences; one idea per sentence.** "41 lines in the
+   parser", never "a clean, minimal change".
+6. **One name per concept — the name from the code.** Present tense for new behavior,
+   past tense only for the behavior it replaced.
+7. **Say what didn't change.** The limits chapter is what makes the brevity trustworthy.
+8. **No section exists to be complete — only to be read.**
+
+Banned on sight: leverages, robust, seamless, comprehensive, delve, streamlined,
+powerful, simply, ensures, significantly, various, clearly, essentially, "it's worth
+noting", and "should" when describing behavior (the page either shows it verified or
+drops the claim).
+
+## Phase 4 — Build the page
+
+- Start from the template; keep its tokens and classes; fill the `SLOT` comments.
+- Everything inline (CSS in the file, no external requests); light and dark themes come
+  from the template's token overrides — do not strip them.
+- **Delta map encoding** (must match the template legend):
+  - added = green node + `+` badge · modified = amber node + `~` badge · removed = red
+    node + `−` badge, kept on the map · unchanged neighbors dimmed.
+  - New edges solid green; removed edges thin red; unchanged edges translucent grey.
+  - Never color without the glyph badge — the badges are the colorblind-safe channel.
+- Diff blocks use the template's `del`/`add`/`ctx` classes; ≤ 10 lines per block.
+
+## Phase 5 — Publish
+
+- Publish the page file with the Artifact tool: title `PR #<N> — <imperative title>`,
+  favicon `📖` (keep it stable across refreshes), a one-sentence description.
+- `--refresh` in the same conversation: republish the same file path — same URL. From a
+  later session: read the existing artifact URL out of the teaser block and pass it as
+  the Artifact `url` parameter so the page updates in place.
+- If the Artifact tool is unavailable (headless/CI run), fall back: put the full story,
+  as markdown, into the PR-body block below instead of a teaser, and say so in your
+  report. Never fail the run because publishing is unavailable.
+
+## Phase 6 — The teaser in the PR body
+
+Maintain exactly one marker-delimited block in the PR description:
+
+```markdown
+<!-- pr-explain:begin -->
+### The story of this PR
+<the bottom-line chapter, verbatim — three sentences>
+
+**[Read the explainer](<artifact-url>)** · map: <n> changed components, <m> untouched neighbors
+<!-- pr-explain:end -->
+```
+
+- Read the current body (`gh pr view --json body`), remove any existing block between
+  the markers, append the fresh block, write back with `gh pr edit --body-file`.
+- Never touch prose outside the markers. If the body is empty, the block is the body.
+
+## Report
+
+End with: the artifact URL, total prose word count, chapters emitted vs dropped, map
+included or skipped (with the reason), and the PR whose teaser was updated.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Padding a thin PR to fill budgets | Budgets are ceilings; five strong sentences beat 500 padded words |
+| A map for a non-structural change | Skip it — conditional diagrams are the quality signal |
+| Raw diff dumps | ≤ 3 annotated moments, ≤ 10 lines each, chosen for the decision they carry |
+| Inventing proof | No evidence dir → CI checks only; never fabricate witnesses or numbers |
+| A new artifact URL on refresh | Same file path in-session; pass `url` across sessions |
+| Editing outside the teaser markers | Only the block between the pr-explain markers is yours |
+| Writing the page before the map | Phase 2 comes first — the map decides what the story must explain |

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -149,12 +149,13 @@ Maintain exactly one marker-delimited block in the PR description:
 ### The story of this PR
 <the bottom-line chapter, verbatim — three sentences>
 
-**[Read the explainer](<artifact-url>)** · map: <n> changed components, <m> untouched neighbors
+**[Read the explainer](<artifact-url>)**<map tail — only when the page has a map>
 <!-- pr-explain:end -->
 ```
 
 - Read the current body (`gh pr view --json body`), remove any existing block between
   the markers, append the fresh block, write back with `gh pr edit --body-file`.
+- The map tail (` · map: <n> changed components, <m> untouched neighbors`) is emitted only when the page includes the map chapter; a non-structural PR's teaser ends at the link.
 - Never touch prose outside the markers. If the body is empty, the block is the body.
 
 ## Report

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -1,176 +1,155 @@
 ---
 name: pr-explain
-description: Use when the user invokes /pr-explain or wants a reader-facing explainer page for a pull request — writes a 2-3 minute, word-budgeted story of the change (bottom line, system delta map, author-order story, proof, limits), publishes it as a private claude.ai artifact, and maintains a marker-delimited teaser in the PR body.
-argument-hint: "[#N | PR URL | blank = current branch's PR] [--refresh]"
+description: Use when the user invokes /pr-explain or wants a reader-facing explainer page for a pull request — writes a 2-3 minute, word-budgeted story of the change with a system delta map and proof, publishes it as a private claude.ai artifact, and maintains a marker-delimited teaser in the PR body.
+argument-hint: "[#N | PR URL | blank = current branch's PR]"
 ---
 
 # PR Explain
 
-Turn one pull request into a page its owner actually reads: the change explained the
-way a teammate would explain it at a whiteboard, in 2-3 minutes, with a picture of how
-the system changed and the evidence it works. The audience is the repo's owner keeping
-a mental model of a codebase agents typed — not a merge gatekeeper hunting defects.
+Write the page a teammate would draw at a whiteboard. The audience is the repo's owner
+keeping a mental model of a codebase agents typed — not a merge gatekeeper hunting
+defects.
 
 ## Arguments
 
 | Form | Meaning |
 |------|---------|
-| *(blank)* | The open PR for the current branch (`gh pr view`) |
-| `#N` or `N` | PR number in the current repo |
+| *(blank)* | The open PR for the current branch |
+| `#N` or `N` | PR number in the target repo |
 | a PR URL | That PR |
-| `--refresh` | Rebuild the page and update the existing artifact + teaser in place |
 
 ## Runtime resolution
 
-- **Template**: `~/.claude/at/templates/pr-explain-page.html` — the page skeleton
-  (design tokens, chapter blocks, delta-map classes, minimap, legend). Staged by the
-  installer with this skill's package extras. If it is missing (skill installed without
-  its package), still ship: build a single-file HTML page with inline CSS following the
-  chapter contract below — visual polish degrades, the contract does not.
-- **Page file**: write the filled page to the session scratch directory (never into the
-  target repo), named `pr-<owner>-<repo>-<number>.html`. A stable name means republishing
-  in the same conversation keeps the same artifact URL.
-- **Target repo**: the git repo of the working directory. Run every `gh` and `git`
-  command there.
+- **Template**: `~/.claude/at/templates/pr-explain-page.html` (design tokens + chapter,
+  delta-map, and minimap classes). If it is missing, still ship: build a single-file HTML
+  page with inline CSS following the chapter contract — visual polish degrades, the
+  contract does not.
+- **Page file**: write the filled page to the session scratch directory (never the
+  target repo) as `pr-<owner>-<repo>-<number>.html`, owner/repo parsed from the PR's `url`.
+- **Target repo**: the git repo of the working directory; run every `gh`/`git` command there.
 
 ## The page contract — six chapters, hard budgets
 
 | Chapter | Job | Budget |
 |---------|-----|--------|
-| Bottom line | What changed, why, impact, risk — the reader can stop here | 40-60 words |
-| The map | How the system changed: one delta-encoded component map + minimap | ≤ 40 words + map |
-| The problem | The concrete failing behavior — real command, error, or number first | 80-120 words + 1 block |
+| Bottom line | What changed, why, impact, risk, in the first three sentences — the reader can stop here | 40-60 words |
+| The map | How the system changed: one delta map + minimap | ≤ 40 words + map |
+| The problem | The concrete failing behavior — real command, error, or number first | 80-120 words + ≤ 1 block |
 | The story | One paragraph per design decision, author order, key diffs annotated | 150-200 words + ≤ 2 blocks |
-| The proof | Witnesses, gate numbers, runtime evidence — real, never invented | 40-70 words + evidence |
+| The proof | Witnesses, gate numbers, runtime evidence | 40-70 words + evidence |
 | The limits | What deliberately didn't change, non-goals, sharp edges | 40-60 words |
 
-- Total prose 410-550 words; everything essential inside the first 200.
+- Total prose ≤ 550 words; everything essential inside the first 200. Budgets are
+  ceilings, not targets — empty chapters are dropped, never padded.
 - Code/output blocks are excluded from the budget and capped at 10 lines each.
-- Budgets are ceilings, not targets. Empty chapters are dropped, never padded.
 - **Scaling**: a non-structural PR (docs, config, formatting, version bumps) gets no map
-  and may shrink to five strong sentences across Bottom line / The story / The limits.
-  A structural PR gets the full page. Conditional diagrams are a quality signal — a
-  forced diagram teaches the reader to stop looking at diagrams.
+  and may shrink to five sentences across Bottom line / The story / The limits. A
+  structural PR gets the full page.
 
 ## Phase 1 — Gather
 
 ```bash
-gh pr view <N> --json number,title,body,url,state,baseRefName,headRefName,closingIssuesReferences
+branch="$(git branch --show-current)"           # blank arg; empty output → detached HEAD: stop, ask for #N
+gh pr list --head "$branch" --json number,url   # [] → no open PR: stop, ask for #N
+gh pr view <N> --json number,title,body,url,headRefName,additions,deletions,createdAt
 gh pr diff <N>
-gh pr view <N> --json commits --jq '.commits[].messageHeadline'
 gh pr checks <N> || true
 ```
 
-- **The why**: read the linked issue (`closingIssuesReferences`) or the issue/PRD the
-  body references. The problem chapter comes from there, not from the diff.
-- **Evidence**: if `<target_repo>/.v1-runs/evidence/` exists for this PR's branch, read
-  it (RED/GREEN witnesses, gate transcript, runtime artifacts). Without it, the proof
-  chapter degrades to `gh pr checks` results and the tests visible in the diff. Never
-  fail for lack of evidence; never invent it either.
+- **The why**: read the issue/PRD the PR body references (`Closes #N` / `Refs #N`;
+  prefer `Closes`, first match) via
+  `gh issue view <N> --json title,body`. The problem chapter comes from there — the
+  slice/PR row the body names, else the issue's headline problem — not from the diff.
+  None referenced → derive it from the PR body and diff, and say so.
+- **Evidence**: look in `<target_repo>/.v1-runs/` for files whose stem is the head
+  branch with `/`→`_`: `<slug>.jsonl` (run log), `<slug>.tdd-runner.json` (RED witness),
+  `<slug>.coder.json`, `<slug>.reviewer.json`, `<slug>.critic.json`. Never invent
+  evidence: without those files, the proof chapter degrades to `gh pr checks` plus the
+  tests visible in the diff. Checks empty too → cite the diff's test files. Gate numbers
+  claimed in the PR body appear only attributed ("PR body reports: pytest 18 passed"),
+  never as verified chips.
 
 ## Phase 2 — Understand (before writing a word)
 
-1. **Name the one big thing** — the single decision that drives the diff. If you cannot
-   name it in one sentence, re-read the diff; do not start writing.
-2. **Group hunks into author-order cohorts** — data/schema first, then logic, then call
-   sites, then tests. The story follows this order, never file order.
-3. **Pick the key moments** — at most 3 hunks that carry the decision. Everything else
-   is summarized in prose.
-4. **Derive the delta map** (structural PRs only):
-   - Nodes are the changed components at the granularity a component diagram would show
-     (a module/file, not a function). Classify each from the diff: added, modified,
-     removed. Removed components stay on the map.
-   - Add unchanged 1-hop neighbors (importers/importees of changed files), dimmed —
-     they are the blast radius. Dim, never hide.
-   - Cap ~20 elements: collapse unchanged neighbors into their parent folder as one
-     dimmed node when over.
-5. **Build the minimap**: the repo's top-level directories, alphabetical, equal-width
-   cells, with the directories containing changes marked. Same strip, same order, every
-   PR — recognition over re-parsing.
+1. **Name the one big thing** — the single decision that drives the diff, in one sentence.
+2. **Group hunks into author-order cohorts** — data/schema, then logic, then call sites,
+   then tests. The story follows this order, never file order.
+3. **Pick the key moments** — at most 3 hunks that carry the decision; the rest is
+   summarized in prose.
+4. **Derive the delta map** (structural PRs only): the diff's changed components, each
+   classified added / modified / removed. Components are modules/files, not functions;
+   config, lockfiles, and fixtures are not components. Removed components stay on the
+   map. Add unchanged 1-hop neighbors (importers/importees), dimmed, never hidden. Cap
+   ~20 components; collapse unchanged neighbors into their parent folder when over.
+5. **Build the minimap**: git-tracked top-level directories
+   (`git ls-tree -d --name-only HEAD`), byte-sorted, equal-width cells; mark the ones
+   containing changes.
 
-## Phase 3 — Write the chapters
+## Phase 3 — Write
 
-Draft the prose in a scratch buffer before touching HTML, then verify mechanically:
+Draft the prose in a scratch buffer under this contract:
 
-- `wc -w` each chapter; cut until inside its budget.
-- Grep the draft for every banned word below; rewrite any hit.
-- Read each sentence once more: does it point at a hunk, a number, or an output the
-  page shows? A sentence that cannot cite its evidence gets cut.
-
-### Style contract
-
-1. **Bottom line first.** Change, reason, impact in the first three sentences.
-2. **One PR, one big thing.** Secondary changes get one line each, never their own arc.
-3. **Every claim points at evidence** — a diff hunk, a gate line, a check result, a
-   screenshot. "Faster", "safer", "fixed" each come with a number or output.
-4. **Concrete before abstract.** The failing command, error, or diff appears before any
-   general statement about it. Examples are trimmed from the real diff, never invented.
-5. **Data over adjectives; 25-word sentences; one idea per sentence.** "41 lines in the
-   parser", never "a clean, minimal change".
-6. **One name per concept — the name from the code.** Present tense for new behavior,
-   past tense only for the behavior it replaced.
-7. **Say what didn't change.** The limits chapter is what makes the brevity trustworthy.
-8. **No section exists to be complete — only to be read.**
+1. **One PR, one big thing.** Secondary changes get one line each, never their own arc.
+2. **Every claim points at evidence the page shows** — a hunk, a gate line, a check
+   result, a screenshot. "Faster", "safer", "fixed" each come with a number or output.
+3. **Concrete before abstract.** The failing command, error, or diff appears before any
+   general statement about it; examples are trimmed from the real diff.
+4. **Data over adjectives; ≤ 25-word sentences; one idea per sentence.**
+5. **One name per concept — the name from the code.** Present tense for new behavior,
+   past tense only for what it replaced.
 
 Banned on sight: leverages, robust, seamless, comprehensive, delve, streamlined,
 powerful, simply, ensures, significantly, various, clearly, essentially, "it's worth
-noting", and "should" when describing behavior (the page either shows it verified or
-drops the claim).
+noting", and "should" when describing behavior.
 
-## Phase 4 — Build the page
+Then verify mechanically: `wc -w` each chapter and cut to budget; grep the draft for
+every banned word and rewrite hits.
 
-- Start from the template; keep its tokens and classes; fill the `SLOT` comments.
-- Everything inline (CSS in the file, no external requests); light and dark themes come
-  from the template's token overrides — do not strip them.
-- **Delta map encoding** (must match the template legend):
-  - added = green node + `+` badge · modified = amber node + `~` badge · removed = red
-    node + `−` badge, kept on the map · unchanged neighbors dimmed.
-  - New edges solid green; removed edges thin red; unchanged edges translucent grey.
-  - Never color without the glyph badge — the badges are the colorblind-safe channel.
-- Diff blocks use the template's `del`/`add`/`ctx` classes; ≤ 10 lines per block.
+## Phase 4 — Build
+
+- Fill the template's `SLOT` comments; keep its tokens, classes, and all four theme
+  token blocks; delete the whole `.chapter` div of any dropped chapter. Everything stays inline —
+  the artifact CSP blocks external requests.
+- **Delta map**: use the classes the template's SLOT comments name; never color a node
+  without its `+`/`~`/`−` glyph badge — the colorblind-safe channel. Grow the SVG
+  viewBox height if the layout needs it.
+- Screenshots embed as `data:` URIs via `img.evidence`.
 
 ## Phase 5 — Publish
 
-- Publish the page file with the Artifact tool: title `PR #<N> — <imperative title>`,
-  favicon `📖` (keep it stable across refreshes), a one-sentence description.
-- `--refresh` in the same conversation: republish the same file path — same URL. From a
-  later session: read the existing artifact URL out of the teaser block and pass it as
-  the Artifact `url` parameter so the page updates in place.
-- If the Artifact tool is unavailable (headless/CI run), fall back: put the full story,
-  as markdown, into the PR-body block below instead of a teaser, and say so in your
-  report. Never fail the run because publishing is unavailable.
+- Artifact tool: title `PR #<N> — <imperative title, ≤ 8 words>`, favicon `📖` (stable
+  across reruns), a one-sentence description.
+- Rerun in the same conversation → republish the same file path (same URL). Rerun in a
+  later session → pass the teaser's artifact URL (from the Phase 1 body) as the `url`
+  parameter. Publishing with `url` fails (artifact deleted or not owned) → publish
+  without it; Phase 6 rewrites the teaser with the new link.
 
-## Phase 6 — The teaser in the PR body
+## Phase 6 — The teaser
 
 Maintain exactly one marker-delimited block in the PR description:
 
 ```markdown
 <!-- pr-explain:begin -->
 ### The story of this PR
-<the bottom-line chapter, verbatim — three sentences>
+<the Bottom line chapter, verbatim>
 
-**[Read the explainer](<artifact-url>)**<map tail — only when the page has a map>
+**[Read the explainer](<artifact-url>)**<map tail>
 <!-- pr-explain:end -->
 ```
 
-- Read the current body (`gh pr view --json body`), remove any existing block between
-  the markers, append the fresh block, write back with `gh pr edit --body-file`. If that fails on a GraphQL projectCards deprecation error (a gh CLI quirk on repos with classic projects), write the same body with `gh api repos/<owner>/<repo>/pulls/<N> -X PATCH -F body=@<file>` instead.
-- The map tail (` · map: <n> changed components, <m> untouched neighbors`) is emitted only when the page includes the map chapter; a non-structural PR's teaser ends at the link.
-- Never touch prose outside the markers. If the body is empty, the block is the body.
+- Map tail (only when the page has a map): ` · map: <n> changed components, <m> unchanged
+  neighbors` — singular when a count is 1; drop the neighbors clause when it is 0.
+- Re-read the body with `gh pr view <N> --json body` — it may have changed since
+  Phase 1; replace the block between the markers in place (append if absent); write
+  back with `gh pr edit <N> --body-file <file>`.
+- If that fails on a GraphQL projectCards deprecation error (a gh quirk on repos with
+  classic projects), write the same body with
+  `gh api repos/<owner>/<repo>/pulls/<N> -X PATCH -F body=@<file>`.
+- Artifact tool unavailable (headless/CI): the full chapters, as markdown, go between
+  the markers in place of the teaser. Say so in your report.
+- Never touch prose outside the markers. Empty body → the block is the body.
 
 ## Report
 
 End with: the artifact URL, total prose word count, chapters emitted vs dropped, map
 included or skipped (with the reason), and the PR whose teaser was updated.
-
-## Common mistakes
-
-| Mistake | Fix |
-|---------|-----|
-| Padding a thin PR to fill budgets | Budgets are ceilings; five strong sentences beat 500 padded words |
-| A map for a non-structural change | Skip it — conditional diagrams are the quality signal |
-| Raw diff dumps | ≤ 3 annotated moments, ≤ 10 lines each, chosen for the decision they carry |
-| Inventing proof | No evidence dir → CI checks only; never fabricate witnesses or numbers |
-| A new artifact URL on refresh | Same file path in-session; pass `url` across sessions |
-| Editing outside the teaser markers | Only the block between the pr-explain markers is yours |
-| Writing the page before the map | Phase 2 comes first — the map decides what the story must explain |

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -154,7 +154,7 @@ Maintain exactly one marker-delimited block in the PR description:
 ```
 
 - Read the current body (`gh pr view --json body`), remove any existing block between
-  the markers, append the fresh block, write back with `gh pr edit --body-file`.
+  the markers, append the fresh block, write back with `gh pr edit --body-file`. If that fails on a GraphQL projectCards deprecation error (a gh CLI quirk on repos with classic projects), write the same body with `gh api repos/<owner>/<repo>/pulls/<N> -X PATCH -F body=@<file>` instead.
 - The map tail (` · map: <n> changed components, <m> untouched neighbors`) is emitted only when the page includes the map chapter; a non-structural PR's teaser ends at the link.
 - Never touch prose outside the markers. If the body is empty, the block is the body.
 

--- a/templates/pr-explain-page.html
+++ b/templates/pr-explain-page.html
@@ -1,0 +1,163 @@
+<!-- pr-explain page skeleton. The skill fills every SLOT comment and deletes unused
+     optional sections. Tokens and classes are the contract with the skill's Phase 4:
+     keep names stable. Self-contained: no external requests. -->
+<title><!-- SLOT: PR #N — imperative title --></title>
+<style>
+  :root {
+    --paper: #F8F8F5; --card: #FFFFFF; --ink: #202723; --ink-2: #59635D; --ink-3: #8B948E;
+    --accent: #14695A; --accent-soft: #E3EEEB; --line: #E1E5E0; --line-strong: #C9CFC9;
+    --red: #AE362E; --red-soft: #F7E9E7; --green: #2C7A44; --green-soft: #E6F1E8;
+    --amber: #8F6400; --amber-soft: #F4ECD6; --code-bg: #EFF1ED;
+    --serif: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+    --mono: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --paper: #141816; --card: #1B201D; --ink: #E7EBE8; --ink-2: #A6AFA9; --ink-3: #6F7873;
+      --accent: #45B29B; --accent-soft: #1E2E2A; --line: #272D29; --line-strong: #39413C;
+      --red: #E06A60; --red-soft: #33211F; --green: #5CBB77; --green-soft: #1E2E22;
+      --amber: #D9A853; --amber-soft: #322A1B; --code-bg: #202622;
+    }
+  }
+  :root[data-theme="light"] {
+    --paper: #F8F8F5; --card: #FFFFFF; --ink: #202723; --ink-2: #59635D; --ink-3: #8B948E;
+    --accent: #14695A; --accent-soft: #E3EEEB; --line: #E1E5E0; --line-strong: #C9CFC9;
+    --red: #AE362E; --red-soft: #F7E9E7; --green: #2C7A44; --green-soft: #E6F1E8;
+    --amber: #8F6400; --amber-soft: #F4ECD6; --code-bg: #EFF1ED;
+  }
+  :root[data-theme="dark"] {
+    --paper: #141816; --card: #1B201D; --ink: #E7EBE8; --ink-2: #A6AFA9; --ink-3: #6F7873;
+    --accent: #45B29B; --accent-soft: #1E2E2A; --line: #272D29; --line-strong: #39413C;
+    --red: #E06A60; --red-soft: #33211F; --green: #5CBB77; --green-soft: #1E2E22;
+    --amber: #D9A853; --amber-soft: #322A1B; --code-bg: #202622;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--paper); color: var(--ink); font-family: var(--serif);
+    font-size: 17px; line-height: 1.65; -webkit-font-smoothing: antialiased; }
+  .wrap { max-width: 680px; margin: 0 auto; padding: 48px 24px 96px; }
+  a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 2px; }
+  .eyebrow { font-family: var(--mono); font-size: 11.5px; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--accent); font-weight: 600; }
+  h1 { font-size: clamp(30px, 5vw, 40px); line-height: 1.12; margin: 10px 0 6px;
+    font-weight: 600; letter-spacing: -0.015em; text-wrap: balance; }
+  .meta { font-family: var(--mono); font-size: 12px; color: var(--ink-3);
+    display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 8px; }
+  p { margin: 12px 0; text-wrap: pretty; }
+  code { font-family: var(--mono); font-size: 0.86em; background: var(--code-bg);
+    padding: 1px 5px; border-radius: 4px; }
+  .chapter { margin-top: 40px; }
+  .clabel { font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em;
+    text-transform: uppercase; color: var(--accent); font-weight: 600; margin-bottom: 6px; }
+  .bottomline { border: 1px solid var(--line-strong); background: var(--card);
+    border-radius: 8px; padding: 18px 22px; margin-top: 28px; }
+  .bottomline p { margin: 6px 0 0; }
+  .diff { font-family: var(--mono); font-size: 12.5px; line-height: 1.55;
+    background: var(--code-bg); border-radius: 6px; padding: 10px 12px; margin: 10px 0;
+    overflow-x: auto; white-space: pre; }
+  .diff .ctx { color: var(--ink-3); }
+  .diff .del { color: var(--red); background: var(--red-soft); display: inline-block; width: 100%; }
+  .diff .add { color: var(--green); background: var(--green-soft); display: inline-block; width: 100%; }
+  .dmap { width: 100%; height: auto; display: block; margin: 10px 0 2px; }
+  .dmap text { font-family: var(--mono); font-size: 12px; fill: var(--ink); }
+  .dmap .badge-txt { font-size: 11px; font-weight: 700; }
+  .n-mod rect.box { fill: var(--amber-soft); stroke: var(--amber); stroke-width: 1.5; }
+  .n-add rect.box { fill: var(--green-soft); stroke: var(--green); stroke-width: 1.5; }
+  .n-del rect.box { fill: var(--red-soft); stroke: var(--red); stroke-width: 1.5; }
+  .n-dim rect.box { fill: var(--code-bg); stroke: var(--line-strong); stroke-width: 1; }
+  .n-dim text { fill: var(--ink-3); }
+  .n-mod .badge { fill: var(--amber); } .n-add .badge { fill: var(--green); }
+  .n-del .badge { fill: var(--red); } .badge-glyph { fill: var(--card); }
+  .e-old { stroke: var(--line-strong); stroke-width: 1.5; opacity: 0.7; }
+  .e-new { stroke: var(--green); stroke-width: 2; }
+  .e-del { stroke: var(--red); stroke-width: 1; opacity: 0.6; }
+  .ah-old { fill: var(--line-strong); opacity: 0.7; } .ah-new { fill: var(--green); }
+  .ah-del { fill: var(--red); opacity: 0.6; }
+  .map-legend { display: flex; gap: 14px; flex-wrap: wrap; font-family: var(--mono);
+    font-size: 11px; color: var(--ink-2); margin: 6px 0 2px; }
+  .map-legend .k { display: inline-flex; align-items: center; gap: 5px; }
+  .sw { width: 11px; height: 11px; border-radius: 3px; display: inline-block; flex: none; }
+  .sw.add { background: var(--green-soft); border: 1.5px solid var(--green); }
+  .sw.mod { background: var(--amber-soft); border: 1.5px solid var(--amber); }
+  .sw.del { background: var(--red-soft); border: 1.5px solid var(--red); }
+  .sw.dim { background: var(--code-bg); border: 1px solid var(--line-strong); }
+  .minimap { display: flex; gap: 4px; margin: 14px 0 2px; }
+  .mm-cell { flex: 1; border: 1px solid var(--line); border-radius: 4px;
+    background: var(--code-bg); font-family: var(--mono); font-size: 10px;
+    color: var(--ink-3); text-align: center; padding: 7px 2px; white-space: nowrap;
+    overflow: hidden; text-overflow: ellipsis; }
+  .mm-cell.here { background: var(--amber-soft); border: 2px solid var(--amber);
+    color: var(--ink); font-weight: 700; }
+  .mm-caption { font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); margin-top: 4px; }
+  .wit { display: flex; gap: 8px; align-items: baseline; font-size: 15px; margin: 8px 0; }
+  .wit .tag { font-family: var(--mono); font-size: 10.5px; font-weight: 700;
+    padding: 1px 7px; border-radius: 4px; flex: none; }
+  .tag.red { color: var(--red); background: var(--red-soft); }
+  .tag.green { color: var(--green); background: var(--green-soft); }
+  .gate-row { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 10px; }
+  .gate-chip { font-family: var(--mono); font-size: 11.5px; padding: 3px 9px;
+    border-radius: 999px; background: var(--green-soft); color: var(--green); }
+  .gate-chip.fail { background: var(--red-soft); color: var(--red); }
+  img.evidence { max-width: 100%; border: 1px solid var(--line-strong); border-radius: 6px; }
+  @media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; } }
+</style>
+
+<div class="wrap">
+  <span class="eyebrow"><!-- SLOT: repo · PR #N --></span>
+  <h1><!-- SLOT: imperative title, ≤ 8 words --></h1>
+  <div class="meta"><!-- SLOT: <span> items: branch, +adds −dels, date --></div>
+
+  <div class="bottomline">
+    <span class="clabel">Bottom line</span>
+    <p><!-- SLOT: 40-60 words — what, why, impact, risk --></p>
+  </div>
+
+  <!-- OPTIONAL: delete this whole chapter for non-structural PRs -->
+  <div class="chapter">
+    <div class="clabel">The map</div>
+    <p><!-- SLOT: ≤ 40 words — what moved at component level --></p>
+    <svg class="dmap" viewBox="0 0 640 200" role="img" aria-label="<!-- SLOT: map summary -->">
+      <!-- SLOT: edges first (lines + arrowhead polygons), then node groups:
+           <g class="n-add|n-mod|n-del|n-dim">
+             <rect class="box" x y width height rx="6"/><text x y>name</text>
+             <circle class="badge" cx cy r="8"/><text class="badge-txt badge-glyph" x y>+|~|−</text>
+           </g> -->
+    </svg>
+    <div class="map-legend">
+      <span class="k"><span class="sw add"></span>+ added</span>
+      <span class="k"><span class="sw mod"></span>~ modified</span>
+      <span class="k"><span class="sw del"></span>− removed</span>
+      <span class="k"><span class="sw dim"></span>unchanged, 1 hop</span>
+    </div>
+    <div class="minimap"><!-- SLOT: one .mm-cell per top-level dir, alphabetical;
+      add class "here" to dirs containing changes --></div>
+    <div class="mm-caption">you are here — same strip, same order, every PR</div>
+  </div>
+
+  <div class="chapter">
+    <div class="clabel">The problem</div>
+    <!-- SLOT: 80-120 words; the failing behavior first; one block max -->
+  </div>
+
+  <div class="chapter">
+    <div class="clabel">The story</div>
+    <!-- SLOT: 150-200 words; one <p> per decision; ≤ 2 .diff blocks, ≤ 10 lines each:
+         <div class="diff"><span class="ctx">  context</span>
+         <span class="del">- removed</span>
+         <span class="add">+ added</span></div> -->
+  </div>
+
+  <div class="chapter">
+    <div class="clabel">The proof</div>
+    <!-- SLOT: 40-70 words + evidence. With witnesses:
+         <div class="wit"><span class="tag red">RED</span><span>…failed first, right reason…</span></div>
+         <div class="wit"><span class="tag green">GREEN</span><span>…what made it pass…</span></div>
+         Gates: <div class="gate-row"><span class="gate-chip">pytest N passed</span>…</div>
+         Without evidence: CI check results as gate chips (class "fail" for red ones). -->
+  </div>
+
+  <div class="chapter">
+    <div class="clabel">The limits</div>
+    <p><!-- SLOT: 40-60 words — what didn't change, non-goals, sharp edges --></p>
+  </div>
+</div>

--- a/templates/pr-explain-page.html
+++ b/templates/pr-explain-page.html
@@ -1,10 +1,11 @@
-<!-- pr-explain page skeleton. The skill fills every SLOT comment and deletes unused
-     optional sections. Tokens and classes are the contract with the skill's Phase 4:
+<!-- pr-explain page skeleton. The skill fills every SLOT comment and deletes the whole
+     .chapter div of any dropped chapter (the map chapter additionally requires a
+     structural PR). Tokens and classes are the contract with the skill's Phase 4:
      keep names stable. Self-contained: no external requests.
      Deliberately a fragment (no DOCTYPE/head/meta): the Artifact publisher wraps the
      file in its own doctype + head skeleton (charset and viewport included), so the
      template must not declare them — do not "fix" this. -->
-<title><!-- SLOT: PR #N — imperative title --></title>
+<title><!-- SLOT: PR #N — imperative title, ≤ 8 words --></title>
 <style>
   :root {
     --paper: #F8F8F5; --card: #FFFFFF; --ink: #202723; --ink-2: #59635D; --ink-3: #8B948E;
@@ -70,7 +71,7 @@
   .n-dim rect.box { fill: var(--code-bg); stroke: var(--line-strong); stroke-width: 1; }
   .n-dim text { fill: var(--ink-3); }
   .n-mod .badge { fill: var(--amber); } .n-add .badge { fill: var(--green); }
-  .n-del .badge { fill: var(--red); } .badge-glyph { fill: var(--card); }
+  .n-del .badge { fill: var(--red); } .dmap .badge-glyph { fill: var(--card); }
   .e-old { stroke: var(--line-strong); stroke-width: 1.5; opacity: 0.7; }
   .e-new { stroke: var(--green); stroke-width: 2; }
   .e-del { stroke: var(--red); stroke-width: 1; opacity: 0.6; }
@@ -102,7 +103,6 @@
     border-radius: 999px; background: var(--green-soft); color: var(--green); }
   .gate-chip.fail { background: var(--red-soft); color: var(--red); }
   img.evidence { max-width: 100%; border: 1px solid var(--line-strong); border-radius: 6px; }
-  @media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; } }
 </style>
 
 <div class="wrap">
@@ -111,7 +111,7 @@
   <div class="meta"><!-- SLOT: <span> items: branch, +adds −dels, date --></div>
 
   <div class="bottomline">
-    <span class="clabel">Bottom line</span>
+    <div class="clabel">Bottom line</div>
     <p><!-- SLOT: 40-60 words — what, why, impact, risk --></p>
   </div>
 
@@ -120,7 +120,9 @@
     <div class="clabel">The map</div>
     <p><!-- SLOT: ≤ 40 words — what moved at component level --></p>
     <svg class="dmap" viewBox="0 0 640 200" role="img" aria-label="<!-- SLOT: map summary -->">
-      <!-- SLOT: edges first (lines + arrowhead polygons), then node groups:
+      <!-- SLOT: edges first (<line class="e-new|e-old|e-del">, arrowheads
+           <polygon class="ah-new|ah-old|ah-del"> matching their edge), then node groups.
+           Badge circle + glyph on n-add|n-mod|n-del only; n-dim gets rect + text, no badge:
            <g class="n-add|n-mod|n-del|n-dim">
              <rect class="box" x y width height rx="6"/><text x y>name</text>
              <circle class="badge" cx cy r="8"/><text class="badge-txt badge-glyph" x y>+|~|−</text>
@@ -132,7 +134,7 @@
       <span class="k"><span class="sw del"></span>− removed</span>
       <span class="k"><span class="sw dim"></span>unchanged, 1 hop</span>
     </div>
-    <div class="minimap"><!-- SLOT: one .mm-cell per top-level dir, alphabetical;
+    <div class="minimap"><!-- SLOT: one .mm-cell per git-tracked top-level dir, byte-sorted;
       add class "here" to dirs containing changes --></div>
     <div class="mm-caption">you are here — same strip, same order, every PR</div>
   </div>
@@ -156,7 +158,8 @@
          <div class="wit"><span class="tag red">RED</span><span>…failed first, right reason…</span></div>
          <div class="wit"><span class="tag green">GREEN</span><span>…what made it pass…</span></div>
          Gates: <div class="gate-row"><span class="gate-chip">pytest N passed</span>…</div>
-         Without evidence: CI check results as gate chips (class "fail" for red ones). -->
+         Without evidence: CI check results as gate chips (class "fail" for red ones);
+         PR-body claims appear only attributed in prose, never as chips. -->
   </div>
 
   <div class="chapter">

--- a/templates/pr-explain-page.html
+++ b/templates/pr-explain-page.html
@@ -1,6 +1,9 @@
 <!-- pr-explain page skeleton. The skill fills every SLOT comment and deletes unused
      optional sections. Tokens and classes are the contract with the skill's Phase 4:
-     keep names stable. Self-contained: no external requests. -->
+     keep names stable. Self-contained: no external requests.
+     Deliberately a fragment (no DOCTYPE/head/meta): the Artifact publisher wraps the
+     file in its own doctype + head skeleton (charset and viewport included), so the
+     template must not declare them — do not "fix" this. -->
 <title><!-- SLOT: PR #N — imperative title --></title>
 <style>
   :root {


### PR DESCRIPTION
PR 1.1 of #135 — the pr-explain skill, standalone.

## What

- `skills/pr-explain/SKILL.md` — the skill: six word-budgeted chapters (Bottom line, The map, The problem, The story, The proof, The limits), author-order storytelling, delta-map + frozen-minimap derivation, style contract with banned-word list, artifact publishing, and a marker-delimited PR-body teaser with a conditional map tail.
- `templates/pr-explain-page.html` — the page skeleton (design tokens, chapter blocks, delta-map/minimap/legend/diff/gate-chip classes), shipped as a package extra; deliberately a fragment because the Artifact publisher wraps it in its own doctype + head.
- `installer/catalog.toml` — new `skill/pr-explain` unit, membership in `pr-ops`, and a `pr-explain` package declaring the template extra (staged to `~/.claude/at/templates/pr-explain-page.html`).

## Checks

- `./validate.sh` → catalog OK — 26 units, 6 packages, 2 bundles
- `cd installer && uv run pytest -q` → 177 passed (the data-driven `test_skill_extras_paths` now covers the new skill/extra pair)
- Reviewer: no CRITICAL, two MINOR findings fixed in one round (score 97 on re-review); critic: achieved, 93.

## Acceptance run (the issue's "done when", executed live)

Installed the catalog, then ran the skill against merged PR #134 with no make-pr run data:
- Explainer page, 404 prose words, correct delta map + minimap: https://claude.ai/code/artifact/084a03b4-d3d1-4c82-8668-7d579ec2e2bf
- Marker-delimited teaser landed in #134's body (see it there).
- Discovery folded back in: `gh pr edit --body-file` fails on this repo's gh projectCards quirk; the SKILL.md now documents the `gh api PATCH` fallback that was used.

Run log: `.v1-runs/feat_pr-explain-skill.jsonl` (local, 12 rows: baseline, TDD skip, dispatches, gates, reviews, acceptance, critic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LtsRdxUKd8Bk5SVYnzpfP

