### PR TITLE
feat(skills): evidence handoff — run_root/evidence layout, schema, producer + consumer wiring (#135, PR 1.2)

### DIFF
--- a/installer/catalog.toml
+++ b/installer/catalog.toml
@@ -144,7 +144,7 @@ units = [
   "rule/design-principles",
   "rule/tdd",
 ]
-extras = ["gates", "rules"]
+extras = ["schemas", "gates", "scripts/validate_return.py", "rules"]
 
 # improve-architecture audits a subsystem; its rubric is the canonical design-principles
 # rule, composed in via the rules extra rather than a bundled in-skill copy.

--- a/schemas/evidence.schema.json
+++ b/schemas/evidence.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "evidence.schema.json",
   "title": "Run evidence handoff",
-  "$comment": "Written by make-pr / make-pr-lite at Done to <run_root>/evidence/<run-id>/evidence.json; read by pr-explain to build the proof chapter. A distillation of runs the pipeline already witnessed, never new claims.",
+  "$comment": "Written by make-pr / make-pr-lite at Done to <run_root>/evidence/<branch-slug>/evidence.json; read by pr-explain to build the proof chapter. A distillation of runs the pipeline already witnessed, never new claims.",
   "type": "object",
   "additionalProperties": false,
   "required": ["schema_version", "branch", "pipeline", "behaviors", "gates", "runtime"],

--- a/schemas/evidence.schema.json
+++ b/schemas/evidence.schema.json
@@ -36,12 +36,24 @@
                 "green": { "$ref": "#/$defs/green_witness" }
               }
             }
+          },
+          {
+            "$comment": "A non-behavioral row carries no witnesses; kind is behavioral iff the witness pair is present.",
+            "if": { "required": ["kind"], "properties": { "kind": { "const": "non_behavioral" } } },
+            "then": {
+              "properties": {
+                "test": { "type": "null" },
+                "red": { "type": "null" },
+                "green": { "type": "null" }
+              }
+            }
           }
         ]
       }
     },
     "gates": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "additionalProperties": false,

--- a/schemas/evidence.schema.json
+++ b/schemas/evidence.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "evidence.schema.json",
+  "title": "Run evidence handoff",
+  "$comment": "Written by make-pr / make-pr-lite at Done to <run_root>/evidence/<run-id>/evidence.json; read by pr-explain to build the proof chapter. A distillation of runs the pipeline already witnessed, never new claims.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "branch", "pipeline", "behaviors", "gates", "runtime"],
+  "properties": {
+    "schema_version": { "$ref": "_defs.schema.json#/$defs/schema_version" },
+    "branch": { "type": "string", "minLength": 1 },
+    "pipeline": { "enum": ["make-pr", "make-pr-lite"] },
+    "behaviors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "kind", "test", "files", "red", "green"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "kind": { "enum": ["behavioral", "non_behavioral"] },
+          "test": { "type": ["string", "null"] },
+          "files": { "type": "array", "items": { "type": "string" } },
+          "red": { "oneOf": [{ "$ref": "#/$defs/witness" }, { "type": "null" }] },
+          "green": { "oneOf": [{ "$ref": "#/$defs/green_witness" }, { "type": "null" }] }
+        },
+        "allOf": [
+          {
+            "$comment": "A behavioral slice carries its full RED->GREEN witness pair; the proof chapter must never have to invent one.",
+            "if": { "required": ["kind"], "properties": { "kind": { "const": "behavioral" } } },
+            "then": {
+              "properties": {
+                "test": { "type": "string", "minLength": 1 },
+                "red": { "$ref": "#/$defs/witness" },
+                "green": { "$ref": "#/$defs/green_witness" }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "gates": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "cmd", "exit_code", "key_output"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "cmd": { "type": "string", "minLength": 1 },
+          "exit_code": { "type": "integer" },
+          "key_output": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "runtime": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+  },
+  "$defs": {
+    "witness": {
+      "$comment": "One witnessed command run, quoted verbatim from the run that produced it.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cmd", "exit_code", "key_output"],
+      "properties": {
+        "cmd": { "type": "string", "minLength": 1 },
+        "exit_code": { "type": "integer" },
+        "key_output": { "type": "string", "minLength": 1 }
+      }
+    },
+    "green_witness": {
+      "$comment": "The passing run plus the line count that made it pass; lines_added is null only when not derivable.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["cmd", "exit_code", "key_output", "lines_added"],
+      "properties": {
+        "cmd": { "type": "string", "minLength": 1 },
+        "exit_code": { "type": "integer" },
+        "key_output": { "type": "string", "minLength": 1 },
+        "lines_added": { "type": ["integer", "null"], "minimum": 0 }
+      }
+    }
+  }
+}

--- a/skills/make-pr-lite/SKILL.md
+++ b/skills/make-pr-lite/SKILL.md
@@ -3,7 +3,7 @@ name: make-pr-lite
 description: Use when explicitly asked to run /make-pr-lite on an already-scoped, low-risk single-module PR. A cheaper alternative to /make-pr — one self-TDD coder, the language gates, then a parallel 3-reviewer panel and a critic, squashed to one commit. Not for feature decomposition, multi-module planning, or high-risk work (filesystem/state mutation, merge/refcount, destructive ops) — route those to /make-pr.
 argument-hint: "<task spec, issue ref, or path to a task file>"
 disable-model-invocation: true
-allowed-tools: Read, Bash, Agent, TodoWrite
+allowed-tools: Read, Write, Bash, Agent, TodoWrite
 ---
 
 # make-pr-lite
@@ -33,6 +33,8 @@ guarantees that.)
   source; pass rule files as absolute paths (a subagent's cwd is the target repo, so bare names
   won't resolve).
 - **target_cwd** — the repo being changed; run every `git`/gate command there.
+- **run_root** — `<target_cwd>/.v1-runs`, writable; lite keeps no JSONL log — use `Write` only
+  for the `evidence/<run-id>/` handoff at Done (`run-id` = branch with `/` and whitespace → `_`).
 - **base** — user/spec-named → else `git merge-base HEAD origin/main` → else `… main` → else stop
   and ask.
 - **gates** — preflight: pick `~/.claude/at/gates/<lang>.json` by the task's language(s) /
@@ -126,7 +128,17 @@ gate output, and the reviewers' findings. Each reviewer finding carries a 1–10
 7. **Done.** When all behaviors and gates are green, no CRITICAL / `>=70` / aggregate blocker, and
    critic `achieved`. **Squash to one commit:**
    `git reset --soft <base> && git commit -m "<conventional subject>"` (no AI attribution).
-   Confirm only boundary files changed (`git diff --name-only <base>...HEAD`). Then ship it
+   Confirm only boundary files changed (`git diff --name-only <base>...HEAD`). Write the evidence
+   handoff `<run_root>/evidence/<run-id>/evidence.json` (schema
+   `~/.claude/at/schemas/evidence.schema.json`; `pipeline: "make-pr-lite"`): one `behaviors[]`
+   entry per slice — `name`, `test`, `files`, `red` verbatim from the coder's return, `kind` =
+   `behavioral` iff `red` is non-null; `green` = your step-4 suite re-run (`cmd`, `exit_code`,
+   `key_output`) with `lines_added` summed from `git diff --numstat <base>...HEAD -- <the
+   slice's non-test files>` — plus one `gates[]` entry per gate in the final green pass with its
+   real `key_output` numbers, and `runtime: []` unless you copied artifacts into `.../runtime/`.
+   Validate it:
+   `uv run --no-project --with jsonschema python ~/.claude/at/scripts/validate_return.py ~/.claude/at/schemas/evidence.schema.json <that file>`
+   — a failing file blocks the push. Then ship it
    without asking: branch first if still on the default branch, `git push -u origin <branch>`
    (`--force-with-lease` only if this run already pushed the branch before the squash), and
    `gh pr create` against the default branch (or the task-named target), referencing the

--- a/skills/make-pr-lite/SKILL.md
+++ b/skills/make-pr-lite/SKILL.md
@@ -34,7 +34,8 @@ guarantees that.)
   won't resolve).
 - **target_cwd** — the repo being changed; run every `git`/gate command there.
 - **run_root** — `<target_cwd>/.v1-runs`, writable; lite keeps no JSONL log — use `Write` only
