### PR TITLE
feat(skills): pr-explain quality bar — Vale prose gate + critic-to-90 with ship-flag (#135, PR 1.4)

### DIFF
--- a/installer/catalog.toml
+++ b/installer/catalog.toml
@@ -179,11 +179,12 @@ units = [
 
 # pr-explain publishes a per-PR explainer page; its page skeleton ships as a package
 # extra so an install is self-contained. The skill degrades to inline styling when
-# installed without it (e.g. via pr-ops alone).
+# installed without it (e.g. via pr-ops alone). The Vale prose-gate config ships alongside
+# the page skeleton; both degrade gracefully when absent.
 [[packages]]
 name = "pr-explain"
 units = ["skill/pr-explain"]
-extras = ["templates/pr-explain-page.html"]
+extras = ["templates/pr-explain-page.html", "templates/pr-explain.vale.ini"]
 
 # --- bundles (provisional) ---
 [[bundles]]

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -116,7 +116,7 @@ The draft leaves Phase 3 only past this gate. Run it in order:
 - **Mechanical gate (always).** `wc -w` each chapter and cut any over budget; `grep` the
   draft for every banned word (the list above) and rewrite each hit. Then, **if `vale` is
   on PATH**, write the draft to a scratch `.md` and run `vale --config
-  ~/.claude/at/templates/pr-explain.vale.ini <draft>.md` (run `vale sync` once first if
+  ~/.claude/at/templates/pr-explain.vale.ini <draft>.md` (run `vale --config ~/.claude/at/templates/pr-explain.vale.ini sync` once first if
   `StylesPath` is empty), rewriting every alert. When `vale` is absent or `vale sync`
   can't reach the registry, degrade to the wc + banned-word checks — note it in the
   report, never fail the run. The banned-word list stays owned by the grep; Vale only adds
@@ -127,7 +127,9 @@ The draft leaves Phase 3 only past this gate. Run it in order:
   reason + impact in the first three sentences. **Concrete & tight** — failing command /
   error / diff before any abstraction; ≤ 25-word sentences; data over adjectives. **Budget
   & scope** — every chapter within budget; one big thing, secondary changes one line each.
-  Below **90** → apply the specific misses as one rewrite pass, then re-score once.
+  Below **90** → apply the specific misses as one rewrite pass, then re-score once. After
+  the rewrite, re-run the banned-word `grep` and per-chapter `wc` — these are hard and must
+  still hold at publish.
 - **Ship-flag.** Still < 90 after the rewrite → publish anyway and record the final score +
   unmet dimensions in the report. Never block the publish or loop a third time.
 

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -24,6 +24,10 @@ defects.
   delta-map, and minimap classes). If it is missing, still ship: build a single-file HTML
   page with inline CSS following the chapter contract — visual polish degrades, the
   contract does not.
+- **Vale config**: `~/.claude/at/templates/pr-explain.vale.ini`, staged with the page
+  template; it names the write-good / proselint / Google packages the mechanical prose
+  gate runs. Missing, or `vale` not installed → the gate degrades to the wc + banned-word
+  checks.
 - **Page file**: write the filled page to the session scratch directory (never the
   target repo) as `pr-<owner>-<repo>-<number>.html`, owner/repo parsed from the PR's `url`.
 - **Target repo**: the git repo of the working directory; run every `gh`/`git` command there.
@@ -105,8 +109,27 @@ Banned on sight: leverages, robust, seamless, comprehensive, delve, streamlined,
 powerful, simply, ensures, significantly, various, clearly, essentially, "it's worth
 noting", and "should" when describing behavior.
 
-Then verify mechanically: `wc -w` each chapter and cut to budget; grep the draft for
-every banned word and rewrite hits.
+### The bar
+
+The draft leaves Phase 3 only past this gate. Run it in order:
+
+- **Mechanical gate (always).** `wc -w` each chapter and cut any over budget; `grep` the
+  draft for every banned word (the list above) and rewrite each hit. Then, **if `vale` is
+  on PATH**, write the draft to a scratch `.md` and run `vale --config
+  ~/.claude/at/templates/pr-explain.vale.ini <draft>.md` (run `vale sync` once first if
+  `StylesPath` is empty), rewriting every alert. When `vale` is absent or `vale sync`
+  can't reach the registry, degrade to the wc + banned-word checks — note it in the
+  report, never fail the run. The banned-word list stays owned by the grep; Vale only adds
+  fuzzy prose quality (weasel words, passive voice, wordiness).
+- **Critic pass (inline, one rubric, one loop).** Score the draft 0–100, four dimensions ×
+  0–25: **Evidenced** — every claim cites a hunk / number / gate line / screenshot the
+  page shows; no unevidenced faster / safer / fixed. **Bottom-line-first** — change +
+  reason + impact in the first three sentences. **Concrete & tight** — failing command /
+  error / diff before any abstraction; ≤ 25-word sentences; data over adjectives. **Budget
+  & scope** — every chapter within budget; one big thing, secondary changes one line each.
+  Below **90** → apply the specific misses as one rewrite pass, then re-score once.
+- **Ship-flag.** Still < 90 after the rewrite → publish anyway and record the final score +
+  unmet dimensions in the report. Never block the publish or loop a third time.
 
 ## Phase 4 — Build
 
@@ -155,4 +178,6 @@ Maintain exactly one marker-delimited block in the PR description:
 ## Report
 
 End with: the artifact URL, total prose word count, chapters emitted vs dropped, map
-included or skipped (with the reason), and the PR whose teaser was updated.
+included or skipped (with the reason), the PR whose teaser was updated, the mechanical
+gate result (Vale alerts fixed, or "vale unavailable — wc + grep only"), and the critic
+score — naming any dimensions left under the bar when the page shipped flagged.

--- a/templates/pr-explain.vale.ini
+++ b/templates/pr-explain.vale.ini
@@ -1,0 +1,12 @@
+# Staged as a pr-explain package extra alongside the page template. Phase 3's bar runs
+# `vale --config <this>` against the draft when the `vale` binary is present, and degrades
+# to the wc budget + banned-word grep checks when it is not. Packages download via `vale sync`.
+
+StylesPath = styles
+
+MinAlertLevel = warning
+
+Packages = write-good, proselint, Google
+
+[*.md]
+BasedOnStyles = write-good, proselint, Google


### PR DESCRIPTION
Refs #135 — slice 1.4 of the pr-explain plan ("The bar"), the last slice.

## What

Adds a quality gate to the already-shipped `/pr-explain` skill so a weak page can't ship unnoticed. Folded into the skill's existing **Phase 3 — Write** as a `### The bar` exit gate (no new phase, no renumbering — a caller still cites "its Phase 5"), run in order:

1. **Mechanical gate (always).** `wc -w` per chapter cuts anything over budget; `grep` rewrites every banned word. When `vale` is on PATH it also runs `vale --config <ini>` over the draft (weasel words, passive voice, wordiness), degrading to wc+grep — never failing — when vale or its package registry is absent.
2. **Critic pass (inline, one loop).** Scores the draft on four dimensions ×0–25 (Evidenced / Bottom-line-first / Concrete & tight / Budget & scope). Below **90** → one rewrite pass, re-score once, then re-run the hard mechanical checks so the rewrite can't reintroduce a banned word or blow a budget.
3. **Ship-flag.** Still <90 → publish anyway and record the final score + unmet dimensions in the report. Never blocks the publish, never loops a third time.

The Vale config (`templates/pr-explain.vale.ini`, pinning the write-good / proselint / Google packages) ships as a package extra alongside the page template and is wired into the catalog. The inline critic (not a dispatched subagent) keeps the gate working when pr-explain runs headless from make-pr's Done or pr-babysit.

## Acceptance (issue "Done when")

A sloppy draft is caught mechanically and rewritten in one loop: **banned words** → grep, **blown budgets** → wc, **unevidenced claims** → the critic's Evidenced dimension. All three hold even when Vale is unavailable.

## Run evidence (make-pr pipeline)

Non-behavioral slice (skill prose + Vale config + catalog wiring; TDD skip logged with reason in `.v1-runs/feat_pr-explain-quality-bar.jsonl`). Objective gate `./at validate` → catalog OK, 27 units. One fix round: the first pass scored **partial (70)** — reviewer caught `vale sync` invoked without `--config` (silently no-opping the Vale layer) and no mechanical re-check after the rewrite; both fixed in `d23bc1f`, re-review clean, critic re-run **achieved (91)**.

Only advisory left: a cosmetic ~110-col source line in SKILL.md (score 12, rendered output unaffected) — flagged, not fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LtsRdxUKd8Bk5SVYnzpfP

<!-- pr-explain:begin -->
### The story of this PR
pr-explain now gates its own draft before publishing. A mechanical pass — word budgets, banned words, and Vale when installed — runs first; then an inline critic scores the draft to a 90 bar with one rewrite loop, and a still-short page ships flagged, never silently. It adds skill prose plus one pinned Vale config.

**[Read the explainer](https://claude.ai/code/artifact/b5a38175-db51-4ff2-8c4b-cfb556755b52)** · map: 3 changed components, 1 untouched neighbor
<!-- pr-explain:end -->
