### PR TITLE
fix(installer): reconcile package extras on update and show extra drift in status

### DIFF
--- a/installer/at.py
+++ b/installer/at.py
@@ -47,7 +47,7 @@ from reconcile import (
 )
 from state import State, load_state
 from tui import launch_tui, status_lines
-from update import update_installed_skills
+from update import update_installed_package_extras, update_installed_skills
 
 AT_VERSION: Final[str] = "0.2.0"
 
@@ -85,12 +85,22 @@ def _run_update() -> int:
         subprocess.run(["git", "pull", "--ff-only"], cwd=REPO_ROOT, check=True)
     catalog: Catalog = load_catalog(_catalog_path())
     state: State = load_state(STATE_ROOT)
-    update_installed_skills(
+    updated: State = update_installed_skills(
         source_root=source_root,
         state_root=STATE_ROOT,
         claude_root=CLAUDE_ROOT,
         catalog=catalog,
         state=state,
+    )
+    # Skill bodies and package extras are the two things an install stages from source;
+    # refresh both so a newly declared or upstream-changed extra is re-staged too, not
+    # just skills. Thread the post-skill state so both passes persist one State.
+    update_installed_package_extras(
+        source_root=source_root,
+        state_root=STATE_ROOT,
+        claude_root=CLAUDE_ROOT,
+        catalog=catalog,
+        state=updated,
     )
     return 0
 

--- a/installer/tests/e2e/goldens/status_dashboard.golden
+++ b/installer/tests/e2e/goldens/status_dashboard.golden
@@ -16,4 +16,5 @@ Hooks
   ❌ demo-hook
 Drift
   demo-skill — up to date
+  demo-pack-extras (extras) — up to date
 <SOURCE_ROOT>

--- a/installer/tests/e2e/test_lifecycle_ii.py
+++ b/installer/tests/e2e/test_lifecycle_ii.py
@@ -198,3 +198,41 @@ def test_update_rescues_locally_edited_staged_copy(tmp_path: Path) -> None:
         actual=snapshot_after,
         goldens_dir=GOLDENS_DIR,
     )
+
+
+@pytest.mark.e2e
+def test_update_restages_package_extra_on_upstream_bump(tmp_path: Path) -> None:
+    home: Path = tmp_path / "home"
+    home.mkdir()
+    # A mutable copy of the frozen fixture's rule unit and its schemas extra, so the
+    # test can bump the extra's upstream source between install and update while the
+    # catalog stays frozen — the extras analogue of the skill re-stage scenario above.
+    source_root: Path = tmp_path / "src"
+    shutil.copytree(FIXTURES_DIR / "rules", source_root / "rules")
+    shutil.copytree(FIXTURES_DIR / "schemas", source_root / "schemas")
+    catalog: Path = FIXTURES_DIR / "catalog.toml"
+
+    install_result: subprocess.CompletedProcess[str] = run_at(
+        args=["install", "--package", "demo-pack-extras", "--non-interactive"],
+        home=home,
+        source_root=source_root,
+        catalog=catalog,
+    )
+    assert install_result.returncode == 0, install_result.stderr
+    staged_schema: Path = home / ".claude" / "at" / "schemas" / "demo-schema.json"
+    assert staged_schema.exists(), "install must stage the package's schemas extra"
+
+    # The extra changes upstream after install; `at update` must re-stage it.
+    (source_root / "schemas" / "demo-schema.json").write_text(
+        '{"demo": "bumped"}\n', encoding="utf-8"
+    )
+
+    update_result: subprocess.CompletedProcess[str] = run_at(
+        args=["update"],
+        home=home,
+        source_root=source_root,
+        catalog=catalog,
+    )
+    assert update_result.returncode == 0, update_result.stderr
+
+    assert staged_schema.read_text(encoding="utf-8") == '{"demo": "bumped"}\n'

--- a/installer/tests/test_at.py
+++ b/installer/tests/test_at.py
@@ -44,6 +44,7 @@ from tui import (
     package_rows,
     rule_rows,
     skill_rows,
+    status_lines,
 )
 
 