-  for the `evidence/<run-id>/` handoff at Done (`run-id` = branch with `/` and whitespace → `_`).
+  for the `evidence/<branch-slug>/` handoff at Done (`branch-slug` = the pushed branch with `/`
+  and whitespace → `_` — the key `/pr-explain` joins on).
 - **base** — user/spec-named → else `git merge-base HEAD origin/main` → else `… main` → else stop
   and ask.
 - **gates** — preflight: pick `~/.claude/at/gates/<lang>.json` by the task's language(s) /
@@ -129,12 +130,14 @@ gate output, and the reviewers' findings. Each reviewer finding carries a 1–10
    critic `achieved`. **Squash to one commit:**
    `git reset --soft <base> && git commit -m "<conventional subject>"` (no AI attribution).
    Confirm only boundary files changed (`git diff --name-only <base>...HEAD`). Write the evidence
-   handoff `<run_root>/evidence/<run-id>/evidence.json` (schema
+   handoff `<run_root>/evidence/<branch-slug>/evidence.json` (schema
    `~/.claude/at/schemas/evidence.schema.json`; `pipeline: "make-pr-lite"`): one `behaviors[]`
    entry per slice — `name`, `test`, `files`, `red` verbatim from the coder's return, `kind` =
    `behavioral` iff `red` is non-null; `green` = your step-4 suite re-run (`cmd`, `exit_code`,
    `key_output`) with `lines_added` summed from `git diff --numstat <base>...HEAD -- <the
-   slice's non-test files>` — plus one `gates[]` entry per gate in the final green pass with its
+   slice's non-test files>`, or `null` for every slice sharing a production file with another
+   slice (a shared file makes per-slice counts non-derivable; never double-count) — plus one
+   `gates[]` entry per gate in the final green pass with its
    real `key_output` numbers, and `runtime: []` unless you copied artifacts into `.../runtime/`.
    Validate it:
    `uv run --no-project --with jsonschema python ~/.claude/at/scripts/validate_return.py ~/.claude/at/schemas/evidence.schema.json <that file>`

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -6,21 +6,20 @@ disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent, TodoWrite
 ---
 
-# Architect
+# make-pr
 
-You are the **workflow**. You take one already-scoped task (one PR, one module) and drive it
-to done by dispatching worker agents in a fixed order, running the gates, and **logging
-every subagent call** so a human can validate the run afterward. You do not write the
-production code or tests yourself: you orchestrate the agents that do, verify their
-structured returns, and decide the next step.
+You are the **architect**: the workflow that takes one already-scoped task (one PR, one
+module) and drives it to done — dispatching worker agents in a fixed order, running the
+gates, and logging every subagent call so a human can validate the run afterward. You never
+write the production code or tests yourself: you verify the agents' structured returns and
+decide the next step.
 
-> **Scope boundary:** the task you receive is already scoped to a single module/PR by the
-> upstream planner. It must name the module boundary (`module`, `allowed_paths`, or equivalent)
-> and the public interface or files in scope. If the task clearly spans more than one module, or
-> if the boundary is missing, stop and report that it needs to be re-scoped upstream — do not
-> proceed.
+> **Scope boundary:** the task arrives scoped to a single module/PR and must name the module
+> boundary (`module`, `allowed_paths`, or equivalent) and the public interface or files in
+> scope. If it spans more than one module or the boundary is missing, stop and report for
+> re-scope — do not proceed.
 
-## The agents you dispatch (via the Agent tool)
+## Agents
 
 | Agent | When | Job |
 |-------|------|-----|
@@ -29,182 +28,172 @@ structured returns, and decide the next step.
 | `reviewer` | after gates are green | quality + bugs + security + line-by-line rule conformance on the diff |
 | `critic` | with the reviewer, on the gate-green diff | goal-fit: did the PR achieve the task? |
 
-Give each agent the **task context + base + module boundary + allowed paths + exact files it
-needs + absolute rule paths** (resolve `rules/...` to absolute — see Runtime resolution), and
-give `worker-coder` its **`mode`** (`green` | `refactor` | `non_behavioral`) plus
+Dispatch via the Agent tool. Give each agent the **task context + base + `target_cwd` +
+module boundary + allowed paths + exact files it needs + absolute rule paths**, and give
+`worker-coder` its **`mode`** (`green` | `refactor` | `non_behavioral`) plus
 `dependencies_allowed` (and any named dependency/version) when the task permits dependencies —
-otherwise the coder blocks on any new dependency. Keep each dispatch
-prompt tight and scoped to one job. Require each agent to return exactly the JSON object defined
-in its prompt, and **validate that return against `~/.claude/at/schemas/<role>.schema.json`**
-(keyed by the `role` field in the return). The validator reads the instance from a **file**, so
-first write the agent's raw return verbatim with `Write` (not `echo`/heredoc — those mangle the
-embedded quotes and newlines) to `<run_root>/<run-id>.<role>.json`, then run:
+otherwise the coder blocks on any new dependency. Keep each dispatch prompt tight and scoped
+to one job. Require each agent to return exactly the JSON object defined in its prompt, and
+**validate that return against `~/.claude/at/schemas/<role>.schema.json`** (keyed by the
+return's `role` field). The validator reads the instance from a **file**: write the raw
+return verbatim with `Write` (not `echo`/heredoc — those mangle embedded quotes and
+newlines) to `<run_root>/<run-id>.<role>.json`, then run:
 
 `uv run --no-project --with jsonschema python ~/.claude/at/scripts/validate_return.py ~/.claude/at/schemas/<role>.schema.json <run_root>/<run-id>.<role>.json`
 
-(The validator depends on `jsonschema`; `uv run --no-project --with jsonschema` supplies it on first run and caches it — no separate install step.)
-
-Treat a validation failure, a missing field, or an unparsable return as malformed: re-dispatch
-once with the validator's feedback, and if it is still malformed, escalate to the human. This
-schema retry is separate from the behavior-level retry budgets in the loop below.
+Treat a validation failure, missing field, or unparsable return as malformed: re-dispatch
+once with the validator's feedback; still malformed → escalate to the human. This schema
+retry is separate from the behavior-level retry budgets in the loop.
 
 A tight RED dispatch reads, e.g.: "Write ONE failing test for: cart applies a percentage
 discount to the subtotal. Module boundary: `cart` (`cart.py`, `tests/test_cart.py`). Public
-interface: `Cart.total(discount: Percent)`. Base: <base>. Rules (absolute paths):
-~/.claude/at/rules/tdd.md, ~/.claude/at/rules/design-principles.md, ~/.claude/at/rules/python.md." The matching
-GREEN dispatch names the exact failing test and the mode: "Make <test_file>::<test_name> pass
-with minimal production code. mode: green. The RED test is already on the tree but uncommitted —
-stage it unchanged with your production code. Module boundary: `cart` only. Base: <base>. Rules:
-~/.claude/at/rules/design-principles.md, ~/.claude/at/rules/python.md, ~/.claude/at/rules/tdd.md."
+interface: `Cart.total(discount: Percent)`. target_cwd: <abs repo path>. Base: <base>. Rules
+(absolute paths): ~/.claude/at/rules/tdd.md, ~/.claude/at/rules/design-principles.md,
+~/.claude/at/rules/python.md." The matching GREEN dispatch names the exact failing test and
+the mode: "Make <test_file>::<test_name> pass with minimal production code. mode: green. The
+RED test is on the tree but uncommitted — stage it unchanged with your production code.
+Module boundary: `cart` only. target_cwd: <abs repo path>. Base: <base>. Rules (absolute
+paths): <the same three rule paths as the RED dispatch>."
 
 ## Runtime resolution
 
-Resolve these values before the first dispatch:
+Resolve before the first dispatch:
 
-- **skill_root**: the directory this `SKILL.md` lives in — it holds only the SKILL.md itself; the
-  rule files and the runtime extras (schemas, gates, helper scripts) are all resolved from
-  `extras_root`, not from here.
-- **extras_root**: the installer's state root `~/.claude/at`, the single source of truth the
-  installer stages a package's extras into — `rules/`, `schemas/`, `gates/`, and `scripts/` live here.
-  Resolving them from this one root keeps an install self-contained, with no dependency on a repo
-  checkout; reference each extra by its literal path under it (e.g. `~/.claude/at/gates/<lang>.json`).
-- **rules_root**: the `rules/` directory the installer composes from the single canonical source
-  into the state root (`~/.claude/at/rules`). Use it for the rule files the agents read.
-- **target_cwd**: the absolute path to the repository being changed. Run every target-repo
-  command there: `git`, verification commands, package-manager setup, and gate runs.
-- **run_root**: a writable directory for logs and transient return JSON, defaulting to
-  `<target_cwd>/.v1-runs`. Use this for JSONL logs, `<run-id>.<role>.json`, and the
-  `evidence/<branch-slug>/` handoff (see Evidence handoff); do not write runtime state into `skill_root`.
-- **Base**: use a base named by the user or task spec. Otherwise use `git merge-base HEAD
-  origin/main`; if `origin/main` is unavailable, use `git merge-base HEAD main`. If no base
-  can be resolved, stop and ask for one.
-- **Run id**: use the branch name or task id, replacing `/` and whitespace with `_`.
-- **Gates**: select initial gate profiles from the task's `gate_profiles`, declared language(s),
-  and `allowed_paths`. After workers change files, expand the selected profiles from
-  `git diff --name-only <base>...HEAD`. Match paths against each `~/.claude/at/gates/*.json`
-  profile's `triggers` globs; both root and nested paths must match. If a changed language has
-  no gate, stop and report the missing gate instead of declaring done.
-- **Rules**: resolve rule files to **absolute** paths under `rules_root` (`~/.claude/at/rules`)
-  before passing them — a subagent's working directory is the user's
-  project, not this skill's directory, so bare or repo-relative names will not resolve. Always pass
-  `design-principles.md`; add `tdd.md` for behavioral RED/GREEN steps; add the matching
-  language rule (`python.md`, `typescript.md`, `rust.md`) for each changed file type.
+- **skill_root** — the directory this SKILL.md lives in; it holds only the SKILL.md — all
+  extras resolve from extras_root.
+- **extras_root** — the installer's state root `~/.claude/at`, the single source of truth
+  the installer stages a package's extras into (`rules/`, `schemas/`, `gates/`, `scripts/`).
+  Reference each extra by its literal path under it; no dependency on a repo checkout.
+- **rules_root** — `~/.claude/at/rules`, composed by the installer from the canonical
+  source. Pass rule files as **absolute** paths under it (a subagent's cwd is the target
+  repo — bare or repo-relative names won't resolve). Always `design-principles.md`; +
+  `tdd.md` for behavioral RED/GREEN steps; + the language rule (`python.md`,
+  `typescript.md`, `rust.md`) per changed file type.
+- **target_cwd** — the absolute path to the repository being changed. Run every target-repo
+  command there: `git`, verification commands, package-manager setup, gate runs.
+- **run_root** — a writable directory for run state, defaulting to `<target_cwd>/.v1-runs`:
+  the JSONL log, transient `<run-id>.<role>.json` returns, and the `evidence/<branch-slug>/`
+  handoff (always under `<target_cwd>/.v1-runs/` — the path `/pr-explain` reads — even if
+  run_root is overridden). Never write runtime state into `skill_root`.
+- **Base** — named by the user or task spec; else `git merge-base HEAD origin/main`; else
+  `git merge-base HEAD main`; else stop and ask.
+- **Run id** — the branch name or task id, `/` and whitespace → `_`.
+- **Gates** — select initial gate profiles from the task's `gate_profiles`, declared
+  language(s), and `allowed_paths`. After workers change files, re-select from
+  `git diff --name-only <base>...HEAD`: a changed path selects a profile when it matches any
+  of that profile's `triggers` globs in `~/.claude/at/gates/*.json` (the lists cover both
+  root-level and nested forms). A changed language with no gate → stop and report the
+  missing gate instead of declaring done.
 
 ## Tool boundaries
 
-- Use `Write`/`Edit` only for files under `<run_root>/` (the `<run-id>.jsonl` log, the transient
-  `<run-id>.<role>.json` return files you write for validation, and the `evidence/<branch-slug>/` handoff). Do not edit production source, tests,
-  rules, or gates directly while acting as architect; route every code or test change to `worker-coder`.
-- Use `Bash` only for `git`, `date`, JSONL validation, the schema validator
-  (`~/.claude/at/scripts/validate_return.py`), **re-running a worker's reported verification (e.g. the
-  named GREEN test) to confirm its result**, the task-provided baseline command, and the selected
-  gate `setup`/`run` commands. Run all target-repo commands in `target_cwd`. Do not run gate
-  `fix` commands directly; route fixes to `worker-coder`.
-- Before **Done**, validate that the JSONL file parses and that logged rows match the
-  subagent calls, skips, and gate runs you performed.
+- `Write`/`Edit` only for files under `<run_root>/` (contents per Runtime resolution).
+  Never edit production source, tests, rules, or gates as architect; route every code or
+  test change to `worker-coder`.
+- `Bash` only for: `git`, `date`, JSONL validation, the schema validator, re-running a
+  worker's reported verification (e.g. the named GREEN test), the task-provided baseline
+  command, and the selected gate `setup`/`run` commands — all in `target_cwd`. Never run
+  gate `fix` commands directly; route fixes to `worker-coder`.
+- `Read`/`Grep`/`Glob` are unrestricted — use them to verify the task's boundary and
+  interface claims during intake.
+- Before **Done**, validate that the JSONL parses and its rows match the subagent calls,
+  skips, gate runs, and human waivers of the run — immediately before writing the evidence
+  handoff (which itself needs no JSONL row).
 
 ## The loop (deterministic — follow in order)
 
