### PR TITLE
feat(skills): pr-breakdown draws a published PR-map artifact synced to the issue table

### DIFF
--- a/installer/catalog.toml
+++ b/installer/catalog.toml
@@ -167,6 +167,16 @@ units = [
   "skill/course-correct",
 ]
 
+# pr-breakdown publishes a PR-map artifact from the issue's PR table; its page skeleton
+# ships as a package extra so an install is self-contained. A dedicated single-skill
+# package carries the extra (like pr-explain) so the multi-skill breakdown package above
+# stays extra-free; the skill degrades to inline HTML (same chip/edge contract) when
+# installed without it. The planning bundle pulls this in so the flagship path ships it.
+[[packages]]
+name = "pr-breakdown"
+units = ["skill/pr-breakdown"]
+extras = ["templates/pr-breakdown-map.html"]
+
 [[packages]]
 name = "pr-ops"
 units = [
@@ -193,4 +203,4 @@ packages = ["architect-pr", "lite-pr"]
 
 [[bundles]]
 name = "planning"
-packages = ["breakdown"]
+packages = ["breakdown", "pr-breakdown"]

--- a/skills/breakdown/SKILL.md
+++ b/skills/breakdown/SKILL.md
@@ -14,7 +14,7 @@ growing GitHub issue**, pausing at each gate. Composes `to-prd`, `to-issues`, an
 
 Phase 1: to-prd       → creates the issue   (gates: clarify, approve)
 Phase 2: to-issues    → appends slices                 (gate: discuss)
-Phase 3: pr-breakdown → appends PR rows                (gate: approve)
+Phase 3: pr-breakdown → appends PR rows + PR-map artifact (gate: approve)
 ```
 
 Run the phases in order; start each only after the previous reports success.
@@ -36,8 +36,9 @@ Invoke `to-issues` with `--issue=N`. It appends the slice plan and reports
 
 ## Phase 3 — PR breakdown
 
-Invoke `pr-breakdown` with `--issue=N`. It appends the PRs and reports
-`PR breakdown appended to issue #N`. Stop if it reports a declined gate.
+Invoke `pr-breakdown` with `--issue=N`. It appends the PR rows, publishes the
+PR-map artifact, and reports `PR breakdown appended to issue #N` with the map URL —
+relay that URL. Stop if it reports a declined gate.
 
 ## If a gate is declined or a phase fails
 

--- a/skills/course-correct/SKILL.md
+++ b/skills/course-correct/SKILL.md
@@ -120,8 +120,9 @@ Run them in parallel (one message, many calls); collect the findings.
 **Plan edits** — each an explicit op with a one-line reason, naming the row:
 **ADD** / **REMOVE** / **RE-SCOPE** / **RE-ORDER** a slice (`#n` in Build plan —
 *Demoable as / Mode / Size / Blocked by*) or a PR row (`n.k` in PR breakdown —
-*LOC / Done when*). Rows only, no coder prompts; PRs stay ~100–200 LOC excluding
-tests.
+*What / LOC / Blocked by / Status / Done when*). Rows only, no coder prompts; PRs
+stay ~100–200 LOC excluding tests. Edits here change the table but not its PR-map
+artifact — Phase 6 flags a re-run of `/pr-breakdown` to redraw it.
 
 Always write the rebuilt **Status block** to `status.md` — even on track, since
 Phase 6 advances the checkpoint from it. Keep it flat below its heading (`###` /
@@ -203,6 +204,10 @@ gh issue edit "$ISSUE" --body-file "$OUT" \
   && rm -f "$OUT" body.txt status.md buildplan.md prbreakdown.md report.md \
   && echo "Course-correction applied to #$ISSUE"
 ```
+
+If any **PR breakdown** row changed (added, removed, re-scoped, or re-ordered), tell
+the user its PR-map artifact is now stale and to re-run `/pr-breakdown` to redraw it —
+that skill regenerates the map from the table it just edited.
 
 ## Common mistakes
 

--- a/skills/pr-breakdown/SKILL.md
+++ b/skills/pr-breakdown/SKILL.md
@@ -1,172 +1,212 @@
 ---
 name: pr-breakdown
-description: Use when a PRD issue's slice plan needs breaking into small ~100-200 LOC pull requests recorded as a table in that issue and drawn as a published PR-map artifact, or invokes /pr-breakdown.
+description: Use when a PRD issue's slice plan needs breaking into small ~100–200 LOC pull requests recorded as a table in that same issue and drawn as a private claude.ai PR-map artifact, or invokes /pr-breakdown.
 ---
 
 # PR Breakdown
 
 Break the slice plan in a PRD issue into **small PRs (~100–200 LOC, excluding
-tests)** and keep two synced views of them:
+tests)**, recorded two ways: a table in the same issue — one row per PR — and a PR map,
+a private claude.ai artifact laying the PRs out as waves, with blocked-by edges and one
+card per PR.
 
-- a **table** in the **same issue** — one row per PR, carrying its dependency, status, and size;
-- a **PR map** — a published claude.ai artifact drawing the PRs as waves with
-  blocked-by edges and a detail card each, like the one the issue links to.
-
-**The issue table is the single source of truth; the map is a projection of it.**
-Every run regenerates the map from the table, so the two never drift.
+**The table is authoritative for the rows** — the map is a projection of it, re-rendered
+every run. **Status is GitHub's** — the table caches each PR's `#NN` and the state it
+last saw.
 
 ```
 /pr-breakdown [--issue=N]
 
-  1. Find the issue, slice plan, and any existing map + statuses
-  2. Split each slice into PR rows (blocked-by + status)
-  3. Show it, wait for approval          (gate)
+  1. Find the issue, slice plan, and existing breakdown
+  2. Draft / reconcile the PR rows (blocked-by + status)
+  3. Discuss and approve                    (gate)
   4. Fill the map template from the rows
   5. Publish / update the artifact
   6. Write table + map link to the SAME issue
 ```
 
-## Phase 1 — Find the issue, plan, and existing state
-
-Use `--issue=N` if given. Otherwise scan the conversation for the last
-`PRD published: ... (issue #N)` line; if there's none, ask. If you auto-detected
-it, confirm the number with the user. Read the body.
-
-- No `## Build plan` section → **stop** and tell the user to run `/to-issues` first;
-  don't invent a breakdown.
-- Build plan says `No slicing — single PR` → emit one `### Slice 1 — <name> (1 PR)`
-  row (derive `<name>` from the PRD's *What we're building*) and continue.
-
-Then capture what a re-run must preserve, from any existing `## PR breakdown`:
-
-- The **map URL** in `<!-- pr-breakdown:map url=<url> -->`. Reuse it in Phase 5 so
-  the same artifact updates instead of a new one appearing.
-- The **Status** cell of every existing row, keyed by its `n.k` id. Carry these
-  forward — a re-run never resets a `Merged`/`In review` row back to `Todo`.
-
 ## Rules for splitting
 
-- 100–200 LOC per PR, excluding tests. Over ~200 → split further; a tiny slice may be one PR.
+- Over ~200 LOC → split further.
 - One cohesive, reviewable, demoable change per PR.
 - Foundations first: reusable primitives before the PRs that wire them up.
-- **Rows only.** Do NOT write coder prompts (module boundary, acceptance criteria,
-  etc.) — those are generated later, one PR at a time.
+- **Blocked by** — the only dependency record: an *acyclic* list, at PR grain, of the
+  `n.k` ids a PR needs merged first (finer than the slice's own *Blocked by*).
+- **Rows only.** No coder prompts (module boundary, acceptance criteria, …) —
+  generated later, one PR at a time.
 
-## Phase 2 — Draft the rows
+## Phase 1 — Find the issue, slice plan, and existing breakdown
 
-Derive each `<name>` from the slice's *What*. One table per slice:
+Use `--issue=N` if given. Otherwise scan the conversation for the last
+`PRD published: ... (issue #N)` line; if there's none, ask. Confirm an auto-detected
+number. Read the body (`gh issue view N --json body -q .body`).
+
+- No `## Build plan — vertical slices` section → **stop**; tell the user to run
+  `/to-issues` first.
+- `No slicing — single PR` under it → treat it as slice 1 with one PR `1.1` (no
+  *Mode*; the map's wave name is the goal). Its *What* and `Done when` come from the PRD's
+  *What we're building* and acceptance; `Blocked by` `—`, `Status` `Todo`.
+
+Otherwise the slices are the `## Build plan — vertical slices` table to-issues wrote —
+each row's *What* and *Blocked by* seed the PRs, and its *Mode* (`AFK` / `HITL`) marks
+whether the slice needs the human.
+
+From any existing `## PR breakdown`, capture what a re-run preserves:
+
+- **The rows.** Carry every cell forward — Phase 2 reconciles.
+- **The map URL** in `<!-- pr-breakdown:map url=<url> -->`. Reuse it in Phase 5 so the
+  same artifact updates instead of a new one appearing.
+
+## Phase 2 — Draft / reconcile the PR rows
+
+**First run (no table)** — split each Build-plan slice into PRs, `<name>` from its
+*What*, each PR's `Done when` a checkable outcome drawn from the slice's *Demoable as*.
+One table per slice:
 
 ```markdown
-## PR breakdown
-
-<!-- pr-breakdown:map url=<artifact-url, or omit the marker on the first run> -->
-🗺️ **[PR map](<artifact-url>)** — waves, blocked-by edges, and a card per PR. Regenerated from the table below.
-
 ### Slice 1 — <name> (2 PRs)
 | PR | What | LOC | Blocked by | Status | Done when |
 |----|------|-----|-----------|--------|-----------|
 | 1.1 | ... | ~120 | — | Todo | <observable result> |
 | 1.2 | ... | ~140 | 1.1 | Todo | ... |
-
-**Estimated total: ~N PRs · N waves.**
 ```
 
-- **Blocked by** — a space/comma-separated list of the `n.k` ids this PR needs
-  merged first, across *any* slice, or `—` for none. This is the only dependency
-  record; parallelism and waves are derived from it, so drop the old `∥` note.
-- **Status** — one of `Todo` · `In review #NN` · `Merged #NN`. New rows are `Todo`;
-  preserved rows keep the Phase 1 value. If a row carries a `#NN`, you may refresh it
-  from live state (`gh pr view NN --json state,merged`) — merged → `Merged #NN`, open
-  → `In review #NN`. Discovering *unrecorded* PRs is `/course-correct`'s job, not this
-  skill's.
-- **Gate PRs** — a PR whose job is validation machinery that blocks merging (a CI
-  gate, an image/deploy/e2e gate). Name it as such in *What* ("Delivery gate"); it
-  gets the `gate` styling in the map. No extra column.
+**Re-run (table exists)** — match rows to slices by slice number (its `### Slice n`
+heading, stable across renames), keep every row and cell, and change only:
 
-**Waves** are the topological layering of *Blocked by*, spanning all slices:
-`wave(pr) = 0` if it has no deps, else `1 + max(wave of its deps)`. Same-wave PRs
-share no blocking relationship — they are the map's columns and can be built at once.
+- refresh each `#NN` row's Status (below);
+- add rows for a Build-plan slice not yet represented.
 
-## Phase 3 — Approve (gate)
+Removing a dropped slice's rows, or growing a slice's PRs, is `/course-correct`'s job —
+so its edits survive this redraw.
 
-Show the full breakdown in chat — the per-slice tables plus the derived wave list
-(which PRs land together). **Wait for approval or edits** before touching the issue
-or publishing anything.
+Close the tables with **Estimated total:** ~P PRs · W waves.
+
+- **Status** — `Todo` · `In review #NN` · `Merged #NN` · `Closed #NN`. make-pr /
+  pr-babysit stamp a row's `#NN` when the PR opens. When `gh` is available, for each row
+  carrying a `#NN` run
+  `gh pr view NN --json state -q .state` and rewrite the word, keeping the `#NN`: `MERGED`
+  → `Merged`, `OPEN` → `In review`, `CLOSED` (unmerged) → `Closed`; a missing `gh` or a
+  failed call → keep the recorded value. New rows are `Todo`. Discovering *unrecorded* PRs
+  is `/course-correct`'s job.
+- **Gate PRs** — validation machinery that blocks merging (a CI / image / deploy / e2e
+  gate). Start its *What* with `Gate:` (e.g. `Gate: delivery contract`); the map keys on
+  that prefix, so nothing else needs a column.
+
+**Waves** — a topological grouping of the *Blocked by* graph (0-indexed): a PR sits one
+column right of its latest blocker (a no-blocker PR is Wave 0), so no same-wave PR blocks
+another. Same-wave PRs are the map's columns. A cycle → stop and report it; don't guess a
+layering.
+
+## Phase 3 — Discuss and approve (gate)
+
+Show the full breakdown in chat — the per-slice tables plus the derived wave list. **Wait
+for approval or edits before touching the issue.**
 
 ## Phase 4 — Fill the map template
 
-- **Template**: `~/.claude/at/templates/pr-breakdown-map.html` — design tokens plus
-  the `lane` / `chip` / `card` / edge classes and the `data-id` / `data-deps`
-  contract. Missing (or stale — prefer the repo's `templates/pr-breakdown-map.html`
-  when running inside this repo)? Still ship: build a single-file HTML page with
-  inline CSS on the same contract — chips carry `data-id`/`data-deps` and an inline
-  script draws the edges from them.
-- Write the filled page to the session scratch directory (never the target repo) as
-  `pr-map-<owner>-<repo>-<issue>.html`, owner/repo from `gh repo view`.
+**Template**: `~/.claude/at/templates/pr-breakdown-map.html` (staged), else the repo's
+`templates/pr-breakdown-map.html`; only if neither exists, hand-author a single-file page
+on the same contract. It owns the tokens, the class *definitions*, and — in its `SLOT`
+comments — the structural fill rules (`data-id` / `data-deps` / `href` / slug / id); this
+skill owns the status classes and the adot (below).
 
-Fill every `SLOT`, keeping the tokens and class names:
+Write the filled page to the session scratch directory (never the target repo) as
+`pr-map-<owner>-<repo>-<issue>.html` — owner/repo from `gh repo view --json owner,name`
+(owner is `.owner.login`), or the issue number alone if that fails.
 
-- **Header** — `owner/repo · issue #N`, a title (`<goal>, one small PR at a time`), a
-  one-paragraph summary, and 4–6 `.stat` blocks (PRs merged `x / y`, PRs planned,
-  ~LOC per PR, waves, moments that need the human).
-- **Lanes** — one `.lane` per wave, left to right; set
-  `grid-template-columns: repeat(<wave count>, 1fr)`. Each PR is a `.chip` with
-  `id="m-<slug>"`, `data-id="<slug>"`, `data-deps="<slug> <slug>"`, and `href="#<slug>"`,
-  where `<slug>` is the `n.k` id made anchor-safe (`.` → `-`, so `1.2` → `1-2`). Add
-  the status/gate class (`gate`, `done` for Merged, `active` for In review) and a
-  `<span class="adot"></span>` when a PR needs the human once. Never author edge SVG —
-  the script draws it from `data-deps`.
-- **Cards** — one `.wave` section per wave with a `.card` per PR (`id="<slug>"`):
-  keycap `PR n.k`, title, `after:` links to its blockers, the *What* as a sentence or
-  two, an optional `why`, a `Done when` list, and — only on merged PRs — an `.ev`
-  evidence line linking the PR. `gatecard` for gates, `donecard` for merged.
+Fill the `SLOT` comments by mirroring the template's example markup, supplying (every id
+— `data-id`, `data-deps`, `href`, `after:` — is the `n.k` hyphen-slugged, `1.2` → `1-2`):
+
+- **Header** — an eyebrow `owner/repo · issue #N`; a page heading `<goal>, one small PR
+  at a time` (`<goal>` from the PRD's *What we're building*); a one-paragraph plan
+  summary; four `.stat` blocks: PRs merged `x / y` (x = `Merged` rows, y = all rows), ~LOC
+  per PR (mean over all rows), `W` waves, `needs you` (pending HITL slices — a slice is
+  *pending* while its **lead PR**, its smallest `n.k`, is neither `Merged` nor `Closed`).
+- **Lanes** — one `.lane` per wave, left to right; set the lane grid to `repeat(W, 1fr)`;
+  label each wave for the slice of its earliest PR (the single-PR plan's one wave is the
+  goal).
+- **Status → class** — on the PR's chip, its card, and the card's status `tag` (class · text):
+
+  | Status | chip | card | tag |
+  |--------|------|------|-----|
+  | Merged | `done` | `donecard` | `tag done` · merged |
+  | In review | `active` | — | `tag active` · in review |
+  | Closed | `closed` | — | `tag closed` · closed |
+  | Todo, a blocker unmerged | `blocked` | — | — |
+
+  A ready Todo takes no status class. A gate adds `gate` / `gatecard` / `tag gate` · gate,
+  composed with the row above (e.g. `class="chip gate done"`). Each *pending* `HITL` slice
+  gets an `<span class="adot"></span>` on its lead-PR chip and a
+  `<span class="tag you">needs you</span>` on that card. The template legend echoes these
+  status words and the adot rule — keep them in step if you rename either.
+- **Cards** — group them into one `.wave` section per wave, same order as the lanes: its
+  `<h2>` is the wave name and its `.sub` a one-line summary of what the wave unlocks.
+- **Text** — per card:
+  - the *What* as a plain-sentence card `<p>`, plus a short title distilled from it for
+    the chip `.n` and card `<h3>`
+  - the LOC in `<span class="tag size">`
+  - an `after:` line linking each blocker's card by hyphen id (`#<slug>`, e.g. `#1-2`),
+    omitted when none
+  - the row's `Done when` as the `Done when` list, one `<li>` per outcome
+  - an `.ev` line to `https://github.com/<owner>/<repo>/pull/NN`, only when `Merged`
+  - optional: a `p.why` (why the PR is scoped this way)
+- **Map hint** — optionally fill the page-level `.map-hint` with the critical path
+  (e.g. `1.1 → 1.2 → 2.1`).
 
 ## Phase 5 — Publish / update the artifact
 
-Use the Artifact tool: title `<repo> — PR map`, favicon `🗺️` (stable across reruns),
-a one-sentence description.
+Publish with the Artifact tool: title `<repo> — PR map`, favicon `🗺️` (stable across
+reruns), a one-sentence description. The template embodies the design — no need to load
+`artifact-design`.
 
-- Reran in the same conversation → republish the same file path (keeps the URL).
-- Reran in a later session → pass the Phase 1 map URL as the `url` parameter so the
-  same artifact updates. If that fails (artifact deleted or not owned), publish
-  without `url` and let Phase 6 record the new link.
-- Artifact tool unavailable (headless/CI) → skip publishing; Phase 6 writes the table
-  with the existing URL (or none) and the report says the map wasn't refreshed.
-
-Capture the returned URL for the marker and the visible link.
+- Same conversation → republish the same file path (keeps the URL).
+- Later session → pass the Phase 1 map URL as the `url` parameter so the same artifact
+  updates. Fails (deleted or not owned) → publish without `url`; Phase 6 records the new
+  link.
+- Artifact tool unavailable (headless/CI) → skip publishing; Phase 6 writes the tables
+  with the existing URL if there is one, else no map link, and the report says the map
+  wasn't refreshed.
 
 ## Phase 6 — Write to the same issue
 
-Keep canonical order PRD → `## Build plan` → `## PR breakdown`; `## PR breakdown` is
-last and this skill owns it whole. Regenerate it — marker with the resolved URL, the
-visible map link, then the per-slice tables — so a re-run replaces it in place. The
-rebuild keys on the exact `## PR breakdown` heading; `tr -d '\r'` guards CRLF; abort on
-an empty read:
+`## PR breakdown` is the last canonical section — PRD → `## Build plan` →
+`## PR breakdown`. A `## Status` block from course-correct may precede the PRD and is
+kept, so don't use those headings in PRD prose. This skill owns the section whole:
+regenerate it as the `## PR breakdown` heading, the `<!-- pr-breakdown:map url=… -->`
+marker, the visible `🗺️ [PR map](url)` line, the per-slice tables, and the Estimated-total
+line.
+
+- **No resolved URL** — omit both the marker and the map line; never an empty `()`.
+- **Author `$NEW` with the Write tool, not an inline heredoc** — *What* / `Done when`
+  cells carry backticks and `$` a heredoc would interpolate. It starts with the
+  `## PR breakdown` heading (HEAD stops before it, or the next re-run's `awk` duplicates
+  the section).
+
+The rebuild keys on that heading; `tr -d '\r'` guards CRLF; a TAIL after the section is
+preserved; it aborts on an empty read:
 
 ```bash
-ISSUE=<the issue number>; NEW=$(mktemp)
-# ...write the new "## PR breakdown" section (marker + map link + tables) to "$NEW"...
-CUR=$(gh issue view "$ISSUE" --json body -q .body | tr -d '\r')
-[ -n "$CUR" ] || { echo "abort: empty issue body" >&2; exit 1; }
-HEAD=$(printf '%s\n' "$CUR" | awk '/^## PR breakdown/{exit} {print}')
+ISSUE=<the issue number>; NEW=<the section file you wrote with the Write tool>
+BODY=$(gh issue view "$ISSUE" --json body -q .body | tr -d '\r')
+[ -n "$BODY" ] || { echo "abort: empty issue body" >&2; exit 1; }
+[ -s "$NEW" ] || { echo "abort: empty new section" >&2; exit 1; }
+HEAD=$(printf '%s\n' "$BODY" | awk '/^## PR breakdown/{exit} {print}')
+TAIL=$(printf '%s\n' "$BODY" | awk '/^## PR breakdown/{b=1;next} b&&/^## /{b=0;t=1} t')
 OUT=$(mktemp)
-{ printf '%s\n\n' "$HEAD"; cat "$NEW"; } > "$OUT"
-gh issue edit "$ISSUE" --body-file "$OUT"
-rm -f "$NEW" "$OUT"
-echo "PR breakdown appended to issue #$ISSUE"
+{ printf '%s\n\n' "$HEAD"; printf '%s\n' "$(cat "$NEW")"; [ -n "$TAIL" ] && printf '\n%s\n' "$TAIL"; } > "$OUT"
+gh issue edit "$ISSUE" --body-file "$OUT" \
+  && rm -f "$NEW" "$OUT" \
+  && echo "PR breakdown appended to issue #$ISSUE"
 ```
 
 ## Report
 
-End with `PR breakdown appended to issue #N`, then: the map artifact URL (or that it
-wasn't refreshed and why), the PR / wave counts, and any statuses carried forward.
+End with `PR breakdown appended to issue #N`, then: the map URL (or that it wasn't
+refreshed, and why), the PR / wave counts, and any statuses carried forward.
 
 ## Common mistakes
 
 | Mistake | Fix |
 |---------|-----|
-| Editing the map by hand | The table is the source of truth; regenerate the map from it |
-| A new artifact each run | Reuse the Phase 1 map URL (`url` param) in a later session |
-| Resetting a merged row to Todo | Carry every existing Status cell forward by `n.k` id |
-| Authoring edge SVG in the map | Emit `data-deps` on chips; the inline script draws edges |
-| Coder prompts in the rows | Rows only — prompts come later, one PR at a time |
+| Authoring the edge SVG yourself | Leave `<svg class="edges">` empty — the inline script draws every edge from `data-deps` |

--- a/skills/pr-breakdown/SKILL.md
+++ b/skills/pr-breakdown/SKILL.md
@@ -1,72 +1,151 @@
 ---
 name: pr-breakdown
-description: Use when a PRD issue's slice plan needs breaking into small ~100-200 LOC pull requests recorded as sub-rows in that issue, or invokes /pr-breakdown.
+description: Use when a PRD issue's slice plan needs breaking into small ~100-200 LOC pull requests recorded as a table in that issue and drawn as a published PR-map artifact, or invokes /pr-breakdown.
 ---
 
 # PR Breakdown
 
 Break the slice plan in a PRD issue into **small PRs (~100–200 LOC, excluding
-tests)**, recorded as sub-rows in the **same issue**.
+tests)** and keep two synced views of them:
+
+- a **table** in the **same issue** — one row per PR, carrying its dependency, status, and size;
+- a **PR map** — a published claude.ai artifact drawing the PRs as waves with
+  blocked-by edges and a detail card each, like the one the issue links to.
+
+**The issue table is the single source of truth; the map is a projection of it.**
+Every run regenerates the map from the table, so the two never drift.
 
 ```
 /pr-breakdown [--issue=N]
 
-  1. Find the issue and slice plan
-  2. Split each slice into PRs
-  3. Show it, wait for approval   (gate)
-  4. Append to the SAME issue
+  1. Find the issue, slice plan, and any existing map + statuses
+  2. Split each slice into PR rows (blocked-by + status)
+  3. Show it, wait for approval          (gate)
+  4. Fill the map template from the rows
+  5. Publish / update the artifact
+  6. Write table + map link to the SAME issue
 ```
 
-## Phase 1 — Find the issue and slice plan
+## Phase 1 — Find the issue, plan, and existing state
 
 Use `--issue=N` if given. Otherwise scan the conversation for the last
 `PRD published: ... (issue #N)` line; if there's none, ask. If you auto-detected
-it, confirm the number with the user. Read the body. If it has no `## Build plan`
-section, **stop** and tell the user to run `/to-issues` first — don't invent a
-breakdown. If the Build plan says `No slicing — single PR`, emit one
-`### Slice 1 — <name> (1 PR)` row (derive `<name>` from the PRD's *What we're
-building*) and skip to Phase 3.
+it, confirm the number with the user. Read the body.
+
+- No `## Build plan` section → **stop** and tell the user to run `/to-issues` first;
+  don't invent a breakdown.
+- Build plan says `No slicing — single PR` → emit one `### Slice 1 — <name> (1 PR)`
+  row (derive `<name>` from the PRD's *What we're building*) and continue.
+
+Then capture what a re-run must preserve, from any existing `## PR breakdown`:
+
+- The **map URL** in `<!-- pr-breakdown:map url=<url> -->`. Reuse it in Phase 5 so
+  the same artifact updates instead of a new one appearing.
+- The **Status** cell of every existing row, keyed by its `n.k` id. Carry these
+  forward — a re-run never resets a `Merged`/`In review` row back to `Todo`.
 
 ## Rules for splitting
 
 - 100–200 LOC per PR, excluding tests. Over ~200 → split further; a tiny slice may be one PR.
 - One cohesive, reviewable, demoable change per PR.
 - Foundations first: reusable primitives before the PRs that wire them up.
-- Note where PRs in a slice run in parallel.
-- **Rows only.** Do NOT write coder prompts (module boundary, acceptance criteria, etc.) — those are generated later, one PR at a time.
+- **Rows only.** Do NOT write coder prompts (module boundary, acceptance criteria,
+  etc.) — those are generated later, one PR at a time.
 
-## Phase 2 — Draft sub-rows
+## Phase 2 — Draft the rows
 
-Derive each `<name>` from the slice's `What`.
+Derive each `<name>` from the slice's *What*. One table per slice:
 
 ```markdown
 ## PR breakdown
 
-### Slice <n> — <name> (<k> PRs)
-| PR | What | LOC | Done when |
-|----|------|-----|-----------|
-| n.1 | ... | ~150 | <observable result> |
-| n.2 | ... | ~120 | ... |
+<!-- pr-breakdown:map url=<artifact-url, or omit the marker on the first run> -->
+🗺️ **[PR map](<artifact-url>)** — waves, blocked-by edges, and a card per PR. Regenerated from the table below.
 
-*n.1 ∥ n.2 (independent)*
+### Slice 1 — <name> (2 PRs)
+| PR | What | LOC | Blocked by | Status | Done when |
+|----|------|-----|-----------|--------|-----------|
+| 1.1 | ... | ~120 | — | Todo | <observable result> |
+| 1.2 | ... | ~140 | 1.1 | Todo | ... |
+
+**Estimated total: ~N PRs · N waves.**
 ```
 
-End with **Estimated total: ~N PRs.**
+- **Blocked by** — a space/comma-separated list of the `n.k` ids this PR needs
+  merged first, across *any* slice, or `—` for none. This is the only dependency
+  record; parallelism and waves are derived from it, so drop the old `∥` note.
+- **Status** — one of `Todo` · `In review #NN` · `Merged #NN`. New rows are `Todo`;
+  preserved rows keep the Phase 1 value. If a row carries a `#NN`, you may refresh it
+  from live state (`gh pr view NN --json state,merged`) — merged → `Merged #NN`, open
+  → `In review #NN`. Discovering *unrecorded* PRs is `/course-correct`'s job, not this
+  skill's.
+- **Gate PRs** — a PR whose job is validation machinery that blocks merging (a CI
+  gate, an image/deploy/e2e gate). Name it as such in *What* ("Delivery gate"); it
+  gets the `gate` styling in the map. No extra column.
+
+**Waves** are the topological layering of *Blocked by*, spanning all slices:
+`wave(pr) = 0` if it has no deps, else `1 + max(wave of its deps)`. Same-wave PRs
+share no blocking relationship — they are the map's columns and can be built at once.
 
 ## Phase 3 — Approve (gate)
 
-Show the full breakdown in chat. **Wait for approval or edits** before touching
-the issue.
+Show the full breakdown in chat — the per-slice tables plus the derived wave list
+(which PRs land together). **Wait for approval or edits** before touching the issue
+or publishing anything.
 
-## Phase 4 — Append to the same issue
+## Phase 4 — Fill the map template
 
-Keep canonical order PRD → `## Build plan` → `## PR breakdown`: replace the PR
-breakdown in place, preserving everything above it. The rebuild keys on the exact
-`## PR breakdown` heading; `tr -d '\r'` guards CRLF; abort on an empty read:
+- **Template**: `~/.claude/at/templates/pr-breakdown-map.html` — design tokens plus
+  the `lane` / `chip` / `card` / edge classes and the `data-id` / `data-deps`
+  contract. Missing (or stale — prefer the repo's `templates/pr-breakdown-map.html`
+  when running inside this repo)? Still ship: build a single-file HTML page with
+  inline CSS on the same contract — chips carry `data-id`/`data-deps` and an inline
+  script draws the edges from them.
+- Write the filled page to the session scratch directory (never the target repo) as
+  `pr-map-<owner>-<repo>-<issue>.html`, owner/repo from `gh repo view`.
+
+Fill every `SLOT`, keeping the tokens and class names:
+
+- **Header** — `owner/repo · issue #N`, a title (`<goal>, one small PR at a time`), a
+  one-paragraph summary, and 4–6 `.stat` blocks (PRs merged `x / y`, PRs planned,
+  ~LOC per PR, waves, moments that need the human).
+- **Lanes** — one `.lane` per wave, left to right; set
+  `grid-template-columns: repeat(<wave count>, 1fr)`. Each PR is a `.chip` with
+  `id="m-<slug>"`, `data-id="<slug>"`, `data-deps="<slug> <slug>"`, and `href="#<slug>"`,
+  where `<slug>` is the `n.k` id made anchor-safe (`.` → `-`, so `1.2` → `1-2`). Add
+  the status/gate class (`gate`, `done` for Merged, `active` for In review) and a
+  `<span class="adot"></span>` when a PR needs the human once. Never author edge SVG —
+  the script draws it from `data-deps`.
+- **Cards** — one `.wave` section per wave with a `.card` per PR (`id="<slug>"`):
+  keycap `PR n.k`, title, `after:` links to its blockers, the *What* as a sentence or
+  two, an optional `why`, a `Done when` list, and — only on merged PRs — an `.ev`
+  evidence line linking the PR. `gatecard` for gates, `donecard` for merged.
+
+## Phase 5 — Publish / update the artifact
+
+Use the Artifact tool: title `<repo> — PR map`, favicon `🗺️` (stable across reruns),
+a one-sentence description.
+
+- Reran in the same conversation → republish the same file path (keeps the URL).
+- Reran in a later session → pass the Phase 1 map URL as the `url` parameter so the
+  same artifact updates. If that fails (artifact deleted or not owned), publish
+  without `url` and let Phase 6 record the new link.
+- Artifact tool unavailable (headless/CI) → skip publishing; Phase 6 writes the table
+  with the existing URL (or none) and the report says the map wasn't refreshed.
+
+Capture the returned URL for the marker and the visible link.
+
+## Phase 6 — Write to the same issue
+
+Keep canonical order PRD → `## Build plan` → `## PR breakdown`; `## PR breakdown` is
+last and this skill owns it whole. Regenerate it — marker with the resolved URL, the
+visible map link, then the per-slice tables — so a re-run replaces it in place. The
+rebuild keys on the exact `## PR breakdown` heading; `tr -d '\r'` guards CRLF; abort on
+an empty read:
 
 ```bash
 ISSUE=<the issue number>; NEW=$(mktemp)
-# ...write the new "## PR breakdown" section to "$NEW"...
+# ...write the new "## PR breakdown" section (marker + map link + tables) to "$NEW"...
 CUR=$(gh issue view "$ISSUE" --json body -q .body | tr -d '\r')
 [ -n "$CUR" ] || { echo "abort: empty issue body" >&2; exit 1; }
 HEAD=$(printf '%s\n' "$CUR" | awk '/^## PR breakdown/{exit} {print}')
@@ -76,3 +155,18 @@ gh issue edit "$ISSUE" --body-file "$OUT"
 rm -f "$NEW" "$OUT"
 echo "PR breakdown appended to issue #$ISSUE"
 ```
+
+## Report
+
+End with `PR breakdown appended to issue #N`, then: the map artifact URL (or that it
+wasn't refreshed and why), the PR / wave counts, and any statuses carried forward.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Editing the map by hand | The table is the source of truth; regenerate the map from it |
+| A new artifact each run | Reuse the Phase 1 map URL (`url` param) in a later session |
+| Resetting a merged row to Todo | Carry every existing Status cell forward by `n.k` id |
+| Authoring edge SVG in the map | Emit `data-deps` on chips; the inline script draws edges |
+| Coder prompts in the rows | Rows only — prompts come later, one PR at a time |

--- a/skills/pr-breakdown/SKILL.md
+++ b/skills/pr-breakdown/SKILL.md
@@ -5,63 +5,45 @@ description: Use when a PRD issue's slice plan needs breaking into small ~100–
 
 # PR Breakdown
 
-Break the slice plan in a PRD issue into **small PRs (~100–200 LOC, excluding
-tests)**, recorded two ways: a table in the same issue — one row per PR — and a PR map,
-a private claude.ai artifact laying the PRs out as waves, with blocked-by edges and one
-card per PR.
+Break the slice plan in a PRD issue into **small PRs (~100–200 LOC, excluding tests)**
+and keep two views of them: a **table** in the same issue, one row per PR, and a **PR
+map** — a private claude.ai artifact laying the PRs out as waves, with blocked-by edges
+and a card per PR.
 
-**The table is authoritative for the rows** — the map is a projection of it, re-rendered
-every run. **Status is GitHub's** — the table caches each PR's `#NN` and the state it
-last saw.
+**The table is the source of truth** — the map is drawn from it every run. **Status comes
+from GitHub** — the table caches each PR's `#NN` and the state it last saw.
 
 ```
 /pr-breakdown [--issue=N]
 
-  1. Find the issue, slice plan, and existing breakdown
-  2. Draft / reconcile the PR rows (blocked-by + status)
-  3. Discuss and approve                    (gate)
-  4. Fill the map template from the rows
-  5. Publish / update the artifact
-  6. Write table + map link to the SAME issue
+  1. Read the issue — plan, existing rows, existing map
+  2. Write the PR rows
+  3. Discuss and approve        (gate)
+  4. Draw and publish the map
+  5. Write it back to the issue
 ```
 
-## Rules for splitting
+## Phase 1 — Read the issue
 
-- Over ~200 LOC → split further.
-- One cohesive, reviewable, demoable change per PR.
-- Foundations first: reusable primitives before the PRs that wire them up.
-- **Blocked by** — the only dependency record: an *acyclic* list, at PR grain, of the
-  `n.k` ids a PR needs merged first (finer than the slice's own *Blocked by*).
-- **Rows only.** No coder prompts (module boundary, acceptance criteria, …) —
-  generated later, one PR at a time.
+Use `--issue=N` if given; else scan the conversation for the last
+`PRD published: ... (issue #N)` line, or ask. Confirm an auto-detected number. Read the
+body with `gh issue view N --json body -q .body`.
 
-## Phase 1 — Find the issue, slice plan, and existing breakdown
+No `## Build plan` section → **stop** and tell the user to run `/to-issues` first.
 
-Use `--issue=N` if given. Otherwise scan the conversation for the last
-`PRD published: ... (issue #N)` line; if there's none, ask. Confirm an auto-detected
-number. Read the body (`gh issue view N --json body -q .body`).
+The slices are that section's table: each row's *What* and *Blocked by* seed the PRs, its
+*Demoable as* seeds their `Done when`, and its *Mode* (`AFK` / `HITL`) says whether it
+needs the human. `No slicing — single PR` instead of a table means one slice, one PR.
 
-- No `## Build plan — vertical slices` section → **stop**; tell the user to run
-  `/to-issues` first.
-- `No slicing — single PR` under it → treat it as slice 1 with one PR `1.1` (no
-  *Mode*; the map's wave name is the goal). Its *What* and `Done when` come from the PRD's
-  *What we're building* and acceptance; `Blocked by` `—`, `Status` `Todo`.
+From an existing `## PR breakdown`, keep two things: **the rows** (Phase 2 builds on them)
+and **the map URL** in `<!-- pr-breakdown:map url=<url> -->` (Phase 4 updates that same
+artifact).
 
-Otherwise the slices are the `## Build plan — vertical slices` table to-issues wrote —
-each row's *What* and *Blocked by* seed the PRs, and its *Mode* (`AFK` / `HITL`) marks
-whether the slice needs the human.
+## Phase 2 — Write the PR rows
 
-From any existing `## PR breakdown`, capture what a re-run preserves:
-
-- **The rows.** Carry every cell forward — Phase 2 reconciles.
-- **The map URL** in `<!-- pr-breakdown:map url=<url> -->`. Reuse it in Phase 5 so the
-  same artifact updates instead of a new one appearing.
-
-## Phase 2 — Draft / reconcile the PR rows
-
-**First run (no table)** — split each Build-plan slice into PRs, `<name>` from its
-*What*, each PR's `Done when` a checkable outcome drawn from the slice's *Demoable as*.
-One table per slice:
+Split each slice into PRs — one cohesive, reviewable, demoable change each, foundations
+before the PRs that use them, over ~200 LOC means split again. **Rows only**: no coder
+prompts (module boundaries, acceptance criteria) — those come later, one PR at a time.
 
 ```markdown
 ### Slice 1 — <name> (2 PRs)
@@ -71,142 +53,109 @@ One table per slice:
 | 1.2 | ... | ~140 | 1.1 | Todo | ... |
 ```
 
-**Re-run (table exists)** — match rows to slices by slice number (its `### Slice n`
-heading, stable across renames), keep every row and cell, and change only:
+Close the tables with `**Estimated total:** ~P PRs · W waves.`
 
-- refresh each `#NN` row's Status (below);
-- add rows for a Build-plan slice not yet represented.
+- **Blocked by** — the `n.k` ids this PR needs merged first, from any slice, or `—`. Must
+  be acyclic; it is the only dependency record, and the waves come from it.
+- **Status** — `Todo` · `In review #NN` · `Merged #NN` · `Closed #NN`. Nothing upstream
+  writes this, so match the rows against the repo's PRs yourself — list them once with
+  `gh pr list --state all -L 200 --json number,title,state,headRefName`, then match each
+  row by its recorded `#NN`, else by a head branch carrying its `n.k` id, else by an
+  unambiguous title match. Record the number the first time it matches and set the word
+  from `state`. No `gh`, or no confident match → leave the row as it is.
+- **Gate PR** — validation machinery that blocks merging (CI, image, deploy, e2e). Start
+  its *What* with `Gate:`; the map styles it from that.
 
-Removing a dropped slice's rows, or growing a slice's PRs, is `/course-correct`'s job —
-so its edits survive this redraw.
+**On a re-run, the existing table wins.** Keep every row and cell, refresh Status, and add
+rows only for a slice that has none yet. Removing or re-scoping rows is `/course-correct`'s
+job, so its edits survive the redraw.
 
-Close the tables with **Estimated total:** ~P PRs · W waves.
-
-- **Status** — `Todo` · `In review #NN` · `Merged #NN` · `Closed #NN`. make-pr /
-  pr-babysit stamp a row's `#NN` when the PR opens. When `gh` is available, for each row
-  carrying a `#NN` run
-  `gh pr view NN --json state -q .state` and rewrite the word, keeping the `#NN`: `MERGED`
-  → `Merged`, `OPEN` → `In review`, `CLOSED` (unmerged) → `Closed`; a missing `gh` or a
-  failed call → keep the recorded value. New rows are `Todo`. Discovering *unrecorded* PRs
-  is `/course-correct`'s job.
-- **Gate PRs** — validation machinery that blocks merging (a CI / image / deploy / e2e
-  gate). Start its *What* with `Gate:` (e.g. `Gate: delivery contract`); the map keys on
-  that prefix, so nothing else needs a column.
-
-**Waves** — a topological grouping of the *Blocked by* graph (0-indexed): a PR sits one
-column right of its latest blocker (a no-blocker PR is Wave 0), so no same-wave PR blocks
-another. Same-wave PRs are the map's columns. A cycle → stop and report it; don't guess a
-layering.
+**Waves** group the *Blocked by* graph: a PR sits one column right of its latest blocker,
+so nothing in a wave blocks anything else in it. A cycle → stop and report it.
 
 ## Phase 3 — Discuss and approve (gate)
 
-Show the full breakdown in chat — the per-slice tables plus the derived wave list. **Wait
-for approval or edits before touching the issue.**
+Show the tables and the waves in chat. **Wait for approval or edits before touching the
+issue or publishing anything.**
 
-## Phase 4 — Fill the map template
+## Phase 4 — Draw and publish the map
 
-**Template**: `~/.claude/at/templates/pr-breakdown-map.html` (staged), else the repo's
-`templates/pr-breakdown-map.html`; only if neither exists, hand-author a single-file page
-on the same contract. It owns the tokens, the class *definitions*, and — in its `SLOT`
-comments — the structural fill rules (`data-id` / `data-deps` / `href` / slug / id); this
-skill owns the status classes and the adot (below).
+Fill `~/.claude/at/templates/pr-breakdown-map.html` (or the repo's copy at
+`templates/pr-breakdown-map.html`). It carries the design, the classes, and — in its
+`SLOT` comments — how chips and cards are wired; mirror its example markup and keep its
+class names. Write the filled page to the session scratch directory, never the target
+repo, as `pr-map-<owner>-<repo>-<issue>.html` (`gh repo view --json owner,name`, owner is
+`.owner.login`).
 
-Write the filled page to the session scratch directory (never the target repo) as
-`pr-map-<owner>-<repo>-<issue>.html` — owner/repo from `gh repo view --json owner,name`
-(owner is `.owner.login`), or the issue number alone if that fails.
+Neither copy present — the staged extra lags a reinstall — → **skip the map, don't
+hand-roll one**: go straight to Phase 5 so the table still lands, and tell the user to
+reinstall the `pr-breakdown` package to get it back.
 
-Fill the `SLOT` comments by mirroring the template's example markup, supplying (every id
-— `data-id`, `data-deps`, `href`, `after:` — is the `n.k` hyphen-slugged, `1.2` → `1-2`):
+What you supply:
 
-- **Header** — an eyebrow `owner/repo · issue #N`; a page heading `<goal>, one small PR
-  at a time` (`<goal>` from the PRD's *What we're building*); a one-paragraph plan
-  summary; four `.stat` blocks: PRs merged `x / y` (x = `Merged` rows, y = all rows), ~LOC
-  per PR (mean over all rows), `W` waves, `needs you` (pending HITL slices — a slice is
-  *pending* while its **lead PR**, its smallest `n.k`, is neither `Merged` nor `Closed`).
-- **Lanes** — one `.lane` per wave, left to right; set the lane grid to `repeat(W, 1fr)`;
-  label each wave for the slice of its earliest PR (the single-PR plan's one wave is the
-  goal).
-- **Status → class** — on the PR's chip, its card, and the card's status `tag` (class · text):
+- **Header** — `owner/repo · issue #N`, a title (`<goal>, one small PR at a time`), a
+  paragraph on the plan, and stats: PRs merged `x / y`, ~LOC per PR, wave count, and how
+  many slices need the human.
+- **Lanes** — one per wave, left to right, named for what the wave unlocks ("The seed",
+  "Fan out"). Every chip carries `data-deps` naming its blockers; the page's own script
+  draws the edges from those, so never hand-author edge SVG.
+- **Cards** — one per PR, grouped into a section per wave: what it does in plain words,
+  why it's scoped that way if that isn't obvious, its blockers, its `Done when`, its LOC,
+  and a link to the PR once merged.
+- **Status → class** — on the chip, and on its card:
 
-  | Status | chip | card | tag |
-  |--------|------|------|-----|
-  | Merged | `done` | `donecard` | `tag done` · merged |
-  | In review | `active` | — | `tag active` · in review |
-  | Closed | `closed` | — | `tag closed` · closed |
-  | Todo, a blocker unmerged | `blocked` | — | — |
+  | Status | chip | card |
+  |--------|------|------|
+  | Merged | `done` | `donecard` + `tag done` |
+  | In review | `active` | `tag active` |
+  | Closed | `closed` | `tag closed` |
+  | Todo, still blocked | `blocked` | — |
+  | Todo, ready | — | — |
 
-  A ready Todo takes no status class. A gate adds `gate` / `gatecard` / `tag gate` · gate,
-  composed with the row above (e.g. `class="chip gate done"`). Each *pending* `HITL` slice
-  gets an `<span class="adot"></span>` on its lead-PR chip and a
-  `<span class="tag you">needs you</span>` on that card. The template legend echoes these
-  status words and the adot rule — keep them in step if you rename either.
-- **Cards** — group them into one `.wave` section per wave, same order as the lanes: its
-  `<h2>` is the wave name and its `.sub` a one-line summary of what the wave unlocks.
-- **Text** — per card:
-  - the *What* as a plain-sentence card `<p>`, plus a short title distilled from it for
-    the chip `.n` and card `<h3>`
-  - the LOC in `<span class="tag size">`
-  - an `after:` line linking each blocker's card by hyphen id (`#<slug>`, e.g. `#1-2`),
-    omitted when none
-  - the row's `Done when` as the `Done when` list, one `<li>` per outcome
-  - an `.ev` line to `https://github.com/<owner>/<repo>/pull/NN`, only when `Merged`
-  - optional: a `p.why` (why the PR is scoped this way)
-- **Map hint** — optionally fill the page-level `.map-hint` with the critical path
-  (e.g. `1.1 → 1.2 → 2.1`).
+  A gate adds `gate` / `gatecard` / `tag gate` on top. A `HITL` slice gets an
+  `<span class="adot"></span>` on its first chip and a `needs you` tag on that card.
 
-## Phase 5 — Publish / update the artifact
+Publish with the Artifact tool — title `<repo> — PR map`, favicon `🗺️`, one-sentence
+description. Reuse the Phase 1 map URL as the `url` parameter so the same artifact
+updates; if that fails, publish fresh and record the new link. No Artifact tool
+(headless) → skip it, keep any existing link, and say so in the report.
 
-Publish with the Artifact tool: title `<repo> — PR map`, favicon `🗺️` (stable across
-reruns), a one-sentence description. The template embodies the design — no need to load
-`artifact-design`.
+## Phase 5 — Write it back to the issue
 
-- Same conversation → republish the same file path (keeps the URL).
-- Later session → pass the Phase 1 map URL as the `url` parameter so the same artifact
-  updates. Fails (deleted or not owned) → publish without `url`; Phase 6 records the new
-  link.
-- Artifact tool unavailable (headless/CI) → skip publishing; Phase 6 writes the tables
-  with the existing URL if there is one, else no map link, and the report says the map
-  wasn't refreshed.
+`## PR breakdown` is the issue's last section (PRD → `## Build plan` → `## PR breakdown`;
+a `## Status` block from course-correct may sit above the PRD and is preserved). This
+skill owns that section whole and rewrites it as: the heading, the map marker, a visible
+`🗺️ [PR map](url)` line, then the tables. With no URL, drop the marker and the link rather
+than emitting an empty one.
 
-## Phase 6 — Write to the same issue
-
-`## PR breakdown` is the last canonical section — PRD → `## Build plan` →
-`## PR breakdown`. A `## Status` block from course-correct may precede the PRD and is
-kept, so don't use those headings in PRD prose. This skill owns the section whole:
-regenerate it as the `## PR breakdown` heading, the `<!-- pr-breakdown:map url=… -->`
-marker, the visible `🗺️ [PR map](url)` line, the per-slice tables, and the Estimated-total
-line.
-
-- **No resolved URL** — omit both the marker and the map line; never an empty `()`.
-- **Author `$NEW` with the Write tool, not an inline heredoc** — *What* / `Done when`
-  cells carry backticks and `$` a heredoc would interpolate. It starts with the
-  `## PR breakdown` heading (HEAD stops before it, or the next re-run's `awk` duplicates
-  the section).
-
-The rebuild keys on that heading; `tr -d '\r'` guards CRLF; a TAIL after the section is
-preserved; it aborts on an empty read:
+**Write the section with the Write tool, not a heredoc** — *What* and `Done when` cells
+carry backticks and `$` that a heredoc would interpolate into the issue.
 
 ```bash
-ISSUE=<the issue number>; NEW=<the section file you wrote with the Write tool>
+ISSUE=<the issue number>; NEW=<the section file you just wrote>
 BODY=$(gh issue view "$ISSUE" --json body -q .body | tr -d '\r')
 [ -n "$BODY" ] || { echo "abort: empty issue body" >&2; exit 1; }
-[ -s "$NEW" ] || { echo "abort: empty new section" >&2; exit 1; }
+[ -s "$NEW" ]  || { echo "abort: empty new section" >&2; exit 1; }
 HEAD=$(printf '%s\n' "$BODY" | awk '/^## PR breakdown/{exit} {print}')
 TAIL=$(printf '%s\n' "$BODY" | awk '/^## PR breakdown/{b=1;next} b&&/^## /{b=0;t=1} t')
 OUT=$(mktemp)
 { printf '%s\n\n' "$HEAD"; printf '%s\n' "$(cat "$NEW")"; [ -n "$TAIL" ] && printf '\n%s\n' "$TAIL"; } > "$OUT"
 gh issue edit "$ISSUE" --body-file "$OUT" \
-  && rm -f "$NEW" "$OUT" \
+  && rm -f "$OUT" \
   && echo "PR breakdown appended to issue #$ISSUE"
 ```
 
+`$NEW` must start with the `## PR breakdown` heading — `HEAD` stops before it, so without
+it the next run can't find the section and appends a duplicate.
+
 ## Report
 
-End with `PR breakdown appended to issue #N`, then: the map URL (or that it wasn't
-refreshed, and why), the PR / wave counts, and any statuses carried forward.
+End with `PR breakdown appended to issue #N`, then the map URL, the PR and wave counts,
+and anything you carried forward or couldn't refresh.
 
 ## Common mistakes
 
 | Mistake | Fix |
 |---------|-----|
-| Authoring the edge SVG yourself | Leave `<svg class="edges">` empty — the inline script draws every edge from `data-deps` |
+| Hand-authoring the edge SVG | Leave `<svg class="edges">` empty — the page's script draws edges from `data-deps` |
+| Rebuilding rows from the Build plan on a re-run | The table wins; keep every cell and only add what's missing |

--- a/templates/pr-breakdown-map.html
+++ b/templates/pr-breakdown-map.html
@@ -79,6 +79,8 @@
   .keydemo { font: 600 .66rem/1 var(--mono); border: 1px solid var(--line); border-bottom-width: 3px; border-radius: 6px; padding: 3px 7px; background: var(--card); }
   .keydemo.gate { border-color: var(--accent); }
   .keydemo.done { border-color: var(--accent); color: var(--accent); }
+  .keydemo.closed { opacity: .55; text-decoration: line-through; }
+  .keydemo.active { border-color: var(--blue); color: var(--blue); }
   .lg .adot { width: 8px; height: 8px; border-radius: 50%; background: var(--amber); }
   .sw { width: 22px; height: 0; border-top: 2px solid var(--line); border-radius: 2px; }
   .sw.dep { border-top-width: 2.5px; border-color: var(--accent); }
@@ -104,6 +106,8 @@
   .chip.done::after { content: "\2713"; position: absolute; top: 6px; right: 8px; font: 800 .72rem/1 var(--sans); color: var(--accent); }
   .chip.active { border-color: var(--blue); }
   .chip.blocked { opacity: .55; }
+  .chip.closed { opacity: .5; }
+  .chip.closed .n { text-decoration: line-through; }
 
   svg.edges { position: absolute; inset: 0; z-index: 1; width: 100%; height: 100%; pointer-events: none; }
   .edge { fill: none; stroke: var(--line); stroke-width: 1.5; }
@@ -138,6 +142,7 @@
   .tag.gate { background: var(--accent-soft); color: var(--accent); }
   .tag.done { background: var(--accent-soft); color: var(--accent); }
   .tag.active { background: var(--blue-soft); color: var(--blue); }
+  .tag.closed { background: var(--chip); color: var(--muted); border: 1px solid var(--line); }
   .tag.you { background: var(--amber-soft); color: var(--amber); }
   .tag.size { background: var(--chip); color: var(--muted); border: 1px solid var(--line);
     text-transform: none; letter-spacing: .02em; font-family: var(--mono); }
@@ -171,10 +176,10 @@
     <p class="lede"><!-- SLOT: one-paragraph summary of the plan; use <b> for the load-bearing phrase --></p>
     <div class="stats">
       <!-- SLOT: 4-6 .stat blocks, e.g.:
-        <div class="stat"><div class="v">0 / 12</div><div class="l">PRs landed</div></div>
-        <div class="stat"><div class="v">12</div><div class="l">PRs planned</div></div>
-        <div class="stat"><div class="v">~140</div><div class="l">lines per PR</div></div>
-        <div class="stat"><div class="v">4</div><div class="l">waves</div></div> -->
+        <div class="stat"><div class="v">0 / 12</div><div class="l">PRs merged</div></div>
+        <div class="stat"><div class="v">~140</div><div class="l">LOC per PR</div></div>
+        <div class="stat"><div class="v">4</div><div class="l">waves</div></div>
+        <div class="stat"><div class="v">1</div><div class="l">needs you</div></div> -->
     </div>
   </header>
 
@@ -187,13 +192,15 @@
     <div class="legend">
       <span class="lg"><span class="keydemo">1.2</span> PR</span>
       <span class="lg"><span class="keydemo gate">1.4</span> gate — blocks merging</span>
+      <span class="lg"><span class="keydemo active">2.2</span> in review</span>
       <span class="lg"><span class="keydemo done">&#10003;</span> merged</span>
+      <span class="lg"><span class="keydemo closed">1.9</span> closed, unmerged</span>
       <span class="lg"><span class="adot"></span> needs you once</span>
       <span class="lg"><span class="sw dep"></span> blocked-by edge</span>
     </div>
 
-    <!-- The script sizes .lanes columns from the number of .lane children; set
-         grid-template-columns to repeat(<wave count>, 1fr). -->
+    <!-- Set grid-template-columns to repeat(<wave count>, 1fr) — one column per wave.
+         The script does NOT size the columns; the fill must. -->
     <div class="map-wrap">
       <div class="map-inner" id="mapInner">
         <svg class="edges" id="edgeSvg" aria-hidden="true"></svg>
@@ -201,9 +208,9 @@
           <!-- SLOT: one .lane per wave, left to right. Each chip:
                - id="m-<id>" data-id="<id>"  (id is the PR row id, slug-safe: "1.2" -> "1-2")
                - data-deps="<id> <id>"       (space-separated ids this PR is blocked by; omit if none)
-               - class "gate" | "done" | "active" | "blocked" as the status warrants
+               - the status class the skill's Status->class map assigns (that map is the skill's, not the template's)
                - href="#<id>" jumps to the detail card
-               - append <span class="adot"></span> when the PR needs the human once
+               - append <span class="adot"></span> where the skill's map directs (it owns the "needs you" rule)
             <div class="lane">
               <div class="lane-h"><span class="wv">Wave 0</span><span class="wt">The seed</span></div>
               <a class="chip" id="m-1-1" data-id="1-1" href="#1-1"><span class="k">PR 1.1</span><span class="n">Walking skeleton</span></a>
@@ -222,7 +229,7 @@
 
 <div class="narrow waves">
   <!-- SLOT: one <section class="wave"> per wave, in the same order as the lanes.
-       Card classes mirror the chip: gatecard for a gate, donecard for a merged PR.
+       Card classes mirror the chip's status classes (per the skill's Status->class map).
     <section class="wave">
       <div class="wave-head"><span class="eyebrow">Wave 1</span><h2>Fan out</h2></div>
       <p class="sub">One-line summary of what this wave opens up.</p>
@@ -231,7 +238,7 @@
           <div class="card-top">
             <span class="keycap">PR 1.2</span><h3>The PR gate</h3>
             <span class="spacer"></span>
-            <span class="tag gate">gate · blocks merge</span><span class="tag size">~40 lines</span>
+            <span class="tag gate">gate</span><span class="tag size">~40 lines</span>
           </div>
           <p class="after">after: <a href="#1-1">PR 1.1</a></p>
           <p>What the PR does, in a sentence or two of plain words.</p>
@@ -239,7 +246,7 @@
           <div class="done"><div class="dh">Done when</div><ul>
             <li>An observable, checkable outcome.</li>
           </ul>
-          <div class="ev">Landed: <a href="#">PR #NN</a> — one line of evidence (only on merged PRs).</div>
+          <div class="ev">Landed: <a href="https://github.com/&lt;owner&gt;/&lt;repo&gt;/pull/NN">PR #NN</a> — one line of evidence (only on merged PRs).</div>
           </div>
         </article>
       </div>

--- a/templates/pr-breakdown-map.html
+++ b/templates/pr-breakdown-map.html
@@ -153,12 +153,13 @@
   .card p { margin: .5rem 0; max-width: 72ch; }
   .card p.why { color: var(--muted); font-size: .88rem; }
 
-  .done { margin-top: 12px; border: 1px solid var(--line); border-radius: 10px; background: var(--bg); padding: 10px 14px; }
-  .done .dh { font: 600 .66rem/1 var(--mono); letter-spacing: .09em; text-transform: uppercase; color: var(--muted); margin-bottom: 6px; }
-  .done ul { list-style: none; margin: 0; padding: 0; }
-  .done li { position: relative; padding: 3px 0 3px 22px; font-size: .85rem; line-height: 1.5; }
-  .done li::before { content: "\2713"; position: absolute; left: 2px; top: 3px; color: var(--accent); font-weight: 700; }
-  .done code, .card code { font: 500 .82em var(--mono); background: var(--chip); border: 1px solid var(--line); border-radius: 5px; padding: 1px 5px; white-space: nowrap; }
+  /* .donewhen, not .done — a bare .done would out-cascade .chip/.tag/.keydemo status classes. */
+  .donewhen { margin-top: 12px; border: 1px solid var(--line); border-radius: 10px; background: var(--bg); padding: 10px 14px; }
+  .donewhen .dh { font: 600 .66rem/1 var(--mono); letter-spacing: .09em; text-transform: uppercase; color: var(--muted); margin-bottom: 6px; }
+  .donewhen ul { list-style: none; margin: 0; padding: 0; }
+  .donewhen li { position: relative; padding: 3px 0 3px 22px; font-size: .85rem; line-height: 1.5; }
+  .donewhen li::before { content: "\2713"; position: absolute; left: 2px; top: 3px; color: var(--accent); font-weight: 700; }
+  .donewhen code, .card code { font: 500 .82em var(--mono); background: var(--chip); border: 1px solid var(--line); border-radius: 5px; padding: 1px 5px; white-space: nowrap; }
   .ev { margin-top: 9px; padding-top: 8px; border-top: 1px dashed var(--line); font-size: .82rem; line-height: 1.5; color: var(--muted); }
   .ev a { color: var(--accent); border-bottom: 1px dotted var(--accent); }
   .ev a:hover { text-decoration: none; }
@@ -243,7 +244,7 @@
           <p class="after">after: <a href="#1-1">PR 1.1</a></p>
           <p>What the PR does, in a sentence or two of plain words.</p>
           <p class="why">Why it exists / why it is scoped this way (optional).</p>
-          <div class="done"><div class="dh">Done when</div><ul>
+          <div class="donewhen"><div class="dh">Done when</div><ul>
             <li>An observable, checkable outcome.</li>
           </ul>
           <div class="ev">Landed: <a href="https://github.com/&lt;owner&gt;/&lt;repo&gt;/pull/NN">PR #NN</a> — one line of evidence (only on merged PRs).</div>

--- a/templates/pr-breakdown-map.html
+++ b/templates/pr-breakdown-map.html
@@ -1,0 +1,318 @@
+<!-- pr-breakdown map skeleton. The skill fills every SLOT comment: header stats, one
+     .lane per wave (chips carry data-id + data-deps), and one detail .card per PR.
+     Tokens, class names, and the data-id/data-deps contract are what the skill's
+     Publish phase keys on — keep them stable. Self-contained: no external requests.
+     Deliberately a fragment (no DOCTYPE/head/meta): the Artifact publisher wraps the
+     file in its own doctype + head skeleton (charset and viewport included), so the
+     template must not declare them — do not "fix" this.
+     Edges are NOT authored: the inline script reads data-deps and draws them, so the
+     skill never computes coordinates — it only declares which PR each chip is blocked by. -->
+<title><!-- SLOT: <repo> — PR map --></title>
+<style>
+  :root {
+    --bg: #F4F7F3; --card: #FFFFFF; --ink: #17231D; --muted: #566A5E; --line: #D9E2D8;
+    --accent: #1E5B41; --accent-soft: #E2EEE7;
+    --blue: #3D6591; --blue-soft: #E6EEF6;
+    --red: #AF3A2D; --red-soft: #F7E8E5;
+    --amber: #8C6A0E; --amber-soft: #F4ECD6;
+    --chip: #FAFCF9;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0F1512; --card: #171F1A; --ink: #E6ECE7; --muted: #98A79C; --line: #28322B;
+      --accent: #5CBB8E; --accent-soft: #1B2F25;
+      --blue: #84A7D3; --blue-soft: #1B2836;
+      --red: #E08273; --red-soft: #34201A;
+      --amber: #D4AC52; --amber-soft: #2E2815;
+      --chip: #131A16;
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #F4F7F3; --card: #FFFFFF; --ink: #17231D; --muted: #566A5E; --line: #D9E2D8;
+    --accent: #1E5B41; --accent-soft: #E2EEE7;
+    --blue: #3D6591; --blue-soft: #E6EEF6;
+    --red: #AF3A2D; --red-soft: #F7E8E5;
+    --amber: #8C6A0E; --amber-soft: #F4ECD6;
+    --chip: #FAFCF9;
+  }
+  :root[data-theme="dark"] {
+    --bg: #0F1512; --card: #171F1A; --ink: #E6ECE7; --muted: #98A79C; --line: #28322B;
+    --accent: #5CBB8E; --accent-soft: #1B2F25;
+    --blue: #84A7D3; --blue-soft: #1B2836;
+    --red: #E08273; --red-soft: #34201A;
+    --amber: #D4AC52; --amber-soft: #2E2815;
+    --chip: #131A16;
+  }
+
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } * { transition: none !important; } }
+  body { margin: 0; background: var(--bg); color: var(--ink); font: 400 15px/1.6 var(--sans);
+    -webkit-font-smoothing: antialiased; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  a:focus-visible, .chip:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 6px; }
+
+  .wrap { max-width: 1240px; margin: 0 auto; padding: 0 24px; }
+  .narrow { max-width: 880px; margin: 0 auto; padding: 0 24px; }
+
+  /* ---------- header ---------- */
+  header { padding: 44px 0 8px; }
+  .eyebrow { font: 600 .72rem/1 var(--mono); letter-spacing: .1em; text-transform: uppercase; color: var(--muted); }
+  h1 { font-size: clamp(1.5rem, 3vw, 2rem); font-weight: 750; letter-spacing: -.015em; margin: .45rem 0 .6rem; text-wrap: balance; }
+  .lede { color: var(--muted); max-width: 64ch; margin: 0; }
+  .lede b { color: var(--ink); font-weight: 600; }
+  .stats { display: flex; flex-wrap: wrap; gap: 10px; margin: 22px 0 0; }
+  .stat { background: var(--card); border: 1px solid var(--line); border-radius: 10px; padding: 10px 16px; min-width: 108px; }
+  .stat .v { font: 650 1.15rem/1.2 var(--sans); font-variant-numeric: tabular-nums; }
+  .stat .l { font: 500 .72rem/1.3 var(--sans); color: var(--muted); letter-spacing: .02em; }
+
+  /* ---------- map ---------- */
+  .map-section { margin-top: 40px; }
+  h2 { font-size: 1.26rem; font-weight: 700; letter-spacing: -.01em; margin: 0 0 4px; }
+  .sub { color: var(--muted); margin: 0 0 16px; max-width: 72ch; }
+
+  .legend { display: flex; flex-wrap: wrap; gap: 12px 20px; margin: 0 0 14px; font-size: .78rem; color: var(--muted); align-items: center; }
+  .lg { display: inline-flex; align-items: center; gap: 7px; }
+  .keydemo { font: 600 .66rem/1 var(--mono); border: 1px solid var(--line); border-bottom-width: 3px; border-radius: 6px; padding: 3px 7px; background: var(--card); }
+  .keydemo.gate { border-color: var(--accent); }
+  .keydemo.done { border-color: var(--accent); color: var(--accent); }
+  .lg .adot { width: 8px; height: 8px; border-radius: 50%; background: var(--amber); }
+  .sw { width: 22px; height: 0; border-top: 2px solid var(--line); border-radius: 2px; }
+  .sw.dep { border-top-width: 2.5px; border-color: var(--accent); }
+
+  .map-wrap { border: 1px solid var(--line); border-radius: 14px; background: var(--card); overflow-x: auto; padding: 4px; }
+  .map-inner { position: relative; min-width: 1000px; padding: 18px 22px 26px; }
+  .lanes { position: relative; z-index: 2; display: grid; gap: 0 34px; }
+  .lane { display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+  .lane-h { border-bottom: 1px solid var(--line); padding-bottom: 8px; margin-bottom: 6px; }
+  .lane-h .wv { display: block; font: 600 .64rem/1 var(--mono); letter-spacing: .09em; text-transform: uppercase; color: var(--muted); }
+  .lane-h .wt { display: block; font-weight: 650; font-size: .86rem; margin-top: 4px; }
+
+  .chip { position: relative; z-index: 2; display: block; background: var(--chip);
+    border: 1px solid var(--line); border-radius: 9px; padding: 7px 10px 8px;
+    color: var(--ink); line-height: 1.25; transition: opacity .15s, box-shadow .15s; }
+  .chip:hover { text-decoration: none; box-shadow: 0 1px 6px rgba(0,0,0,.08); }
+  .chip .k { display: inline-block; font: 650 .64rem/1 var(--mono); letter-spacing: .03em; color: var(--muted); margin-bottom: 3px; }
+  .chip .n { display: block; font-size: .8rem; font-weight: 550; }
+  .chip.gate { border-color: var(--accent); background: var(--accent-soft); }
+  .chip.gate .k { color: var(--accent); }
+  .chip .adot { position: absolute; top: 8px; right: 8px; width: 8px; height: 8px; border-radius: 50%; background: var(--amber); }
+  .chip.done { border-color: var(--accent); }
+  .chip.done::after { content: "\2713"; position: absolute; top: 6px; right: 8px; font: 800 .72rem/1 var(--sans); color: var(--accent); }
+  .chip.active { border-color: var(--blue); }
+  .chip.blocked { opacity: .55; }
+
+  svg.edges { position: absolute; inset: 0; z-index: 1; width: 100%; height: 100%; pointer-events: none; }
+  .edge { fill: none; stroke: var(--line); stroke-width: 1.5; }
+  .edge.gate { stroke: var(--accent); stroke-width: 2; }
+  .edot { fill: var(--line); }
+  .edot.gate { fill: var(--accent); }
+  .map-inner.focus .edge:not(.on) { opacity: .1; }
+  .map-inner.focus .edot:not(.on) { opacity: .1; }
+  .map-inner.focus .chip:not(.lit) { opacity: .3; }
+  .map-hint { font-size: .78rem; color: var(--muted); margin: 10px 2px 0; }
+
+  /* ---------- detail waves ---------- */
+  .waves { margin-top: 52px; }
+  .wave { margin: 0 0 46px; }
+  .wave-head { display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; margin-bottom: 2px; }
+  .wave-head .eyebrow { color: var(--accent); }
+  .cards { display: grid; gap: 14px; margin-top: 16px; }
+
+  .card { background: var(--card); border: 1px solid var(--line); border-radius: 13px;
+    padding: 18px 20px 16px; scroll-margin-top: 24px; }
+  .card.gatecard { border-color: var(--accent); }
+  .card.donecard { border-left: 3px solid var(--accent); }
+  .card-top { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 8px; }
+  .keycap { font: 650 .74rem/1 var(--mono); letter-spacing: .03em;
+    border: 1px solid var(--line); border-bottom-width: 3px; border-radius: 7px;
+    padding: 4px 9px 5px; background: var(--chip); flex-shrink: 0; }
+  .gatecard .keycap { border-color: var(--accent); color: var(--accent); }
+  .card-top h3 { font-size: 1rem; font-weight: 650; margin: 0; letter-spacing: -.005em; }
+  .card-top .spacer { flex: 1; }
+  .tag { font: 600 .64rem/1 var(--sans); letter-spacing: .05em; text-transform: uppercase;
+    border-radius: 99px; padding: 4px 9px; white-space: nowrap; }
+  .tag.gate { background: var(--accent-soft); color: var(--accent); }
+  .tag.done { background: var(--accent-soft); color: var(--accent); }
+  .tag.active { background: var(--blue-soft); color: var(--blue); }
+  .tag.you { background: var(--amber-soft); color: var(--amber); }
+  .tag.size { background: var(--chip); color: var(--muted); border: 1px solid var(--line);
+    text-transform: none; letter-spacing: .02em; font-family: var(--mono); }
+
+  .after { font-size: .76rem; color: var(--muted); margin: 0 0 10px; font-family: var(--mono); }
+  .after a { color: var(--muted); border-bottom: 1px dotted var(--muted); }
+  .after a:hover { color: var(--accent); text-decoration: none; border-color: var(--accent); }
+  .card p { margin: .5rem 0; max-width: 72ch; }
+  .card p.why { color: var(--muted); font-size: .88rem; }
+
+  .done { margin-top: 12px; border: 1px solid var(--line); border-radius: 10px; background: var(--bg); padding: 10px 14px; }
+  .done .dh { font: 600 .66rem/1 var(--mono); letter-spacing: .09em; text-transform: uppercase; color: var(--muted); margin-bottom: 6px; }
+  .done ul { list-style: none; margin: 0; padding: 0; }
+  .done li { position: relative; padding: 3px 0 3px 22px; font-size: .85rem; line-height: 1.5; }
+  .done li::before { content: "\2713"; position: absolute; left: 2px; top: 3px; color: var(--accent); font-weight: 700; }
+  .done code, .card code { font: 500 .82em var(--mono); background: var(--chip); border: 1px solid var(--line); border-radius: 5px; padding: 1px 5px; white-space: nowrap; }
+  .ev { margin-top: 9px; padding-top: 8px; border-top: 1px dashed var(--line); font-size: .82rem; line-height: 1.5; color: var(--muted); }
+  .ev a { color: var(--accent); border-bottom: 1px dotted var(--accent); }
+  .ev a:hover { text-decoration: none; }
+
+  @media (max-width: 640px) {
+    .wrap, .narrow { padding: 0 16px; }
+    header { padding-top: 30px; }
+  }
+</style>
+
+<div class="wrap">
+  <header>
+    <span class="eyebrow"><!-- SLOT: owner/repo · issue #N --></span>
+    <h1><!-- SLOT: plan title, e.g. "<goal>, one small PR at a time" --></h1>
+    <p class="lede"><!-- SLOT: one-paragraph summary of the plan; use <b> for the load-bearing phrase --></p>
+    <div class="stats">
+      <!-- SLOT: 4-6 .stat blocks, e.g.:
+        <div class="stat"><div class="v">0 / 12</div><div class="l">PRs landed</div></div>
+        <div class="stat"><div class="v">12</div><div class="l">PRs planned</div></div>
+        <div class="stat"><div class="v">~140</div><div class="l">lines per PR</div></div>
+        <div class="stat"><div class="v">4</div><div class="l">waves</div></div> -->
+    </div>
+  </header>
+
+  <section class="map-section">
+    <h2>The map</h2>
+    <p class="sub">Waves run left to right. Anything in the same column can be built at the same
+    time. Hover a card to see what blocks it and what it unblocks; click to jump to its full
+    description below.</p>
+
+    <div class="legend">
+      <span class="lg"><span class="keydemo">1.2</span> PR</span>
+      <span class="lg"><span class="keydemo gate">1.4</span> gate — blocks merging</span>
+      <span class="lg"><span class="keydemo done">&#10003;</span> merged</span>
+      <span class="lg"><span class="adot"></span> needs you once</span>
+      <span class="lg"><span class="sw dep"></span> blocked-by edge</span>
+    </div>
+
+    <!-- The script sizes .lanes columns from the number of .lane children; set
+         grid-template-columns to repeat(<wave count>, 1fr). -->
+    <div class="map-wrap">
+      <div class="map-inner" id="mapInner">
+        <svg class="edges" id="edgeSvg" aria-hidden="true"></svg>
+        <div class="lanes" style="grid-template-columns: repeat(1, 1fr);">
+          <!-- SLOT: one .lane per wave, left to right. Each chip:
+               - id="m-<id>" data-id="<id>"  (id is the PR row id, slug-safe: "1.2" -> "1-2")
+               - data-deps="<id> <id>"       (space-separated ids this PR is blocked by; omit if none)
+               - class "gate" | "done" | "active" | "blocked" as the status warrants
+               - href="#<id>" jumps to the detail card
+               - append <span class="adot"></span> when the PR needs the human once
+            <div class="lane">
+              <div class="lane-h"><span class="wv">Wave 0</span><span class="wt">The seed</span></div>
+              <a class="chip" id="m-1-1" data-id="1-1" href="#1-1"><span class="k">PR 1.1</span><span class="n">Walking skeleton</span></a>
+            </div>
+            <div class="lane">
+              <div class="lane-h"><span class="wv">Wave 1</span><span class="wt">Fan out</span></div>
+              <a class="chip gate" id="m-1-2" data-id="1-2" data-deps="1-1" href="#1-2"><span class="k">PR 1.2</span><span class="n">The PR gate</span></a>
+            </div>
+          -->
+        </div>
+      </div>
+    </div>
+    <p class="map-hint"><!-- SLOT: optional critical-path note, e.g. "Critical path: 1.1 → 1.2 → 2.1 (5 PRs deep)." --></p>
+  </section>
+</div>
+
+<div class="narrow waves">
+  <!-- SLOT: one <section class="wave"> per wave, in the same order as the lanes.
+       Card classes mirror the chip: gatecard for a gate, donecard for a merged PR.
+    <section class="wave">
+      <div class="wave-head"><span class="eyebrow">Wave 1</span><h2>Fan out</h2></div>
+      <p class="sub">One-line summary of what this wave opens up.</p>
+      <div class="cards">
+        <article class="card gatecard" id="1-2">
+          <div class="card-top">
+            <span class="keycap">PR 1.2</span><h3>The PR gate</h3>
+            <span class="spacer"></span>
+            <span class="tag gate">gate · blocks merge</span><span class="tag size">~40 lines</span>
+          </div>
+          <p class="after">after: <a href="#1-1">PR 1.1</a></p>
+          <p>What the PR does, in a sentence or two of plain words.</p>
+          <p class="why">Why it exists / why it is scoped this way (optional).</p>
+          <div class="done"><div class="dh">Done when</div><ul>
+            <li>An observable, checkable outcome.</li>
+          </ul>
+          <div class="ev">Landed: <a href="#">PR #NN</a> — one line of evidence (only on merged PRs).</div>
+          </div>
+        </article>
+      </div>
+    </section>
+  -->
+</div>
+
+<script>
+  (function () {
+    var inner = document.getElementById("mapInner");
+    var svg = document.getElementById("edgeSvg");
+    if (!inner || !svg) return;
+    var NS = "http://www.w3.org/2000/svg";
+    var chips = Array.prototype.slice.call(inner.querySelectorAll(".chip[data-id]"));
+    var byId = {};
+    chips.forEach(function (chip) { byId[chip.dataset.id] = chip; });
+    var deps = function (chip) { return (chip.dataset.deps || "").split(/\s+/).filter(Boolean); };
+
+    function draw() {
+      while (svg.firstChild) svg.removeChild(svg.firstChild);
+      var base = inner.getBoundingClientRect();
+      if (!base.width) return;
+      svg.setAttribute("viewBox", "0 0 " + base.width + " " + base.height);
+      chips.forEach(function (chip) {
+        var to = chip.getBoundingClientRect();
+        var x2 = to.left - base.left, y2 = to.top - base.top + to.height / 2;
+        var gate = chip.classList.contains("gate");
+        deps(chip).forEach(function (id) {
+          var src = byId[id];
+          if (!src) return;
+          var from = src.getBoundingClientRect();
+          var x1 = from.right - base.left, y1 = from.top - base.top + from.height / 2;
+          var mx = (x1 + x2) / 2;
+          var path = document.createElementNS(NS, "path");
+          path.setAttribute("d", "M " + x1 + " " + y1 + " C " + mx + " " + y1 + ", " + mx + " " + y2 + ", " + x2 + " " + y2);
+          path.setAttribute("class", gate ? "edge gate" : "edge");
+          path.dataset.a = id; path.dataset.b = chip.dataset.id;
+          svg.appendChild(path);
+          var dot = document.createElementNS(NS, "circle");
+          dot.setAttribute("cx", x2); dot.setAttribute("cy", y2); dot.setAttribute("r", "2.5");
+          dot.setAttribute("class", gate ? "edot gate" : "edot");
+          dot.dataset.a = id; dot.dataset.b = chip.dataset.id;
+          svg.appendChild(dot);
+        });
+      });
+    }
+
+    function focus(id) {
+      inner.classList.add("focus");
+      var lit = {}; lit[id] = true;
+      deps(byId[id]).forEach(function (d) { lit[d] = true; });
+      chips.forEach(function (c) { if (deps(c).indexOf(id) !== -1) lit[c.dataset.id] = true; });
+      chips.forEach(function (c) { c.classList.toggle("lit", !!lit[c.dataset.id]); });
+      Array.prototype.forEach.call(svg.childNodes, function (e) {
+        if (e.classList) e.classList.toggle("on", e.dataset.a === id || e.dataset.b === id);
+      });
+    }
+    function clear() {
+      inner.classList.remove("focus");
+      chips.forEach(function (c) { c.classList.remove("lit"); });
+      Array.prototype.forEach.call(svg.childNodes, function (e) { if (e.classList) e.classList.remove("on"); });
+    }
+    chips.forEach(function (c) {
+      c.addEventListener("mouseenter", function () { focus(c.dataset.id); });
+      c.addEventListener("focus", function () { focus(c.dataset.id); });
+      c.addEventListener("mouseleave", clear);
+      c.addEventListener("blur", clear);
+    });
+
+    draw();
+    if (window.ResizeObserver) new ResizeObserver(draw).observe(inner);
+    window.addEventListener("resize", draw);
+    window.addEventListener("load", draw);
+    if (document.fonts && document.fonts.ready) document.fonts.ready.then(draw);
+  })();
+</script>


### PR DESCRIPTION
## What

Turns `/pr-breakdown` from a table-only planner into **two synced views** of the same PRs:

- **The issue table** stays the single source of truth — now with `Blocked by` and `Status` columns alongside `What` / `LOC` / `Done when`.
- **A published claude.ai artifact** projects that table as a **wave map**: PRs laid out left-to-right by dependency, with blocked-by edges you can trace on hover, gate / merged / in-review states, and a detail card per PR. This is the design from the reference plan artifact, turned into a reusable template.

Every run regenerates the map from the table, so the two never drift.

**Sample of the output** (verifies the template renders): https://claude.ai/code/artifact/9d683e9d-2ac1-4930-a816-e3f1b1018238

## Changes

- **`templates/pr-breakdown-map.html`** — self-contained, theme-aware (light/dark/`data-theme`) map skeleton. Chips are declarative (`data-id` / `data-deps` + status classes); an inline script draws the dependency edges and hover-focus, so the skill never computes coordinates. Modeled on `pr-explain-page.html` conventions (fragment, no DOCTYPE; SLOT comments; stable token/class contract).
- **`skills/pr-breakdown/SKILL.md`** — rewritten:
  - PR rows gain **Blocked by** (the only dependency record; waves + parallelism derived from it) and **Status** (`Todo` · `In review #NN` · `Merged #NN`).
  - **Waves** = topological layering of Blocked by across all slices → the map columns.
  - New phases: fill the template → publish/update the artifact **idempotently** (reuse the URL stored in a `<!-- pr-breakdown:map -->` marker so a later session updates the *same* artifact) → write marker + visible map link + tables back under the canonical `## PR breakdown` section.
  - Statuses **carry forward** by `n.k` id across runs; a merged row never resets to Todo. Degrades to inline HTML when the template isn't staged; skips publishing (not the issue write) when the Artifact tool is unavailable.
- **`installer/catalog.toml`** — dedicated single-skill `pr-breakdown` package carries the page skeleton as an `extra` (same pattern as `pr-explain`), wired into the `planning` bundle so the flagship path ships it.
- **`skills/breakdown` / `skills/course-correct`** — relay the map URL; note the map is stale after a plan edit and that a `/pr-breakdown` re-run redraws it from the table.

## Verification

- `installer` test suite: **182 passed** (incl. `test_skill_extras_paths`, `test_catalog`, `test_skill_dep_composition`).
- Inline JS syntax-checked (`node --check`) for both the skeleton and a filled sample; skeleton HTML tags balance.
- Filled sample published as an artifact to confirm the map, edges, and light/dark all render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hau7LgyFpxxKdg5fb1LDPx