### PR TITLE
feat(skills): wire pr-explain into make-pr/-lite Done and pr-babysit refresh (#135, PR 1.3)

### DIFF
--- a/skills/make-pr-lite/SKILL.md
+++ b/skills/make-pr-lite/SKILL.md
@@ -3,7 +3,7 @@ name: make-pr-lite
 description: Use when explicitly asked to run /make-pr-lite on an already-scoped, low-risk single-module PR. A cheaper alternative to /make-pr — one self-TDD coder, the language gates, then a parallel 3-reviewer panel and a critic, squashed to one commit. Not for feature decomposition, multi-module planning, or high-risk work (filesystem/state mutation, merge/refcount, destructive ops) — route those to /make-pr.
 argument-hint: "<task spec, issue ref, or path to a task file>"
 disable-model-invocation: true
-allowed-tools: Read, Write, Bash, Agent, TodoWrite
+allowed-tools: Read, Write, Bash, Agent, TodoWrite, Skill
 ---
 
 # make-pr-lite
@@ -145,7 +145,11 @@ gate output, and the reviewers' findings. Each reviewer finding carries a 1–10
    without asking: branch first if still on the default branch, `git push -u origin <branch>`
    (`--force-with-lease` only if this run already pushed the branch before the squash), and
    `gh pr create` against the default branch (or the task-named target), referencing the
-   task/issue in the body. Summarize with the PR URL — done needs no human confirmation.
+   task/issue in the body. Summarize with the PR URL — done needs no human confirmation. Then
+   invoke the `pr-explain` skill (Skill tool, args: the new PR number) — it publishes the
+   explainer page from the evidence handoff and maintains the PR-body teaser; headless it
+   degrades to markdown in the body on its own, so never skip it; a failure goes in the summary
+   and never reopens done.
 
 ## Status table
 

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -3,7 +3,7 @@ name: make-pr
 description: Use when explicitly asked to run the architect workflow on an already-scoped PR (the /make-pr command) — drives one single-module coding task to done via a deterministic TDD loop: plans behavior slices, dispatches the tdd-runner/worker-coder/reviewer/critic agents, runs the language gates, and logs every subagent call to a per-run JSONL for validation. Not for feature decomposition, direct coding, exploratory fixes, or multi-module planning.
 argument-hint: "<task spec, issue ref, or path to a task file>"
 disable-model-invocation: true
-allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent, TodoWrite
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent, TodoWrite, Skill
 ---
 
 # make-pr
@@ -253,7 +253,12 @@ After review + critic, choose one:
 - **done** — the step-8 predicate holds. Ship it yourself — never ask the human to confirm:
   branch first if still on the default branch, `git push -u origin <branch>`, then
   `gh pr create` against the default branch (or the task-named target), referencing the
-  task/issue in the body, and report the PR URL.
+  task/issue in the body, and report the PR URL. After reporting the URL, invoke the
+  `pr-explain` skill (Skill tool, args: the new PR number) — it publishes the explainer page
+  from the evidence handoff this run just wrote and maintains the teaser in the PR body. Invoke
+  it even when the Artifact tool is unavailable (headless/CI): it degrades to writing the story
+  as markdown into the PR body on its own. A pr-explain failure goes in the final summary; it
+  never reopens Done.
 - **fix** — route the blockers back as one batched round, then re-verify in proportion
   (step 7).
 - **stop / re-scope** — mis-scoped, blocked, or spans modules; report up with why. Only

--- a/skills/pr-babysit/SKILL.md
+++ b/skills/pr-babysit/SKILL.md
@@ -18,8 +18,8 @@ Loop:
   5. Reply to question comments (bot: auto; human: only approved reply, in parallel)
   6. If CI failing → read logs, fix failures
   7. If conflicts → rebase/merge main and resolve conflicts
-  8. If changes were made → commit & push, reset idle counter
-  9. If nothing left to fix AND CI green AND no conflicts AND no undecided human comments → [READY TO MERGE]
+  8. If changes were made → commit & push, refresh the PR explainer, reset idle counter
+  9. If nothing left to fix AND CI green AND no conflicts AND no undecided human comments → final explainer refresh, then [READY TO MERGE]
  10. Otherwise → wait interval, repeat
 ```
 
@@ -107,9 +107,12 @@ CONSECUTIVE_READY_COUNT = 0              # must reach 2 before declaring ready
 PUSHED_AT = None                         # set to current time after each push
 EXTERNAL_CHECK_PATIENCE = 10             # separate counter for external check waits
 DECISIONS = load_decisions(PR_NUMBER)    # comment_id → {decision, drafted_reply?, custom?} — persisted across iterations and skill runs
+EXPLAINED_DIFF_SHA = load .claude/pr-babysit/<PR_NUMBER>/explained-diff.sha  # empty if missing
 ```
 
 `DECISIONS` persists at `.claude/pr-babysit/<PR_NUMBER>/decisions.json`. Load on startup (create empty if missing), write after every human gate decision. This survives Ctrl-C, re-invocations, and worksheet round-trips so the user is never asked twice about the same comment.
+
+`EXPLAINED_DIFF_SHA` is the sha256 of `git diff origin/<BASE_BRANCH>...HEAD` at the last `/pr-explain` refresh — the diff the explainer page currently matches. Empty means this run hasn't verified page currency yet. Written after every refresh; persisting it avoids republishing an unchanged page across re-invocations.
 
 Three counters prevent infinite loops:
 - `IDLE_ROUNDS_REMAINING` resets when progress is made (commit & push). Exhaustion means the PR stalled.
@@ -399,6 +402,7 @@ Increment `TOTAL_ITERATIONS`.
 4. **Reset `IDLE_ROUNDS_REMAINING` to `max-rounds`** — progress was made
 5. **Reset `CONSECUTIVE_READY_COUNT` to 0** — changes invalidate any previous ready verdict
 6. **Set `PUSHED_AT` to current time** — starts the post-push cooldown
+7. **Refresh the PR explainer** when the diff materially changed: `DIFF_SHA=$(git diff "origin/$BASE_BRANCH"...HEAD | sha256sum | cut -d' ' -f1)`; if it differs from `EXPLAINED_DIFF_SHA`, invoke the `pr-explain` skill (Skill tool, args: `$PR_NUMBER`), then write the new sha to the state file. The refresh republishes to the teaser's existing artifact URL — same link, updated page. A rebase-only push whose diff content is unchanged hashes the same and skips the refresh.
 
 **Post-push cooldown:** If `PUSHED_AT` is set and less than 60 seconds have elapsed since the push, do NOT evaluate readiness. Checks may not be reported yet. Reset `CONSECUTIVE_READY_COUNT` to 0 and wait for the next iteration. Also: if checks are empty and less than 2 minutes have elapsed since `PUSHED_AT`, treat this as "checks pending" not "no checks configured."
 
@@ -421,7 +425,7 @@ Treat unreplied comments by author type:
 
 **If no changes were needed** AND **no unreplied comments exist** AND **at least one check exists** (not empty) AND **every** check has reached a terminal state AND all required checks pass AND no conflicts:
 → Increment `CONSECUTIVE_READY_COUNT`
-→ If `CONSECUTIVE_READY_COUNT >= 2`: print and exit:
+→ If `CONSECUTIVE_READY_COUNT >= 2`: recompute `DIFF_SHA`; if it differs from `EXPLAINED_DIFF_SHA`, invoke `pr-explain` once more and store the sha — the page must match the final diff. Then print and exit:
 ```
 [READY TO MERGE] <PR_URL>
 ```
@@ -492,3 +496,6 @@ Otherwise:
 | Detecting bots by login suffix only | Check all three: `user.type == "Bot"`, login ends in `[bot]`, login in the known-bot allowlist. Bots like `cursor-bugbot` don't have the `[bot]` suffix. |
 | Sleeping/looping while waiting for the worksheet | When >5 human comments trigger the slow path, exit the skill — do NOT sleep indefinitely. User re-invokes after editing the file. |
 | Declaring ready while a human comment is `defer` | `defer` is explicitly "decide later" — it blocks readiness. Only `apply` / `push-back` / `dismiss` (and bot completion) clear the readiness check. |
+| Minting a new artifact URL on refresh | /pr-explain reuses the teaser's URL (its Phase 5) — a refresh lands on the same link, or the link reviewers already have goes stale |
+| Skipping the explainer refresh when headless | /pr-explain writes the story as markdown between its PR-body markers on its own — invoke it regardless |
+| Refreshing the explainer every round | Hash the diff; only a changed hash (a material change) or the final READY check warrants a refresh |


### PR DESCRIPTION
Refs #135 — slice 1.3 of the pr-explain plan (the wiring).

## What

- **make-pr / make-pr-lite** — the Done step now invokes the `pr-explain` skill right after `gh pr create` (both frontmatter `allowed-tools` lists gain `Skill`, without which the invocation would be blocked). The page publishes from the evidence handoff the run just wrote; a pr-explain failure is reported, never a reason to reopen Done.
- **pr-babysit** — refreshes the explainer when the diff materially changed: after each push it hashes `git diff origin/<base>...HEAD` and re-invokes `/pr-explain` only when the sha differs from the persisted `EXPLAINED_DIFF_SHA` (state at `.claude/pr-babysit/<N>/explained-diff.sha`, gitignored); a final currency check runs before printing `[READY TO MERGE]`, so the page always matches the final diff. Three new Common Mistakes rows pin the sharp edges (same-URL refresh, headless, no per-round republish).
- **Headless** — callers invoke pr-explain unconditionally; the markdown-into-body fallback stays owned by pr-explain (Phase 6), delegated rather than reimplemented. `pr-make-till-merge` composes `/make-pr` + `/pr-babysit`, so it inherits the wiring with no edit.

## Run evidence (make-pr pipeline)

- Non-behavioral slice (skill prose; TDD skip logged with reason in `.v1-runs/feat_pr-explain-wiring.jsonl`).
- Gate: `./at validate` → catalog OK — 27 units, 6 packages, 2 bundles.
- Reviewer: no CRITICAL, none ≥ 70; three MINOR advisories (noted below).
- Critic: **achieved**, 90/100, no gaps — verified the Skill allowlists, every diff-changing exit path routes through a refresh, and `.gitignore` keeps the state file out of the PR diff.

## Advisories (non-blocking, surfaced for the record)

1. pr-explain's phase numbers/mechanism are restated in caller prose ("its Phase 5", marker mechanics) — renumbering pr-explain would stale three call sites (score 40).
2. Babysit's loop-summary line 8 reads as an unconditional per-push refresh; body step 7 hash-gates it (score 30).
3. `explained-diff.sha` follows the existing `decisions.json` in-repo state pattern; `.gitignore`'s `.claude/` entry keeps it out of the diff (score 28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LtsRdxUKd8Bk5SVYnzpfP

<!-- pr-explain:begin -->
### The story of this PR
Every PR the pipeline ships now gets an explainer page without a human asking. make-pr and make-pr-lite publish it at Done after `gh pr create`, and pr-babysit republishes to the same artifact URL when the diff materially changes and once more at READY TO MERGE. The wiring is 23 lines of skill prose across three files — no executable code.

**[Read the explainer](https://claude.ai/code/artifact/a44a2f9f-b519-4cdc-b8c4-4eaf174f644d)** · map: 3 changed components, 3 untouched neighbors
<!-- pr-explain:end -->
