### PR TITLE
fix(catalog): register grill-me skill unit (#137 follow-up)

### DIFF
--- a/installer/catalog.toml
+++ b/installer/catalog.toml
@@ -24,6 +24,10 @@ name = "explain"
 
 [[units]]
 kind = "skill"
+name = "grill-me"
+
+[[units]]
+kind = "skill"
 name = "improve-architecture"
 
 [[units]]


### PR DESCRIPTION
## What

Adds the missing `[[units]]` entry for `grill-me` to `installer/catalog.toml`. PR #137 shipped the skill directory, but the catalog is the installer's exhaustive inventory — without the entry the TUI never listed it and `--skill grill-me` didn't resolve, so the skill wasn't installable.

Unit only for now — no package membership. If we want it in a curated package, `breakdown` (planning flow) is the natural home since grill-me hands off to `/to-prd` → `/breakdown`; left out as package curation is marked provisional.

## Verification

- `./validate.sh` — catalog OK, 27 units, 6 packages, 2 bundles
- `uv run pytest` in `installer/` — 177 passed
- Real install: `./at install --skill grill-me` → `~/.claude/skills/grill-me` symlink to the staged copy, correct SKILL.md content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J6rqPucC9tRJjJGGWESgGC