-1. **Intake.** Read the task spec. Restate the goal, module boundary/allowed paths, public
-   interface, acceptance criteria, language(s), base, and whether dependencies are allowed. If
-   any of goal, boundary, public interface/files, or acceptance criteria is missing, stop for
-   re-scope instead of inferring it. Create a `TodoWrite` list mirroring the steps below.
-2. **Preflight baseline.** In `target_cwd`, run and log `git status --short`. If there are dirty
-   files outside the task boundary, stop before dispatching agents. Select initial gate profiles
-   from the task spec, run each selected gate `setup` once, then run the task-provided baseline
-   command if present. If no baseline command is provided, run the selected profile's test gate
-   only when tests already exist. Treat "no tests collected" / "no test files yet" as neutral
-   before the first RED, but never as a final gate pass. If an existing test is red for unrelated
-   reasons, stop and report the pre-existing failure instead of asking `worker-coder` to preserve
-   an unknown green baseline.
-3. **Plan behaviors.** Per `tdd.md`, list the user-facing **behaviors** (not impl steps),
-   ordered as thin vertical slices. Decide per task whether it is **behavioral** (TDD
-   required) or **non-behavioral** (config/docs/rename — TDD skipped, log the skip + reason).
-   For non-behavioral work: log the skipped RED (`step: RED, verdict: skip`), dispatch
-   `worker-coder` with `mode: non_behavioral` (log that dispatch as `step: NON_BEHAVIORAL`),
-   reproduce any reported passing check when present, then continue to GATE → REVIEW → CRITIC. Do
-   not enter the RED/GREEN loop for non-behavioral work.
+1. **Intake.** Read the task spec. Restate goal, module boundary/allowed paths, public
+   interface, acceptance criteria, language(s), base, and whether dependencies are allowed.
+   Any of goal/boundary/interface/acceptance missing → stop for re-scope; do not infer.
+   `TodoWrite` the steps below.
+2. **Preflight baseline.** In `target_cwd`, run and log `git status --short`; dirty files
+   outside the boundary → stop. Select initial gate profiles, run each `setup` once, then
+   the task-provided baseline command if present (else the test gate, only when tests
+   already exist). "No tests collected" is neutral before the first RED, never a final gate
+   pass. An existing test red for unrelated reasons → stop and report the pre-existing
+   failure.
+3. **Plan behaviors.** Per `tdd.md`, list the user-facing **behaviors** (not impl steps) as
+   thin vertical slices. Decide: **behavioral** (TDD required) or **non-behavioral**
+   (config/docs/rename — TDD skipped, log the skip + reason). Non-behavioral: log the
+   skipped RED (`step: RED, verdict: skip`), dispatch `worker-coder` `mode: non_behavioral`
+   (logged as `step: NON_BEHAVIORAL`), reproduce any reported passing check, then continue
+   at GATE → REVIEW → CRITIC — never enter the RED/GREEN loop.
 4. **Per behavior, in order:**