@@ -2973,3 +2974,42 @@ def test_uninstall_all_removes_whole_catalog_leaving_empty_install(
     assert not rule_link.exists() and not rule_link.is_symlink()
     assert not hook_link.exists() and not hook_link.is_symlink()
     assert not gates_extra.exists()
+
+
+def test_status_drift_reports_upstream_changed_package_extra(tmp_path: Path) -> None:
+    source_root: Path = tmp_path / "repo"
+    (source_root / "skills" / "demo").mkdir(parents=True)
+    (source_root / "skills" / "demo" / "SKILL.md").write_text(
+        "# demo\n", encoding="utf-8"
+    )
+    extra_source: Path = source_root / "extras" / "thing.txt"
+    extra_source.parent.mkdir(parents=True)
+    extra_source.write_text("original\n", encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    unit: Unit = Unit(kind="skill", name="demo")
+    catalog: Catalog = Catalog(
+        units=(unit,),
+        packages=(
+            Package(name="demo-pkg", units=(unit,), extras=("extras/thing.txt",)),
+        ),
+        bundles=(),
+    )
+    state: State = install_package(
+        name="demo-pkg",
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+
+    # The extra changes upstream after install, so the dashboard must report it drifted.
+    extra_source.write_text("revised\n", encoding="utf-8")
+
+    lines: list[str] = status_lines(
+        catalog=catalog, state=state, source_root=source_root, state_root=state_root
+    )
+
+    assert "demo-pkg (extras) — upstream changed" in "\n".join(lines)

--- a/installer/tests/test_update.py
+++ b/installer/tests/test_update.py
@@ -1,10 +1,14 @@
 from pathlib import Path
 
-from actions import install_skill
-from catalog import Catalog, Unit, skill_unit_id
+from actions import install_package, install_skill
+from catalog import Catalog, Package, Unit, skill_unit_id
 from hashing import hash_unit
 from state import State, load_state
-from update import update_installed_skills, update_skill
+from update import (
+    update_installed_package_extras,
+    update_installed_skills,
+    update_skill,
+)
 
 
 def test_update_skill_restages_upstream_change_and_refreshes_recorded_hash(
@@ -200,3 +204,138 @@ def test_update_installed_skills_updates_installed_skill_and_skips_uninstalled(
     assert (staged_a / "SKILL.md").read_text(encoding="utf-8") == updated_a
     assert skill_unit_id("demo-b") not in result.units
     assert not staged_b.exists()
+
+
+def test_update_package_extras_stages_newly_declared_extra_for_installed_package(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "demo"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    extra_source: Path = source_root / "extras" / "thing.txt"
+    extra_source.parent.mkdir(parents=True)
+    extra_source.write_text("staged support file\n", encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    unit: Unit = Unit(kind="skill", name="demo")
+    # Install the package before the extra is declared: the unit lands, no extra staged.
+    before: Catalog = Catalog(
+        units=(unit,),
+        packages=(Package(name="demo-pkg", units=(unit,), extras=()),),
+        bundles=(),
+    )
+    installed: State = install_package(
+        name="demo-pkg",
+        catalog=before,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+    # A later PR adds the extra to the already-installed package.
+    after: Catalog = Catalog(
+        units=(unit,),
+        packages=(
+            Package(name="demo-pkg", units=(unit,), extras=("extras/thing.txt",)),
+        ),
+        bundles=(),
+    )
+
+    result: State = update_installed_package_extras(
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        catalog=after,
+        state=installed,
+    )
+
+    staged: Path = state_root / "extras" / "thing.txt"
+    assert staged.read_text(encoding="utf-8") == "staged support file\n"
+    assert result.extra_hashes["extras/thing.txt"] == hash_unit(extra_source)
+    assert load_state(state_root).extra_hashes["extras/thing.txt"] == hash_unit(
+        extra_source
+    )
+    assert "extras/thing.txt" not in installed.extra_hashes
+
+
+def test_update_package_extras_restages_upstream_changed_extra_and_refreshes_hash(
+    tmp_path: Path,
+) -> None:
+    source_root: Path = tmp_path / "repo"
+    skill_source: Path = source_root / "skills" / "demo"
+    skill_source.mkdir(parents=True)
+    (skill_source / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    extra_source: Path = source_root / "extras" / "thing.txt"
+    extra_source.parent.mkdir(parents=True)
+    extra_source.write_text("original support file\n", encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    unit: Unit = Unit(kind="skill", name="demo")
+    catalog: Catalog = Catalog(
+        units=(unit,),
+        packages=(
+            Package(name="demo-pkg", units=(unit,), extras=("extras/thing.txt",)),
+        ),
+        bundles=(),
+    )
+    installed: State = install_package(
+        name="demo-pkg",
+        catalog=catalog,
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        state=State(version=1, units={}),
+    )
+    install_hash: str = installed.extra_hashes["extras/thing.txt"]
+
+    # The extra changes upstream after it was installed.
+    extra_source.write_text("revised support file\n", encoding="utf-8")
+
+    result: State = update_installed_package_extras(
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        catalog=catalog,
+        state=installed,
+    )
+
+    staged: Path = state_root / "extras" / "thing.txt"
+    assert staged.read_text(encoding="utf-8") == "revised support file\n"
+    assert result.extra_hashes["extras/thing.txt"] == hash_unit(extra_source)
+    assert result.extra_hashes["extras/thing.txt"] != install_hash
+    assert load_state(state_root).extra_hashes["extras/thing.txt"] == hash_unit(
+        extra_source
+    )
+
+
+def test_update_package_extras_skips_uninstalled_package(tmp_path: Path) -> None:
+    source_root: Path = tmp_path / "repo"
+    extra_source: Path = source_root / "extras" / "thing.txt"
+    extra_source.parent.mkdir(parents=True)
+    extra_source.write_text("must not be adopted\n", encoding="utf-8")
+
+    state_root: Path = tmp_path / "at"
+    claude_root: Path = tmp_path / "claude"
+    unit: Unit = Unit(kind="skill", name="demo")
+    # The catalog declares the package and its extra, but nothing is installed.
+    catalog: Catalog = Catalog(
+        units=(unit,),
+        packages=(
+            Package(name="demo-pkg", units=(unit,), extras=("extras/thing.txt",)),
+        ),
+        bundles=(),
+    )
+
+    result: State = update_installed_package_extras(
+        source_root=source_root,
+        state_root=state_root,
+        claude_root=claude_root,
+        catalog=catalog,
+        state=State(version=1, units={}),
+    )
+
+    assert not (state_root / "extras" / "thing.txt").exists()
+    assert "extras/thing.txt" not in result.extra_hashes

--- a/installer/tui.py
+++ b/installer/tui.py
@@ -58,7 +58,7 @@ from reconcile import (
     plan_skill_reconcile,
 )
 from state import State, load_state
-from update import skill_drift
+from update import package_extra_drift, skill_drift
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -259,6 +259,19 @@ def _drift_row(*, name: str, source_root: Path, state_root: Path, state: State) 
     return f"{name} — {_drift_label(drift=drift)}"
 
 
+def _package_extra_drift_row(
+    *, name: str, package: Package, source_root: Path, state: State
+) -> str:
+    """Report whether one installed package's staged extras still match what its install
+    recorded, reading divergence through the shared update.package_extra_drift so the
+    dashboard and an `at update` agree on which extras are current."""
+    drifted: tuple[str, ...] = package_extra_drift(
+        package=package, source_root=source_root, state=state
+    )
+    label: str = "upstream changed" if drifted else "up to date"
+    return f"{name} (extras) — {label}"
+
+
 def status_lines(
     *, catalog: Catalog, state: State, source_root: Path, state_root: Path
 ) -> list[str]:
@@ -278,7 +291,8 @@ def status_lines(
     ]
     for title, rows in grid:
         lines.extend(_section(title=title, rows=rows))
-    # Drift is skills-only, as in update.py: agents/rules/hooks carry no drift wiring.
+    # Drift covers the two things an install stages from source and an update refreshes:
+    # skill bodies and package extras. Agents/rules/hooks carry no drift wiring.
     drift_rows: list[str] = [
         _drift_row(
             name=name, source_root=source_root, state_root=state_root, state=state
@@ -286,9 +300,24 @@ def status_lines(
         for name in list_skills(catalog)
         if skill_unit_id(name) in state.units
     ]
-    # No installed skill has any drift to report, so stand in a placeholder rather than
-    # leave the section a bare title.
-    lines.extend(_section(title="Drift", rows=drift_rows or ["(none installed)"]))
+    extra_drift_rows: list[str] = [
+        _package_extra_drift_row(
+            name=name,
+            package=resolve_package(catalog, name),
+            source_root=source_root,
+            state=state,
+        )
+        for name in list_packages(catalog=catalog)
+        if package_installed(catalog=catalog, name=name, state=state)
+        and resolve_package(catalog, name).extras
+    ]
+    # No installed skill or package extra has any drift to report, so stand in a
+    # placeholder rather than leave the section a bare title.
+    lines.extend(
+        _section(
+            title="Drift", rows=drift_rows + extra_drift_rows or ["(none installed)"]
+        )
+    )
     lines.append(str(source_root))
     return lines
 

--- a/installer/update.py
+++ b/installer/update.py
@@ -1,10 +1,19 @@
 from pathlib import Path
 
-from actions import install_skill
-from catalog import Catalog, list_skills, skill_unit, skill_unit_id
+from actions import install_package, install_skill
+from catalog import (
+    Catalog,
+    Package,
+    list_packages,
+    list_skills,
+    resolve_package,
+    skill_unit,
+    skill_unit_id,
+)
 from constants import SKILLS_DIRNAME, STAGED_DIRNAME
-from hashing import Drift, detect_drift
+from hashing import Drift, detect_drift, hash_unit
 from placement import backup_staged_unit, staged_unit_path
+from reconcile import package_installed
 from state import State
 
 
@@ -68,6 +77,51 @@ def update_installed_skills(
         if skill_unit_id(name) in state.units:
             current = update_skill(
                 name=name,
+                source_root=source_root,
+                state_root=state_root,
+                claude_root=claude_root,
+                state=current,
+            )
+    return current
+
+
+def package_extra_drift(
+    *, package: Package, source_root: Path, state: State
+) -> tuple[str, ...]:
+    """The declared extras of one package whose upstream source no longer matches what
+    the install recorded — the extras an update must re-stage — so the update reconcile
+    and the status view read extra divergence from one definition. A never-recorded
+    extra (newly declared on an already installed package) reads drifted too: its absent
+    recorded hash cannot match its source. Reads currency only, never whether the
+    package is installed (that stays the refcount predicate's job)."""
+    return tuple(
+        relpath
+        for relpath in package.extras
+        if state.extra_hashes.get(relpath) != hash_unit(source_root / relpath)
+    )
+
+
+def update_installed_package_extras(
+    *,
+    source_root: Path,
+    state_root: Path,
+    claude_root: Path,
+    catalog: Catalog,
+    state: State,
+) -> State:
+    """Re-stage every drifted extra of every installed package in one pass, so an update
+    brings package support files current the same way it brings skill bodies current —
+    closing the gap where a newly declared or upstream-changed extra on an already
+    installed package was staged by neither update nor a units-only reconcile."""
+    current: State = state
+    for name in list_packages(catalog=catalog):
+        if not package_installed(catalog=catalog, name=name, state=current):
+            continue
+        package: Package = resolve_package(catalog, name)
+        if package_extra_drift(package=package, source_root=source_root, state=current):
+            current = install_package(
+                name=name,
+                catalog=catalog,
                 source_root=source_root,
                 state_root=state_root,
                 claude_root=claude_root,


### PR DESCRIPTION
## The bug

Found while installing the pr-explain quality bar (#141): after merging a PR that **adds an extra to an already-installed package** (or changes an existing one), neither `at update` nor `at install --package` stages it, and `at status` never flags it.

- `at update` refreshes **skill bodies only** (`update_installed_skills`).
- `at install --package X` short-circuits when the package reads installed — and `plan_package_reconcile` / `package_installed` decide "installed" from a package's **units only, never its extras**. Units present → both commands no-op.
- `at status` Drift is **skills-only**, so the missing/stale extra is invisible.

Concretely, this is how `templates/pr-explain.vale.ini` (added to the `pr-explain` package) and `schemas/evidence.schema.json` (added inside `architect-pr`/`lite-pr`'s `schemas` extra) went missing from an already-populated state root — the installed skills referenced files that were never staged, including the `evidence.schema.json` that `make-pr`'s Done step validates against.

## The fix

Mirrors the existing skill-drift structure exactly:

| New | Job |
|---|---|
| `package_extra_drift` | Shared predicate: which of a package's extras diverge from what the install recorded (`source hash != recorded hash`; a never-recorded new extra reads drifted too). One definition, read by both the update pass and the status view — the `skill_drift` analogue. |
| `update_installed_package_extras` | Update pass that re-stages every drifted extra of every installed package, built on the deep `install_package` so staging + state recording live in one place. Wired into `_run_update` after the skill pass. |
| status Drift rows | Installed packages that declare extras now render `name (extras) — up to date \| upstream changed`. |

**Refcount-neutral by design:** `package_installed` keeps its units-only meaning (uninstall/bundle semantics unchanged); extra *currency* lives in `update`/`status`, where "bring installed things current" belongs — not conflated into the "is it installed" predicate.

## Tests (TDD, red→green each)

- `update` stages a **newly declared** extra on an installed package.
- `update` re-stages an **upstream-changed** extra and refreshes its recorded hash.
- `update` **skips uninstalled** packages' extras (proven non-vacuous — fails with the guard removed).
- status Drift reports a package's **upstream-changed** extra.
- e2e: `at update` re-stages a bumped package extra end-to-end (fails before the `_run_update` wiring).
- e2e `status_dashboard` golden updated for the new `demo-pack-extras (extras) — up to date` row.

Gates green from `installer/`: ruff format + check, `mypy --strict`, 161 unit + 21 e2e passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LtsRdxUKd8Bk5SVYnzpfP