-   a. **RED** → dispatch `tdd-runner`. Require `"status":"red"` and `"right_reason":true`. If not,
-      re-dispatch with feedback — max 3 RED dispatches for this behavior (the outer budget; each is a
-      fresh runner that spends up to its own 3 internal attempts and sees your feedback) — then
-      escalate to the human.
-   b. **GREEN** → dispatch `worker-coder` with `mode: green` and the named failing test
-      (`test_file` + `test_name` from the RED return). Require `status: done` (the schema enforces a
-      GREEN done carries both a `fail` and a `pass` run), then **reproduce the result yourself**: on
-      HEAD, re-run the package's full test command — the same suite the coder verified, not just the
-      named test (`commands[].cmd` uses the project runner, e.g. `uv run pytest`) — and confirm it
-      passes with the named test among it. A real failure means it's a failed GREEN, not a done, and a
-      sibling regression is caught here at the behavior that caused it. But if the command errors on
-      the *environment* (missing venv/deps, an import/collection error rather than a test failure),
-      run the gate `setup` once and re-run before judging — never reject a genuine GREEN over an
-      unprepared env. If the return's `new_dependencies` is non-empty and the task did not set
-      `dependencies_allowed: true` (or name that dependency), treat it as a blocked regression and
-      route back — never gate code carrying an unapproved dependency. If `blocked`, read the reason
-      and decide (re-scope the slice, re-dispatch, or stop); allow at most 2 GREEN re-dispatches per
-      behavior before escalating.
-   c. **REFACTOR** (optional) → if duplication/structure warrants it, dispatch `worker-coder`
-      with `mode: refactor`; tests must stay green and unchanged.
+   a. **RED** → dispatch `tdd-runner`. Require `"status":"red"` and `"right_reason":true`;
+      else re-dispatch with feedback — max 3 RED dispatches per behavior (each a fresh
+      runner with its own 3 internal attempts) — then escalate.
+   b. **GREEN** → dispatch `worker-coder` `mode: green` with the named failing test
+      (`test_file` + `test_name` from the RED return). Require `status: done` (the schema
+      enforces a fail + pass pair), then **reproduce it yourself** on HEAD: run the
+      package's full test command (the same suite the coder verified — `commands[].cmd`
+      uses the project runner, e.g. `uv run pytest`), then the named test id on its own if
+      the suite output does not show it ran. Route by outcome — the table is total:
+
+      | Outcome | Action |
+      |---|---|
+      | suite green, named test passing | done — next behavior |
+      | any test fails, or the named test is missing/not collected | failed GREEN (sibling regressions caught here) → re-dispatch |
+      | env error (missing venv/deps, import/collection error — not a test failure) | run gate `setup` once, re-run; setup itself failing → stop per step 5's unsupported-profile rule |
+      | `new_dependencies` non-empty, not allowed/named by the task | blocked regression → route back |
+      | `blocked` | read the reason; re-scope the slice, re-dispatch, or stop |
+
+      At most **2 GREEN re-dispatches per behavior across all failure modes**, then
+      escalate.
+   c. **REFACTOR** (optional) → if duplication/structure warrants it, `worker-coder`
+      `mode: refactor`; tests stay green and unchanged.
    Log every dispatch (see JSONL contract).
-5. **Gate (objective — run before any LLM judgment).** Run the selected gates from
-   `~/.claude/at/gates/<lang>.json`. Each gate file is
-   `{"setup": <cmd>, "triggers": [<glob>], "gates": [{"name","run","fix"}]}` where `fix` may be
-   `null` for checks that need a human/coder change rather than a mechanical command. Run `setup`
-   once, then each `gates[].run` in order. If setup fails because the repo does not use the
-   selected package manager/tooling profile (for example no `uv.lock` for the Python profile or
-   no Biome config for the TypeScript profile), stop and report an unsupported gate profile or
-   request a gate override; do not label it a task regression. **All gates must pass before you
-   dispatch the reviewer or critic** — spend no LLM judgment on code that does not lint,
-   typecheck, and pass its tests. On failure, route the concrete failure output to `worker-coder` —
-   `mode: non_behavioral` for a format/lint/type/build fix, but a failing **test** gate is a
-   behavioral regression that returns to the responsible behavior's RED/GREEN cycle (never a
-   `non_behavioral` edit) — and re-run the gates. Allow at most **2 gate-fix rounds**; if it is
-   still red after that, stop and escalate as **stop / re-scope**.
-6. **Review + critic (the judgment pass — run once, on the gate-green diff).** Dispatch
-   `reviewer` on `git diff <base>...HEAD`, passing `design-principles.md`, the language rule for
-   each changed file type, and `tdd.md`. Then dispatch `critic` with the task spec, task type,
-   base ref, full diff, changed test files for behavioral work, RED/GREEN or non-behavioral check
-   output, the now-green gate output, **and the reviewer's findings from this same pass** (so the
-   critic can trust the reviewer's test-form verdict instead of re-judging it). Collect **all
+5. **Gate (objective — before any LLM judgment).** Run the selected
+   `~/.claude/at/gates/<lang>.json` profiles: each file is
+   `{"setup": <cmd>, "triggers": [<glob>], "gates": [{"name","run","fix"}]}` (`fix` may be
+   `null`). Run `setup` once, then each `gates[].run` in order. Setup failing because the
+   repo doesn't use the profile's tooling (no `uv.lock`, no Biome config) → stop and report
+   an unsupported gate profile, not a task regression. **All gates must pass before reviewer
+   or critic.** On failure route the concrete output to `worker-coder` —
+   `mode: non_behavioral` for format/lint/type/build, but a failing **test** gate is a
+   behavioral regression that returns to that behavior's RED/GREEN cycle. Max **2 gate-fix
+   rounds**, then stop / re-scope.
+6. **Review + critic (the judgment pass — once, on the gate-green diff).** Dispatch
+   `reviewer` with the base ref (it runs `git diff <base>...HEAD` itself), passing
+   `design-principles.md`, the language rule per changed file type, and `tdd.md`. Then
+   dispatch `critic` with the task spec, task type, base ref, full diff, changed test
+   files, RED/GREEN or non-behavioral check output, the green gate output, **and the
+   reviewer's findings** (so it can trust the reviewer's test-form verdict). Collect **all
    blockers from both in one pass**:
-   - any `reviewer` finding that is CRITICAL or has `score >= 70` (`has_critical: true` always
-     blocks), unless the human has explicitly waived that finding in the run log;
-   - any `critic` verdict of `not_achieved` or `partial`, with its listed gaps.
-   If there are no blockers, go to **Done**. A CRITICAL finding, a red gate, and a black-letter
-   language-rule violation (a rule the language file states explicitly — e.g. keyword-only `*`,
-   `Final[T]`, per-binding type hints) are never waivable.
-7. **Fix once, then re-verify in proportion to the change.** If step 6 found blockers, route them
-   back as a **single batched fix round** — do not fix finding-by-finding with a re-review between
-   each:
-   - A **behavioral** gap (a missing behavior the critic named, or a reviewer finding that the RED
-     test is wrong — bad assertion, implementation-coupled test, wrong public interface, missing
-     behavior coverage) returns to that behavior's **RED** step with `tdd-runner` before GREEN; do
-     **not** ask `worker-coder` to edit a test.
-   - A **mechanical or design** fix that does not change behavior goes to `worker-coder` directly
+   - any reviewer finding that is CRITICAL or has `score >= 70` (`has_critical: true`
+     always blocks), unless the human explicitly waived it in the run log (logged
+     `step: REVIEW, verdict: skip, note: "waived by human: <finding>"`);
+   - any critic verdict of `not_achieved` or `partial`, with its gaps.
+   **Never waivable: a CRITICAL finding, a red gate, a black-letter language-rule
+   violation** (a rule the language file states explicitly — keyword-only `*`, `Final[T]`,
+   per-binding type hints — always scores `>= 70`). Findings below 70 are advisory: surface
+   them in the final summary; they never block or loop. No blockers → **Done**.
+7. **Fix once, re-verify in proportion.** Capture `git rev-parse HEAD` as `<pre_fix>`, then
+   route all blockers back as **one batched fix round** (never finding-by-finding):
+   - a **behavioral** gap (missing behavior; a wrong RED test — bad assertion,
+     implementation-coupled, wrong interface) returns to that behavior's **RED** with
+     `tdd-runner` before GREEN; never ask `worker-coder` to edit a test;
+   - a **mechanical or design** fix goes to `worker-coder` directly
      (`mode: non_behavioral` for format/lint/type/rename; `mode: refactor` for a
      behavior-preserving restructure).
-   After the fix lands, **re-verify in proportion to what changed** — never a blanket re-run:
-   - **always** re-run the gates (the full objective safety net — they catch any cross-file
-     regression a scoped re-review would not);
-   - re-review **only the changed hunks of this fix** with `reviewer`, never a full re-review — a
-     scoped re-review cannot re-litigate code already approved;
-   - re-run the `critic` **only if** the fix changed behavior or coverage; a mechanical or
-     design-only fix cannot change goal-fit, so skip it.
-   Allow **one** fix round; a **second** is permitted only if round 1 *introduced a new blocker*.
-   After 2 rounds, **stop**: declare Done if clean, otherwise escalate the remaining findings as
-   **stop / re-scope** — surface unresolved non-CRITICAL findings to the human as waive-or-rescope
-   decisions rather than looping again.
-8. **Done** → only when: all behaviors green, all gates green, no CRITICAL review finding, no
-   unwaived review finding with `score >= 70` (a black-letter language-rule violation always scores
-   `>= 70` and is never waivable), critic `achieved`, and any step-7 fix has been re-verified per
-   the proportional rule above. Write the evidence handoff (next section), then ship it without
-   asking (see Decisions you own): push the branch, open the PR, and summarize with the PR URL.
+   Then re-verify in proportion — never a blanket re-run: **always** re-run the gates; a
+   gate red on this re-run is a blocker introduced by the round — it consumes the single
+   permitted second round (routed per step 5's failure-type rules), and if still red after
+   that, stop / re-scope. Re-review **only** `git diff <pre_fix>...HEAD` with `reviewer` — a
+   scoped re-review cannot re-litigate approved code. Re-run `critic` **only if** the fix
+   changed behavior or coverage. One fix round; a second only if round 1 introduced a new
+   blocker. After 2 rounds: Done if clean, else escalate the remainder as **stop /
+   re-scope** (waive-or-rescope decisions for the human, never another loop). On resume,
+   log the human's waiver rows, then re-enter step 6 with waived findings excluded.
+8. **Done** → only when: all behaviors green, all gates green, no unwaived blocker per step
+   6's waivability rule, critic `achieved`, and any step-7 fix re-verified per the
+   proportional rule. Write the evidence handoff (see Evidence handoff), then ship it
+   without asking (see Decisions you own).
 
 ## JSONL logging contract (mandatory)
 
-Append **one line per subagent call, TDD skip, and gate run** to `<run_root>/<run-id>.jsonl`
-(create the dir/file if missing). Write the line immediately after each agent or command
-returns. `<run-id>` (per Runtime resolution) cannot create nested paths. Schema:
+Append **one line per subagent call, TDD skip, gate run, and human waiver** to `<run_root>/<run-id>.jsonl`
+(create if missing), immediately after each agent or command returns. `<run-id>` cannot
+create nested paths. Schema:
 
 ```json
 {"ts":"<ISO8601>","run":"<run-id>","step":"RED|GREEN|REFACTOR|NON_BEHAVIORAL|GATE|REVIEW|CRITIC",
@@ -213,73 +202,73 @@ returns. `<run-id>` (per Runtime resolution) cannot create nested paths. Schema:
  "note":"<e.g. TDD skip reason, retry #, decision made>"}
 ```
 
-Get the timestamp with `date -u +%Y-%m-%dT%H:%M:%SZ` (you don't have a clock primitive). One
-JSON object per line, no pretty-printing. JSON-escape prompts and results; do not hand-build
-strings that contain raw newlines or quotes. A skipped TDD step is logged with
-`"step":"RED","verdict":"skip","note":"non-behavioral: <reason>"`. The `worker-coder` agent is
-logged with `role: coder` — its stable pipeline role, which is also the key for its return
-schema (`coder.schema.json`).
+Timestamps from `date -u +%Y-%m-%dT%H:%M:%SZ`. One JSON object per line, no
+pretty-printing; JSON-escape prompts and results — never hand-build strings containing raw
+newlines or quotes. A skipped TDD step:
+`"step":"RED","verdict":"skip","note":"non-behavioral: <reason>"`. `worker-coder` is logged
+as `role: coder` — its stable pipeline role and the key for its return schema
+(`coder.schema.json`).
 
 Example rows — a GREEN dispatch and a non-behavioral skip:
 
 ```json
-{"ts":"2026-06-01T14:32:07Z","run":"feat_cart-discount","step":"GREEN","role":"coder","prompt":"Make tests/test_cart.py::test_discount_applies_to_subtotal pass with minimal production code. mode: green. Module boundary: cart.py, tests/test_cart.py. Base: <merge-base>. Rules: <abs>/design-principles.md, <abs>/python.md, <abs>/tdd.md.","result":"{\"schema_version\":\"v1\",\"role\":\"coder\",\"mode\":\"green\",\"status\":\"done\",\"commit\":{\"sha\":\"a1b2c3d\",\"subject\":\"feat: apply cart discount\"},\"files_changed\":[\"cart.py\",\"tests/test_cart.py\"],\"files_staged\":[\"cart.py\",\"tests/test_cart.py\"],\"commands\":[{\"cmd\":\"uv run pytest tests/test_cart.py::test_discount_applies_to_subtotal\",\"exit_code\":1,\"outcome\":\"fail\",\"key_output\":\"AssertionError: expected Money(135), got Money(150)\"},{\"cmd\":\"uv run pytest tests/test_cart.py::test_discount_applies_to_subtotal\",\"exit_code\":0,\"outcome\":\"pass\",\"key_output\":\"1 passed\"},{\"cmd\":\"uv run pytest\",\"exit_code\":0,\"outcome\":\"pass\",\"key_output\":\"42 passed\"}],\"scope_notes\":\"Implemented only the named behavior.\",\"new_dependencies\":[],\"blocked_reason\":\"\"}","verdict":"pass","files":["cart.py","tests/test_cart.py"],"note":"GREEN attempt 1"}
+{"ts":"2026-06-01T14:32:07Z","run":"feat_cart-discount","step":"GREEN","role":"coder","prompt":"Make tests/test_cart.py::test_discount_applies_to_subtotal pass with minimal production code. mode: green. ...","result":"<the coder's full JSON return, verbatim — shape per coder.schema.json>","verdict":"pass","files":["cart.py","tests/test_cart.py"],"note":"GREEN attempt 1"}
 {"ts":"2026-06-01T14:10:55Z","run":"chore_bump-deps","step":"RED","role":"architect","prompt":"n/a","result":"n/a","verdict":"skip","files":["pyproject.toml"],"note":"non-behavioral: dependency bump"}
 ```
 
 ## Evidence handoff (at Done)
 
-At **Done**, before pushing, distill the run into `<run_root>/evidence/<branch-slug>/evidence.json`,
-where `<branch-slug>` is the branch you are about to push with `/` and whitespace → `_` — the
-key `/pr-explain` joins on, so never the task id, even when this run's id came from one. It is
-the file `/pr-explain` builds its proof chapter from, and restates only runs already witnessed
+At **Done**, before pushing, distill the run into
+`<run_root>/evidence/<branch-slug>/evidence.json`, where `<branch-slug>` is the branch you
+are about to push with `/` and whitespace → `_` — the key `/pr-explain` joins on, so never
+the task id, even when this run's id came from one. It restates only runs already witnessed
 in your JSONL log and the agents' returns, never new claims:
 
 - `branch`: the branch you are about to push; `pipeline`: `"make-pr"`.
 - one `behaviors[]` entry per planned behavior: `name` (the behavior sentence), `kind`,
   `test` (`test_file::test_name`), `files`, `red` (the RED return's failing run: `cmd`,
-  `exit_code`, `key_output` — the witnessed failure reason), and `green` (the passing run
-  from the GREEN return, plus `lines_added`: insertions in that behavior's GREEN commit,
-  from `git show --shortstat <sha>`; `null` only when not derivable). A non-behavioral
-  task is one entry with `kind: "non_behavioral"` and `test`/`red`/`green` null.
-- one `gates[]` entry per gate in the final green gate pass, `key_output` carrying the
-  real numbers ("18 passed in 0.42s"), never a summary.
+  `exit_code`, `key_output` — the witnessed failure reason), `green` (your own step-4b
+  full-suite reproduction, plus `lines_added`: insertions summed from
+  `git show --numstat <sha> -- <the behavior's non-test files>`; `null` only when not
+  derivable). Non-behavioral: one entry, `kind: "non_behavioral"`, witnesses null
+  (schema-enforced).
+- one `gates[]` entry per gate in the final green pass, `key_output` carrying the real
+  numbers ("18 passed in 0.42s"), never a summary.
 - `runtime`: paths relative to the evidence dir of any runtime evidence (screenshots, e2e
   transcripts) you copy into `<run_root>/evidence/<branch-slug>/runtime/`; `[]` when none.
 
-Validate it like any agent return —
-`uv run --no-project --with jsonschema python ~/.claude/at/scripts/validate_return.py ~/.claude/at/schemas/evidence.schema.json <run_root>/evidence/<branch-slug>/evidence.json`
-— a failing file blocks the push: fix the file, never the schema.
+Validate it with the same validator command as agent returns, against
+`~/.claude/at/schemas/evidence.schema.json` — a failing file blocks the push: fix the file,
+never the schema.
 
-## Maintaining the task table
+## Task table
 
-Keep a short live table in your responses (the human's at-a-glance view) — one row per
-behavior with its RED/GREEN/REFACTOR state and the latest verdict. You are the single source
-of truth for status.
+Keep a live table in your responses — one row per behavior with its RED/GREEN/REFACTOR state
+and latest verdict, e.g. `| B1 discount applies to subtotal | RED✓ | GREEN✓ | gate✓ |`. You
+are the single source of truth for status.
 
 ## Decisions you own
 
-After review + critic you choose one:
-- **done** — the step-8 predicate holds (its conditions are the single source of truth).
-- **fix** — route the blockers back as one batched round, then re-verify in proportion to the
-  change (step 7).
-- **stop / re-scope** — task is mis-scoped, blocked, or spans modules; report up with why.
-
-A **done** you ship yourself — never ask the human to confirm it. Branch first if still on the
-default branch, `git push -u origin <branch>`, then `gh pr create` against the default branch (or
-the task-named target), referencing the task/issue in the body, and report the PR URL. Only a
-**stop / re-scope** goes back to the human.
+After review + critic, choose one:
+- **done** — the step-8 predicate holds. Ship it yourself — never ask the human to confirm:
+  branch first if still on the default branch, `git push -u origin <branch>`, then
+  `gh pr create` against the default branch (or the task-named target), referencing the
+  task/issue in the body, and report the PR URL.
+- **fix** — route the blockers back as one batched round, then re-verify in proportion
+  (step 7).
+- **stop / re-scope** — mis-scoped, blocked, or spans modules; report up with why. Only
+  this goes back to the human.
 
 ## Hard rules
 
-- Never refactor or declare done while any test or gate is red, and never weaken a test or gate to
-  get green.
-- One behavior per RED/GREEN cycle (no horizontal slicing); non-behavioral TDD skips only when
-  logged with a reason.
-- Fixed order: RED → GREEN → (refactor) → GATE → REVIEW → CRITIC — gates before judgment.
-- **Language-rule conformance is non-skippable and covers every change — including the workflow's own
-  scripts, schemas, gates, and agent prompts. There is no "it's just tooling / internal" bypass.**
-  It runs in two places: the coder's pre-commit conform gate (worker-coder step 5) and the
-  reviewer's line-by-line rule check. ruff/mypy/biome/clippy do **not** enforce rules like
-  keyword-only `*`, `Final[T]`, or per-binding type hints — only this pass does, and a black-letter
-  violation is never waivable. A green objective gate is never sufficient evidence of conformance.
+- Never weaken a test or gate to get green, and never refactor or declare done while any
+  test or gate is red. Step order and waivability: the loop and step 6 are the single
+  source of truth.
+- One behavior per RED/GREEN cycle (no horizontal slicing); non-behavioral TDD skips only
+  when logged with a reason.
+- **Language-rule conformance covers every change — including the workflow's own scripts,
+  schemas, gates, and agent prompts; there is no "just tooling / internal" bypass.** It
+  runs twice: the coder's pre-commit conform gate and the reviewer's line-by-line check.
+  ruff/mypy/biome/clippy do **not** enforce rules like keyword-only `*`, `Final[T]`, or
+  per-binding type hints — only this pass does. A green objective gate is never evidence of
+  conformance.

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -74,7 +74,7 @@ Resolve these values before the first dispatch:
   command there: `git`, verification commands, package-manager setup, and gate runs.
 - **run_root**: a writable directory for logs and transient return JSON, defaulting to
   `<target_cwd>/.v1-runs`. Use this for JSONL logs, `<run-id>.<role>.json`, and the
-  `evidence/<run-id>/` handoff (see Evidence handoff); do not write runtime state into `skill_root`.
+  `evidence/<branch-slug>/` handoff (see Evidence handoff); do not write runtime state into `skill_root`.
 - **Base**: use a base named by the user or task spec. Otherwise use `git merge-base HEAD
   origin/main`; if `origin/main` is unavailable, use `git merge-base HEAD main`. If no base
   can be resolved, stop and ask for one.
@@ -93,7 +93,7 @@ Resolve these values before the first dispatch:
 ## Tool boundaries
 
 - Use `Write`/`Edit` only for files under `<run_root>/` (the `<run-id>.jsonl` log, the transient
-  `<run-id>.<role>.json` return files you write for validation, and the `evidence/<run-id>/` handoff). Do not edit production source, tests,
+  `<run-id>.<role>.json` return files you write for validation, and the `evidence/<branch-slug>/` handoff). Do not edit production source, tests,
   rules, or gates directly while acting as architect; route every code or test change to `worker-coder`.
 - Use `Bash` only for `git`, `date`, JSONL validation, the schema validator
   (`~/.claude/at/scripts/validate_return.py`), **re-running a worker's reported verification (e.g. the
@@ -229,8 +229,10 @@ Example rows — a GREEN dispatch and a non-behavioral skip:
 
 ## Evidence handoff (at Done)
 
-At **Done**, before pushing, distill the run into `<run_root>/evidence/<run-id>/evidence.json`
-— the file `/pr-explain` builds its proof chapter from. It restates only runs already witnessed
+At **Done**, before pushing, distill the run into `<run_root>/evidence/<branch-slug>/evidence.json`,
+where `<branch-slug>` is the branch you are about to push with `/` and whitespace → `_` — the
+key `/pr-explain` joins on, so never the task id, even when this run's id came from one. It is
+the file `/pr-explain` builds its proof chapter from, and restates only runs already witnessed
 in your JSONL log and the agents' returns, never new claims:
 
 - `branch`: the branch you are about to push; `pipeline`: `"make-pr"`.
@@ -243,10 +245,10 @@ in your JSONL log and the agents' returns, never new claims:
 - one `gates[]` entry per gate in the final green gate pass, `key_output` carrying the
   real numbers ("18 passed in 0.42s"), never a summary.
 - `runtime`: paths relative to the evidence dir of any runtime evidence (screenshots, e2e
-  transcripts) you copy into `<run_root>/evidence/<run-id>/runtime/`; `[]` when none.
+  transcripts) you copy into `<run_root>/evidence/<branch-slug>/runtime/`; `[]` when none.
 
 Validate it like any agent return —
-`uv run --no-project --with jsonschema python ~/.claude/at/scripts/validate_return.py ~/.claude/at/schemas/evidence.schema.json <run_root>/evidence/<run-id>/evidence.json`
+`uv run --no-project --with jsonschema python ~/.claude/at/scripts/validate_return.py ~/.claude/at/schemas/evidence.schema.json <run_root>/evidence/<branch-slug>/evidence.json`
 — a failing file blocks the push: fix the file, never the schema.
 
 ## Maintaining the task table

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -73,8 +73,8 @@ Resolve these values before the first dispatch:
 - **target_cwd**: the absolute path to the repository being changed. Run every target-repo
   command there: `git`, verification commands, package-manager setup, and gate runs.
 - **run_root**: a writable directory for logs and transient return JSON, defaulting to
-  `<target_cwd>/.v1-runs`. Use this for JSONL logs and `<run-id>.<role>.json`; do not write
-  runtime state into `skill_root`.
+  `<target_cwd>/.v1-runs`. Use this for JSONL logs, `<run-id>.<role>.json`, and the
+  `evidence/<run-id>/` handoff (see Evidence handoff); do not write runtime state into `skill_root`.
 - **Base**: use a base named by the user or task spec. Otherwise use `git merge-base HEAD
   origin/main`; if `origin/main` is unavailable, use `git merge-base HEAD main`. If no base
   can be resolved, stop and ask for one.
@@ -92,8 +92,8 @@ Resolve these values before the first dispatch:
 
 ## Tool boundaries
 
-- Use `Write`/`Edit` only for files under `<run_root>/` (the `<run-id>.jsonl` log and the transient
-  `<run-id>.<role>.json` return files you write for validation). Do not edit production source, tests,
+- Use `Write`/`Edit` only for files under `<run_root>/` (the `<run-id>.jsonl` log, the transient
+  `<run-id>.<role>.json` return files you write for validation, and the `evidence/<run-id>/` handoff). Do not edit production source, tests,
   rules, or gates directly while acting as architect; route every code or test change to `worker-coder`.
 - Use `Bash` only for `git`, `date`, JSONL validation, the schema validator
   (`~/.claude/at/scripts/validate_return.py`), **re-running a worker's reported verification (e.g. the
@@ -197,8 +197,8 @@ Resolve these values before the first dispatch:
 8. **Done** → only when: all behaviors green, all gates green, no CRITICAL review finding, no
    unwaived review finding with `score >= 70` (a black-letter language-rule violation always scores
    `>= 70` and is never waivable), critic `achieved`, and any step-7 fix has been re-verified per
-   the proportional rule above. Ship it without asking (see Decisions you own): push the branch,
-   open the PR, and summarize with the PR URL.
+   the proportional rule above. Write the evidence handoff (next section), then ship it without
+   asking (see Decisions you own): push the branch, open the PR, and summarize with the PR URL.
 
 ## JSONL logging contract (mandatory)
 
@@ -226,6 +226,28 @@ Example rows — a GREEN dispatch and a non-behavioral skip:
 {"ts":"2026-06-01T14:32:07Z","run":"feat_cart-discount","step":"GREEN","role":"coder","prompt":"Make tests/test_cart.py::test_discount_applies_to_subtotal pass with minimal production code. mode: green. Module boundary: cart.py, tests/test_cart.py. Base: <merge-base>. Rules: <abs>/design-principles.md, <abs>/python.md, <abs>/tdd.md.","result":"{\"schema_version\":\"v1\",\"role\":\"coder\",\"mode\":\"green\",\"status\":\"done\",\"commit\":{\"sha\":\"a1b2c3d\",\"subject\":\"feat: apply cart discount\"},\"files_changed\":[\"cart.py\",\"tests/test_cart.py\"],\"files_staged\":[\"cart.py\",\"tests/test_cart.py\"],\"commands\":[{\"cmd\":\"uv run pytest tests/test_cart.py::test_discount_applies_to_subtotal\",\"exit_code\":1,\"outcome\":\"fail\",\"key_output\":\"AssertionError: expected Money(135), got Money(150)\"},{\"cmd\":\"uv run pytest tests/test_cart.py::test_discount_applies_to_subtotal\",\"exit_code\":0,\"outcome\":\"pass\",\"key_output\":\"1 passed\"},{\"cmd\":\"uv run pytest\",\"exit_code\":0,\"outcome\":\"pass\",\"key_output\":\"42 passed\"}],\"scope_notes\":\"Implemented only the named behavior.\",\"new_dependencies\":[],\"blocked_reason\":\"\"}","verdict":"pass","files":["cart.py","tests/test_cart.py"],"note":"GREEN attempt 1"}
 {"ts":"2026-06-01T14:10:55Z","run":"chore_bump-deps","step":"RED","role":"architect","prompt":"n/a","result":"n/a","verdict":"skip","files":["pyproject.toml"],"note":"non-behavioral: dependency bump"}
 ```
+
+## Evidence handoff (at Done)
+
+At **Done**, before pushing, distill the run into `<run_root>/evidence/<run-id>/evidence.json`
+— the file `/pr-explain` builds its proof chapter from. It restates only runs already witnessed
+in your JSONL log and the agents' returns, never new claims:
+
+- `branch`: the branch you are about to push; `pipeline`: `"make-pr"`.
+- one `behaviors[]` entry per planned behavior: `name` (the behavior sentence), `kind`,
+  `test` (`test_file::test_name`), `files`, `red` (the RED return's failing run: `cmd`,
+  `exit_code`, `key_output` — the witnessed failure reason), and `green` (the passing run
+  from the GREEN return, plus `lines_added`: insertions in that behavior's GREEN commit,
+  from `git show --shortstat <sha>`; `null` only when not derivable). A non-behavioral
+  task is one entry with `kind: "non_behavioral"` and `test`/`red`/`green` null.
+- one `gates[]` entry per gate in the final green gate pass, `key_output` carrying the
+  real numbers ("18 passed in 0.42s"), never a summary.
+- `runtime`: paths relative to the evidence dir of any runtime evidence (screenshots, e2e
+  transcripts) you copy into `<run_root>/evidence/<run-id>/runtime/`; `[]` when none.
+
+Validate it like any agent return —
+`uv run --no-project --with jsonschema python ~/.claude/at/scripts/validate_return.py ~/.claude/at/schemas/evidence.schema.json <run_root>/evidence/<run-id>/evidence.json`
+— a failing file blocks the push: fix the file, never the schema.
 
 ## Maintaining the task table
 

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -61,13 +61,16 @@ gh pr checks <N> || true
   `gh issue view <N> --json title,body`. The problem chapter comes from there — the
   slice/PR row the body names, else the issue's headline problem — not from the diff.
   None referenced → derive it from the PR body and diff, and say so.
-- **Evidence**: look in `<target_repo>/.v1-runs/` for files whose stem is the head
-  branch with `/`→`_`: `<slug>.jsonl` (run log), `<slug>.tdd-runner.json` (RED witness),
-  `<slug>.coder.json`, `<slug>.reviewer.json`, `<slug>.critic.json`. Never invent
-  evidence: without those files, the proof chapter degrades to `gh pr checks` plus the
-  tests visible in the diff. Checks empty too → cite the diff's test files. Gate numbers
-  claimed in the PR body appear only attributed ("PR body reports: pytest 18 passed"),
-  never as verified chips.
+- **Evidence**: with the head branch slugged `/`→`_`, read
+  `<target_repo>/.v1-runs/evidence/<slug>/evidence.json` — the make-pr/-lite handoff:
+  `behaviors[]` with RED and GREEN witnesses, `gates[]` with the run's real gate numbers,
+  `runtime` artifact paths relative to that dir. The proof chapter quotes it verbatim:
+  the RED tag carries `red.key_output` (the witnessed failure reason), the GREEN tag
+  what made it pass plus `+<lines_added>` lines, one gate chip per `gates[]` row from
+  its `key_output`. Never invent evidence: without that file, the proof chapter degrades
+  to `gh pr checks` plus the tests visible in the diff. Checks empty too → cite the
+  diff's test files. Gate numbers claimed in the PR body appear only attributed
+  ("PR body reports: pytest 18 passed"), never as verified chips.
 
 ## Phase 2 — Understand (before writing a word)
 

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -61,7 +61,7 @@ gh pr checks <N> || true
   `gh issue view <N> --json title,body`. The problem chapter comes from there — the
   slice/PR row the body names, else the issue's headline problem — not from the diff.
   None referenced → derive it from the PR body and diff, and say so.
-- **Evidence**: with the head branch slugged `/`→`_`, read
+- **Evidence**: with the head branch slugged (`/` and whitespace → `_`), read
   `<target_repo>/.v1-runs/evidence/<slug>/evidence.json` — the make-pr/-lite handoff:
   `behaviors[]` with RED and GREEN witnesses, `gates[]` with the run's real gate numbers,
   `runtime` artifact paths relative to that dir. The proof chapter quotes it verbatim:


### PR DESCRIPTION
Part of #135 — PR 1.2 of the pr-explain plan (proof pipeline).

## What

The evidence handoff between the PR pipelines and `/pr-explain`, defined once and machine-checked:

- **`schemas/evidence.schema.json`** (new) — the single source of truth for the contract: `branch`, `pipeline`, `behaviors[]` (name, kind, test, files, RED/GREEN witnesses with `lines_added`), `gates[]` (real `key_output` numbers, `minItems: 1`), `runtime[]`. Two kind-keyed conditionals make witnesses **required** on behavioral rows and **forbidden** (null) on non-behavioral rows, so a producer can never write evidence the proof chapter would have to invent around.
- **make-pr** — new "Evidence handoff (at Done)" section: before pushing, the architect distills the run into `<run_root>/evidence/<branch-slug>/evidence.json` (witnesses from the RED/GREEN returns, `lines_added` via `git show --shortstat`, final green gate rows, optional `runtime/` artifacts) and validates it with the existing validator; a failing file blocks the push.
- **make-pr-lite** — gains `Write` (scoped to the handoff), a `run_root` bullet, and the same Done-step write+validate; the GREEN witness is the orchestrator's own suite re-run, and `lines_added` degrades to `null` for slices sharing a production file (never double-counted).
- **pr-explain** — Phase-1 Evidence now reads `.v1-runs/evidence/<slug>/evidence.json` and quotes it verbatim (RED tag = `red.key_output`, GREEN tag = `+<lines_added>` lines, one gate chip per `gates[]` row), with the unchanged degradation chain: no file → `gh pr checks` → tests visible in the diff.
- **catalog** — `lite-pr` now stages `schemas` + `scripts/validate_return.py`, so every runtime path the lite skill references exists on a lite install (enforced by the catalog-driven `test_skill_extras_paths`).

The join key is pinned on both sides: producers write and pr-explain reads `evidence/<branch-slug>/` where the slug is the pushed branch with `/` and whitespace → `_` — explicitly never the task id.

## Verification

- Validator round-trip against the real schema: a mixed behavioral + non-behavioral sample passes; behavioral with `red: null`, non-behavioral carrying a witness, and empty `gates` are each rejected.
- `./validate.sh` → `catalog OK — 26 units, 6 packages, 2 bundles`; installer suite → 177 passed.
- Dogfooded live: this run wrote its own `.v1-runs/evidence/feat_pr-explain-evidence/evidence.json` per the new contract and it validates against the new schema.
- Pipeline: non-behavioral run (skill prose + schema + config; TDD skip logged), reviewer pass (0 open findings after one fix round), critic **achieved** (94, zero gaps). Full audit trail in `.v1-runs/feat_pr-explain-evidence.jsonl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LtsRdxUKd8Bk5SVYnzpfP


## Post-review hardening (commit 4acd959)

The make-pr SKILL.md was then run through a 3-critic review-bar loop (token-economy / executor / editor lenses, 2 rounds): mean 84.8 → **91.9** (92 / 92 / 91.75). Compacted 3,019 → 2,581 words (−15%) with every rule stated once and cross-referenced, step 4b converted to a total outcome→action routing table, and real executor defects fixed: `target_cwd` in every dispatch, `<pre_fix>` capture for the scoped re-review, `lines_added` semantics aligned with make-pr-lite (prod-only numstat), the post-fix red-gate budget defined, the GREEN retry budget scoped across all failure modes, and waiver rows added to the JSONL contract.
