### PR TITLE
feat(pr-explain): plain-words five-chapter redesign with an annotated file-tree map

### DIFF
--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -1,14 +1,23 @@
 ---
 name: pr-explain
-description: Use when the user invokes /pr-explain or wants a reader-facing explainer page for a pull request — writes a 2-3 minute, word-budgeted story of the change with a system delta map and proof, publishes it as a private claude.ai artifact, and maintains a marker-delimited teaser in the PR body.
+description: Use when the user invokes /pr-explain or wants a reader-facing explainer page for a pull request — a short, plain-words page with five chapters (what it is for, a map of the touched files, the tests, the proof, and commands to try it), published as a private claude.ai artifact with a teaser in the PR body.
 argument-hint: "[#N | PR URL | blank = current branch's PR]"
 ---
 
 # PR Explain
 
-Write the page a teammate would draw at a whiteboard. The audience is the repo's owner
-keeping a mental model of a codebase agents typed — not a merge gatekeeper hunting
-defects.
+Write the page you would draw at a whiteboard for the person who owns this repo. They
+want to keep a clear mental model of code that agents typed. They are not hunting for
+bugs — a reviewer does that. They want to *understand the change fast*.
+
+Two rules run through the whole page:
+
+- **Plain words.** Say it the way you would to a smart friend who has not seen the code.
+  If a code word is the only word that fits (`hash`, `symlink`, `CI`), say what it does in
+  plain words right after — once. Short sentences, one idea each. Active voice. Talk to the
+  reader: "you", "your". Start with the point; no wind-up.
+- **Sharp, not padded.** Every chapter is a few clean statements, not a wall and not a
+  bullet list. Cut any sentence that does not earn its place.
 
 ## Arguments
 
@@ -20,137 +29,148 @@ defects.
 
 ## Runtime resolution
 
-- **Template**: `~/.claude/at/templates/pr-explain-page.html` (design tokens + chapter,
-  delta-map, and minimap classes). If it is missing, still ship: build a single-file HTML
-  page with inline CSS following the chapter contract — visual polish degrades, the
-  contract does not.
-- **Vale config**: `~/.claude/at/templates/pr-explain.vale.ini`, staged with the page
-  template; it names the write-good / proselint / Google packages the mechanical prose
-  gate runs. Missing, or `vale` not installed → the gate degrades to the wc + banned-word
-  checks.
-- **Page file**: write the filled page to the session scratch directory (never the
-  target repo) as `pr-<owner>-<repo>-<number>.html`, owner/repo parsed from the PR's `url`.
+- **Template**: `~/.claude/at/templates/pr-explain-page.html` — design tokens plus the
+  `.bottomline`, `.tree`, `.wit`, `.gate-chip`, and `.cmd` classes the chapters use. Missing?
+  Still ship: build a single-file HTML page with inline CSS that follows the chapter
+  contract. Visual polish degrades; the contract does not.
+- **Vale config**: `~/.claude/at/templates/pr-explain.vale.ini`, staged with the template. It
+  names the write-good / proselint / Google packages the mechanical prose gate runs. Missing,
+  or `vale` not installed → the gate degrades to the `wc` + banned-word checks.
+- **Page file**: write the filled page to the session scratch directory (never the target
+  repo) as `pr-<owner>-<repo>-<number>.html`, owner/repo parsed from the PR's `url`.
 - **Target repo**: the git repo of the working directory; run every `gh`/`git` command there.
 
-## The page contract — six chapters, hard budgets
+## The page — five chapters
 
-| Chapter | Job | Budget |
-|---------|-----|--------|
-| Bottom line | What changed, why, impact, risk, in the first three sentences — the reader can stop here | 40-60 words |
-| The map | How the system changed: one delta map + minimap | ≤ 40 words + map |
-| The problem | The concrete failing behavior — real command, error, or number first | 80-120 words + ≤ 1 block |
-| The story | One paragraph per design decision, author order, key diffs annotated | 150-200 words + ≤ 2 blocks |
-| The proof | Witnesses, gate numbers, runtime evidence | 40-70 words + evidence |
-| The limits | What deliberately didn't change, non-goals, sharp edges | 40-60 words |
+Each chapter answers one question. Keep to the budget; a budget is a ceiling, not a target.
+Drop an empty chapter, never pad it.
 
-- Total prose ≤ 550 words; everything essential inside the first 200. Budgets are
-  ceilings, not targets — empty chapters are dropped, never padded.
-- Code/output blocks are excluded from the budget and capped at 10 lines each.
-- **Scaling**: a non-structural PR (docs, config, formatting, version bumps) gets no map
-  and may shrink to five sentences across Bottom line / The story / The limits. A
-  structural PR gets the full page.
+| # | Chapter | The question it answers | Budget |
+|---|---------|-------------------------|--------|
+| 1 | What this is for | Why did we build this, what is it, and what changes once it merges? | 60-100 words |
+| 2 | The map | Which files did we touch, and what did we do in each? | tree + ≤ 40 words + ≤ 2 diffs |
+| 3 | The tests | What do the tests set up and check, and how did they go RED then GREEN? | 50-90 words |
+| 4 | The proof | What did we run to show it really works? | 40-70 words + evidence |
+| 5 | See for yourself | What can you paste to confirm it yourself? | ≤ 40 words + commands |
+
+Total prose ≤ 380 words. Code, diffs, the tree, and command blocks do not count, and each
+diff or command block caps at 10 lines. A tiny PR (docs, a version bump, one-line config)
+shrinks to Chapter 1, a one-line tree, and Chapter 5 — no forced tests or proof.
 
 ## Phase 1 — Gather
 
 ```bash
 branch="$(git branch --show-current)"           # blank arg; empty output → detached HEAD: stop, ask for #N
-gh pr list --head "$branch" --json number,url   # [] → no open PR: stop, ask for #N
-gh pr view <N> --json number,title,body,url,headRefName,additions,deletions,createdAt
+gh pr list --head "$branch" --json number,url    # [] → no open PR: stop, ask for #N
+gh pr view <N> --json number,title,body,url,headRefName,additions,deletions,createdAt,files
 gh pr diff <N>
 gh pr checks <N> || true
 ```
 
-- **The why**: read the issue/PRD the PR body references (`Closes #N` / `Refs #N`;
-  prefer `Closes`, first match) via
-  `gh issue view <N> --json title,body`. The problem chapter comes from there — the
-  slice/PR row the body names, else the issue's headline problem — not from the diff.
-  None referenced → derive it from the PR body and diff, and say so.
-- **Evidence**: with the head branch slugged (`/` and whitespace → `_`), read
-  `<target_repo>/.v1-runs/evidence/<slug>/evidence.json` — the make-pr/-lite handoff:
-  `behaviors[]` with RED and GREEN witnesses, `gates[]` with the run's real gate numbers,
-  `runtime` artifact paths relative to that dir. The proof chapter quotes it verbatim:
-  the RED tag carries `red.key_output` (the witnessed failure reason), the GREEN tag
-  what made it pass plus `+<lines_added>` lines, one gate chip per `gates[]` row from
-  its `key_output`. Never invent evidence: without that file, the proof chapter degrades
-  to `gh pr checks` plus the tests visible in the diff. Checks empty too → cite the
-  diff's test files. Gate numbers claimed in the PR body appear only attributed
-  ("PR body reports: pytest 18 passed"), never as verified chips.
+Always pass the explicit `<N>` — a bare `gh pr view` targets the current branch's PR, which
+may not be the one you were asked about. `--json files` gives every touched path with its
+`additions`/`deletions`; that list builds the Chapter 2 tree.
+
+- **The why (Chapter 1)**: read the issue or PRD the PR body references (`Closes #N` /
+  `Refs #N`; prefer `Closes`, first match) with `gh issue view <N> --json title,body` (this
+  repo needs `--json`, a bare `gh issue view` errors on classic project cards). The reason
+  comes from there — the slice/PR row the body names, else the issue's headline problem — not
+  from the diff. Nothing referenced → derive it from the PR body and diff, and say so on the
+  page.
+- **Evidence (Chapters 3-4)**: slug the head branch (`/` and whitespace → `_`) and read
+  `<target_repo>/.v1-runs/evidence/<slug>/evidence.json` — the make-pr / make-pr-lite handoff.
+  It carries `behaviors[]` (each with a RED and a GREEN witness), `gates[]` (real gate numbers
+  from the run), and `runtime` (artifact paths relative to that dir). Chapters 3 and 4 quote it
+  verbatim: the RED witness carries the failure reason, the GREEN witness what made it pass plus
+  `+<lines_added>`, one gate chip per `gates[]` row. **Never invent evidence.** No file → the
+  proof degrades to `gh pr checks` plus the test files in the diff. Checks empty too → cite the
+  diff's test files. Numbers claimed only in the PR body appear attributed ("PR body reports:
+  pytest 161 passed"), never as a verified chip.
 
 ## Phase 2 — Understand (before writing a word)
 
-1. **Name the one big thing** — the single decision that drives the diff, in one sentence.
-2. **Group hunks into author-order cohorts** — data/schema, then logic, then call sites,
-   then tests. The story follows this order, never file order.
-3. **Pick the key moments** — at most 3 hunks that carry the decision; the rest is
-   summarized in prose.
-4. **Derive the delta map** (structural PRs only): the diff's changed components, each
-   classified added / modified / removed. Components are modules/files, not functions;
-   config, lockfiles, and fixtures are not components. Removed components stay on the
-   map. Add unchanged 1-hop neighbors (importers/importees), dimmed, never hidden. Cap
-   ~20 components; collapse unchanged neighbors into their parent folder when over.
-5. **Build the minimap**: git-tracked top-level directories
-   (`git ls-tree -d --name-only HEAD`), byte-sorted, equal-width cells; mark the ones
-   containing changes.
+1. **Name the one thing** this PR does, in a single plain sentence. Everything else is a
+   detail that hangs off it.
+2. **Split the touched files** into production and tests (path holds `test`, `spec`,
+   `__tests__`, `.test.`, `.spec.`, or lives under `tests/`). Production files drive Chapter 2;
+   test files drive Chapter 3.
+3. **Read the production hunks** and write, for each touched non-test file, one plain phrase
+   of what changed there — the tree callout. Pick at most **2** hunks that carry the decision
+   to show as real diff lines under the tree.
+4. **Build the tree** (Chapter 2): the touched subtree only. Group touched files under their
+   folders; show a touched file with a `●`, its name in bold, and `+adds −dels`; mark test
+   files with a `test` tag and give them no callout. Add a couple of untouched siblings, dimmed
+   with `·`, only when they help the reader place the change — do not print the whole folder.
+   Cap the tree around 20 rows.
+5. **Build the "you are here" strip**: top-level git-tracked directories
+   (`git ls-tree -d --name-only HEAD`), byte-sorted, equal-width cells; light the ones that
+   contain a touched file. Same strip, same order, every PR — it orients the reader in the
+   whole repo without printing it.
 
 ## Phase 3 — Write
 
-Draft the prose in a scratch buffer under this contract:
+Draft the prose in a scratch buffer under these rules:
 
-1. **One PR, one big thing.** Secondary changes get one line each, never their own arc.
-2. **Every claim points at evidence the page shows** — a hunk, a gate line, a check
-   result, a screenshot. "Faster", "safer", "fixed" each come with a number or output.
-3. **Concrete before abstract.** The failing command, error, or diff appears before any
-   general statement about it; examples are trimmed from the real diff.
-4. **Data over adjectives; ≤ 25-word sentences; one idea per sentence.**
-5. **One name per concept — the name from the code.** Present tense for new behavior,
-   past tense only for what it replaced.
+1. **One PR, one thing.** Chapter 1 leads with it. Secondary changes get one line, never an arc.
+2. **Every claim points at something the page shows** — a tree callout, a diff line, a gate
+   chip, a check, a screenshot. "Faster", "safer", "fixed" each arrive with a number or output.
+3. **Concrete before abstract.** The failing command, the error, or the real line comes before
+   any statement about it. Examples are trimmed from the actual diff, never invented.
+4. **Plain words, ≤ 25-word sentences, one idea per sentence, data over adjectives.**
+5. **One name per concept — the name from the code.** Present tense for the new behavior; past
+   tense only for what it replaced.
 
-Banned on sight: leverages, robust, seamless, comprehensive, delve, streamlined,
-powerful, simply, ensures, significantly, various, clearly, essentially, "it's worth
-noting", and "should" when describing behavior.
+Banned on sight: leverages, robust, seamless, comprehensive, delve, streamlined, powerful,
+simply, utilize, facilitate, ensures, significantly, various, clearly, essentially, furthermore,
+moreover, "in order to", "it's worth noting", "not only… but also", and "should" when you mean
+what the code *does*.
 
 ### The bar
 
-The draft leaves Phase 3 only past this gate. Run it in order:
+The draft leaves Phase 3 only after both gates. Run them in order:
 
-- **Mechanical gate (always).** `wc -w` each chapter and cut any over budget; `grep` the
-  draft for every banned word (the list above) and rewrite each hit. Then, **if `vale` is
-  on PATH**, write the draft to a scratch `.md` and run `vale --config
-  ~/.claude/at/templates/pr-explain.vale.ini <draft>.md` (run `vale --config ~/.claude/at/templates/pr-explain.vale.ini sync` once first if
-  `StylesPath` is empty), rewriting every alert. When `vale` is absent or `vale sync`
-  can't reach the registry, degrade to the wc + banned-word checks — note it in the
-  report, never fail the run. The banned-word list stays owned by the grep; Vale only adds
-  fuzzy prose quality (weasel words, passive voice, wordiness).
-- **Critic pass (inline, one rubric, one loop).** Score the draft 0–100, four dimensions ×
-  0–25: **Evidenced** — every claim cites a hunk / number / gate line / screenshot the
-  page shows; no unevidenced faster / safer / fixed. **Bottom-line-first** — change +
-  reason + impact in the first three sentences. **Concrete & tight** — failing command /
-  error / diff before any abstraction; ≤ 25-word sentences; data over adjectives. **Budget
-  & scope** — every chapter within budget; one big thing, secondary changes one line each.
-  Below **90** → apply the specific misses as one rewrite pass, then re-score once. After
-  the rewrite, re-run the banned-word `grep` and per-chapter `wc` — these are hard and must
-  still hold at publish.
-- **Ship-flag.** Still < 90 after the rewrite → publish anyway and record the final score +
-  unmet dimensions in the report. Never block the publish or loop a third time.
+- **Mechanical gate (always).** `wc -w` each chapter and cut anything over budget. `grep` the
+  draft for every banned word above and rewrite each hit. Then, **if `vale` is on PATH**, write
+  the draft to a scratch `.md` and run `vale --config ~/.claude/at/templates/pr-explain.vale.ini
+  <draft>.md` (run `vale --config … sync` once first if `StylesPath` is empty), rewriting every
+  alert. `vale` absent or `sync` can't reach the registry → degrade to the `wc` + banned-word
+  checks and note it in the report; never fail the run. The banned-word list stays owned by the
+  grep; Vale only adds fuzzy prose quality (weasel words, passive voice, wordiness).
+- **Critic pass (inline, one rubric, one loop).** Score the draft 0-100, four dimensions ×
+  0-25:
+  - **Plain & simple** — commonest words; any code word explained once; a first-time reader
+    follows it without stopping. This is the point of the page — weight it hardest.
+  - **Evidenced** — every claim cites a tree callout / diff line / gate chip / check / screenshot
+    the page shows; no unevidenced faster / safer / fixed.
+  - **Sharp & short** — clean statements, not bullets and not a wall; ≤ 25-word sentences; every
+    chapter within budget.
+  - **Complete map & confirm** — the tree marks every touched file with a plain callout (tests
+    excepted), and Chapter 5's commands actually confirm *this* change.
+
+  Below **90** → apply the specific misses as one rewrite pass, then re-score once. After the
+  rewrite, re-run the banned-word `grep` and per-chapter `wc` — those are hard and must still
+  hold at publish.
+- **Ship-flag.** Still < 90 after the rewrite → publish anyway and record the final score and
+  the unmet dimensions in the report. Never block the publish or loop a third time.
 
 ## Phase 4 — Build
 
-- Fill the template's `SLOT` comments; keep its tokens, classes, and all four theme
-  token blocks; delete the whole `.chapter` div of any dropped chapter. Everything stays inline —
+- Fill the template's `SLOT` comments. Keep its tokens, classes, and all four theme token
+  blocks. Delete the whole `.chapter` div of any chapter you drop. Everything stays inline —
   the artifact CSP blocks external requests.
-- **Delta map**: use the classes the template's SLOT comments name; never color a node
-  without its `+`/`~`/`−` glyph badge — the colorblind-safe channel. Grow the SVG
-  viewBox height if the layout needs it.
-- Screenshots embed as `data:` URIs via `img.evidence`.
+- **The tree**: use the `.row`, `.dir`, `.file`/`.file.hit`, `.dot`, `.stat`, `.is-test`, and
+  `.note` classes exactly as the SLOT comment shows; indent rows with `l1`/`l2`/`l3`. A callout
+  is a `.note` row directly under its file.
+- Screenshots and e2e output embed as `data:` URIs via `img.evidence`.
 
 ## Phase 5 — Publish
 
-- Artifact tool: title `PR #<N> — <imperative title, ≤ 8 words>`, favicon `📖` (stable
-  across reruns), a one-sentence description.
-- Rerun in the same conversation → republish the same file path (same URL). Rerun in a
-  later session → pass the teaser's artifact URL (from the Phase 1 body) as the `url`
-  parameter. Publishing with `url` fails (artifact deleted or not owned) → publish
-  without it; Phase 6 rewrites the teaser with the new link.
+- Artifact tool: title `PR #<N> — <plain title, ≤ 8 words>`, favicon `📖` (stable across
+  reruns), a one-sentence description.
+- Rerun in the same conversation → republish the same file path (same URL). Rerun in a later
+  session → pass the teaser's artifact URL (from the Phase 1 body) as the `url` parameter.
+  Publishing with `url` fails (artifact deleted or not owned) → publish without it; Phase 6
+  rewrites the teaser with the new link.
 
 ## Phase 6 — The teaser
 
@@ -158,28 +178,26 @@ Maintain exactly one marker-delimited block in the PR description:
 
 ```markdown
 <!-- pr-explain:begin -->
-### The story of this PR
-<the Bottom line chapter, verbatim>
+### What this PR is for
+<the What-this-is-for chapter, verbatim>
 
-**[Read the explainer](<artifact-url>)**<map tail>
+**[Read the explainer](<artifact-url>)** · <n> files touched
 <!-- pr-explain:end -->
 ```
 
-- Map tail (only when the page has a map): ` · map: <n> changed components, <m> unchanged
-  neighbors` — singular when a count is 1; drop the neighbors clause when it is 0.
-- Re-read the body with `gh pr view <N> --json body` — it may have changed since
-  Phase 1; replace the block between the markers in place (append if absent); write
-  back with `gh pr edit <N> --body-file <file>`.
-- If that fails on a GraphQL projectCards deprecation error (a gh quirk on repos with
-  classic projects), write the same body with
+- Re-read the body with `gh pr view <N> --json body` — it may have changed since Phase 1.
+  Replace the block between the markers in place (append if the markers are absent); write the
+  body back with `gh pr edit <N> --body-file <file>`.
+- If that fails on a GraphQL `projectCards` deprecation error (a gh quirk on repos with classic
+  projects), write the same body with
   `gh api repos/<owner>/<repo>/pulls/<N> -X PATCH -F body=@<file>`.
-- Artifact tool unavailable (headless/CI): the full chapters, as markdown, go between
+- Artifact tool unavailable (headless / CI): put the full five chapters, as markdown, between
   the markers in place of the teaser. Say so in your report.
 - Never touch prose outside the markers. Empty body → the block is the body.
 
 ## Report
 
-End with: the artifact URL, total prose word count, chapters emitted vs dropped, map
-included or skipped (with the reason), the PR whose teaser was updated, the mechanical
-gate result (Vale alerts fixed, or "vale unavailable — wc + grep only"), and the critic
-score — naming any dimensions left under the bar when the page shipped flagged.
+End with: the artifact URL, total prose word count, chapters emitted vs dropped, the number of
+touched files in the tree, the PR whose teaser you updated, the mechanical gate result (Vale
+alerts fixed, or "vale unavailable — wc + grep only"), and the critic score — naming any
+dimension left under the bar when the page shipped flagged.

--- a/templates/pr-explain-page.html
+++ b/templates/pr-explain-page.html
@@ -1,11 +1,10 @@
 <!-- pr-explain page skeleton. The skill fills every SLOT comment and deletes the whole
-     .chapter div of any dropped chapter (the map chapter additionally requires a
-     structural PR). Tokens and classes are the contract with the skill's Phase 4:
-     keep names stable. Self-contained: no external requests.
+     .chapter div of any chapter it drops. Tokens and classes are the contract with the
+     skill's Build phase: keep the names stable. Self-contained: no external requests.
      Deliberately a fragment (no DOCTYPE/head/meta): the Artifact publisher wraps the
      file in its own doctype + head skeleton (charset and viewport included), so the
      template must not declare them — do not "fix" this. -->
-<title><!-- SLOT: PR #N — imperative title, ≤ 8 words --></title>
+<title><!-- SLOT: PR #N — plain title, ≤ 8 words --></title>
 <style>
   :root {
     --paper: #F8F8F5; --card: #FFFFFF; --ink: #202723; --ink-2: #59635D; --ink-3: #8B948E;
@@ -56,114 +55,115 @@
   .bottomline { border: 1px solid var(--line-strong); background: var(--card);
     border-radius: 8px; padding: 18px 22px; margin-top: 28px; }
   .bottomline p { margin: 6px 0 0; }
-  .diff { font-family: var(--mono); font-size: 12.5px; line-height: 1.55;
-    background: var(--code-bg); border-radius: 6px; padding: 10px 12px; margin: 10px 0;
-    overflow-x: auto; white-space: pre; }
-  .diff .ctx { color: var(--ink-3); }
-  .diff .del { color: var(--red); background: var(--red-soft); display: inline-block; width: 100%; }
-  .diff .add { color: var(--green); background: var(--green-soft); display: inline-block; width: 100%; }
-  .dmap { width: 100%; height: auto; display: block; margin: 10px 0 2px; }
-  .dmap text { font-family: var(--mono); font-size: 12px; fill: var(--ink); }
-  .dmap .badge-txt { font-size: 11px; font-weight: 700; }
-  .n-mod rect.box { fill: var(--amber-soft); stroke: var(--amber); stroke-width: 1.5; }
-  .n-add rect.box { fill: var(--green-soft); stroke: var(--green); stroke-width: 1.5; }
-  .n-del rect.box { fill: var(--red-soft); stroke: var(--red); stroke-width: 1.5; }
-  .n-dim rect.box { fill: var(--code-bg); stroke: var(--line-strong); stroke-width: 1; }
-  .n-dim text { fill: var(--ink-3); }
-  .n-mod .badge { fill: var(--amber); } .n-add .badge { fill: var(--green); }
-  .n-del .badge { fill: var(--red); } .dmap .badge-glyph { fill: var(--card); }
-  .e-old { stroke: var(--line-strong); stroke-width: 1.5; opacity: 0.7; }
-  .e-new { stroke: var(--green); stroke-width: 2; }
-  .e-del { stroke: var(--red); stroke-width: 1; opacity: 0.6; }
-  .ah-old { fill: var(--line-strong); opacity: 0.7; } .ah-new { fill: var(--green); }
-  .ah-del { fill: var(--red); opacity: 0.6; }
-  .map-legend { display: flex; gap: 14px; flex-wrap: wrap; font-family: var(--mono);
-    font-size: 11px; color: var(--ink-2); margin: 6px 0 2px; }
-  .map-legend .k { display: inline-flex; align-items: center; gap: 5px; }
-  .sw { width: 11px; height: 11px; border-radius: 3px; display: inline-block; flex: none; }
-  .sw.add { background: var(--green-soft); border: 1.5px solid var(--green); }
-  .sw.mod { background: var(--amber-soft); border: 1.5px solid var(--amber); }
-  .sw.del { background: var(--red-soft); border: 1.5px solid var(--red); }
-  .sw.dim { background: var(--code-bg); border: 1px solid var(--line-strong); }
-  .minimap { display: flex; gap: 4px; margin: 14px 0 2px; }
+
+  /* Chapter 2 — the map: one annotated file tree of the touched subtree. */
+  .minimap { display: flex; gap: 4px; margin: 6px 0 2px; }
   .mm-cell { flex: 1; border: 1px solid var(--line); border-radius: 4px;
     background: var(--code-bg); font-family: var(--mono); font-size: 10px;
     color: var(--ink-3); text-align: center; padding: 7px 2px; white-space: nowrap;
     overflow: hidden; text-overflow: ellipsis; }
-  .mm-cell.here { background: var(--amber-soft); border: 2px solid var(--amber);
+  .mm-cell.here { background: var(--accent-soft); border: 2px solid var(--accent);
     color: var(--ink); font-weight: 700; }
-  .mm-caption { font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); margin-top: 4px; }
+  .mm-caption { font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); margin: 4px 0 0; }
+  .tree { font-family: var(--mono); font-size: 13px; line-height: 1.5; margin: 16px 0 4px;
+    background: var(--card); border: 1px solid var(--line); border-radius: 8px;
+    padding: 14px 16px; overflow-x: auto; }
+  .tree .row { white-space: pre; }
+  .tree .l1 { padding-left: 1.6em; } .tree .l2 { padding-left: 3.2em; } .tree .l3 { padding-left: 4.8em; }
+  .tree .dir { color: var(--ink-2); font-weight: 600; }
+  .tree .file { color: var(--ink-3); }
+  .tree .file.hit { color: var(--ink); font-weight: 700; }
+  .tree .dot { color: var(--accent); font-weight: 700; }
+  .tree .stat { color: var(--ink-3); }
+  .tree .stat .add { color: var(--green); } .tree .stat .del { color: var(--red); }
+  .tree .is-test { color: var(--amber); font-size: 0.82em; letter-spacing: 0.04em; }
+  .tree .note { font-family: var(--serif); font-style: italic; font-size: 14px;
+    color: var(--ink-2); margin: 1px 0 6px; }
+  .tree .note::before { content: "└ "; color: var(--accent); font-style: normal; }
+
+  .diff { font-family: var(--mono); font-size: 12.5px; line-height: 1.55;
+    background: var(--code-bg); border-radius: 6px; padding: 10px 12px; margin: 12px 0;
+    overflow-x: auto; white-space: pre; }
+  .diff .ctx { color: var(--ink-3); }
+  .diff .del { color: var(--red); background: var(--red-soft); display: inline-block; width: 100%; }
+  .diff .add { color: var(--green); background: var(--green-soft); display: inline-block; width: 100%; }
+  .diff-note { font-size: 15px; color: var(--ink-2); margin: 6px 0 0; }
+
+  /* Chapter 3 — the tests: RED → GREEN witnesses. */
   .wit { display: flex; gap: 8px; align-items: baseline; font-size: 15px; margin: 8px 0; }
   .wit .tag { font-family: var(--mono); font-size: 10.5px; font-weight: 700;
     padding: 1px 7px; border-radius: 4px; flex: none; }
   .tag.red { color: var(--red); background: var(--red-soft); }
   .tag.green { color: var(--green); background: var(--green-soft); }
+
+  /* Chapter 4 — the proof: gate chips + runtime evidence. */
   .gate-row { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 10px; }
   .gate-chip { font-family: var(--mono); font-size: 11.5px; padding: 3px 9px;
     border-radius: 999px; background: var(--green-soft); color: var(--green); }
   .gate-chip.fail { background: var(--red-soft); color: var(--red); }
-  img.evidence { max-width: 100%; border: 1px solid var(--line-strong); border-radius: 6px; }
+  img.evidence { max-width: 100%; border: 1px solid var(--line-strong); border-radius: 6px; margin-top: 12px; }
+
+  /* Chapter 5 — see for yourself: commands the reader can run. */
+  .cmd { font-family: var(--mono); font-size: 12.5px; line-height: 1.65; background: var(--code-bg);
+    border-radius: 6px; padding: 12px 14px; margin: 12px 0; overflow-x: auto; white-space: pre; }
+  .cmd .p { color: var(--accent); font-weight: 700; }
+  .cmd .out { color: var(--ink-3); }
 </style>
 
 <div class="wrap">
   <span class="eyebrow"><!-- SLOT: repo · PR #N --></span>
-  <h1><!-- SLOT: imperative title, ≤ 8 words --></h1>
+  <h1><!-- SLOT: plain title, ≤ 8 words --></h1>
   <div class="meta"><!-- SLOT: <span> items: branch, +adds −dels, date --></div>
 
   <div class="bottomline">
-    <div class="clabel">Bottom line</div>
-    <p><!-- SLOT: 40-60 words — what, why, impact, risk --></p>
+    <div class="clabel">What this is for</div>
+    <!-- SLOT: 60-100 words, plain words — why we built it, what it is, what changes after it merges -->
   </div>
 
-  <!-- OPTIONAL: delete this whole chapter for non-structural PRs -->
   <div class="chapter">
     <div class="clabel">The map</div>
-    <p><!-- SLOT: ≤ 40 words — what moved at component level --></p>
-    <svg class="dmap" viewBox="0 0 640 200" role="img" aria-label="<!-- SLOT: map summary -->">
-      <!-- SLOT: edges first (<line class="e-new|e-old|e-del">, arrowheads
-           <polygon class="ah-new|ah-old|ah-del"> matching their edge), then node groups.
-           Badge circle + glyph on n-add|n-mod|n-del only; n-dim gets rect + text, no badge:
-           <g class="n-add|n-mod|n-del|n-dim">
-             <rect class="box" x y width height rx="6"/><text x y>name</text>
-             <circle class="badge" cx cy r="8"/><text class="badge-txt badge-glyph" x y>+|~|−</text>
-           </g> -->
-    </svg>
-    <div class="map-legend">
-      <span class="k"><span class="sw add"></span>+ added</span>
-      <span class="k"><span class="sw mod"></span>~ modified</span>
-      <span class="k"><span class="sw del"></span>− removed</span>
-      <span class="k"><span class="sw dim"></span>unchanged, 1 hop</span>
-    </div>
     <div class="minimap"><!-- SLOT: one .mm-cell per git-tracked top-level dir, byte-sorted;
-      add class "here" to dirs containing changes --></div>
-    <div class="mm-caption">you are here — same strip, same order, every PR</div>
+      add class "here" to dirs that contain a touched file --></div>
+    <div class="mm-caption">you are here — every top folder in the repo; lit = we touched it</div>
+    <div class="tree">
+      <!-- SLOT: the touched subtree. One .row per line, indent with l1/l2/l3:
+           dir:            <div class="row l1"><span class="dir">installer/</span></div>
+           touched file:   <div class="row l2"><span class="dot">●</span> <span class="file hit">at.py</span>  <span class="stat"><span class="add">+24</span> <span class="del">−6</span></span></div>
+           its callout:    <div class="note l2">what we did here, ≤ 12 plain words</div>
+           test file:      <div class="row l2"><span class="dot">●</span> <span class="file hit">test_at.py</span> <span class="is-test">test</span>  <span class="stat"><span class="add">+40</span></span></div>   (no callout — tests are Chapter 3)
+           untouched sib:  <div class="row l2"><span class="file">catalog.toml</span>  <span class="stat">·</span></div>
+      -->
+    </div>
+    <!-- OPTIONAL: at most 2 key non-test changes shown as real lines, each with one plain sentence:
+      <div class="diff"><span class="ctx">  context</span>
+      <span class="del">- removed</span>
+      <span class="add">+ added</span></div>
+      <p class="diff-note">Here we do X so that Y.</p>
+    -->
   </div>
 
   <div class="chapter">
-    <div class="clabel">The problem</div>
-    <!-- SLOT: 80-120 words; the failing behavior first; one block max -->
-  </div>
-
-  <div class="chapter">
-    <div class="clabel">The story</div>
-    <!-- SLOT: 150-200 words; one <p> per decision; ≤ 2 .diff blocks, ≤ 10 lines each:
-         <div class="diff"><span class="ctx">  context</span>
-         <span class="del">- removed</span>
-         <span class="add">+ added</span></div> -->
+    <div class="clabel">The tests</div>
+    <!-- SLOT: 50-90 words. First the scenario in plain words — what the test sets up and checks.
+         Then the RED → GREEN story from the witnesses:
+         <div class="wit"><span class="tag red">RED</span><span>…failed first, and the exact reason…</span></div>
+         <div class="wit"><span class="tag green">GREEN</span><span>…what made it pass…</span></div>
+         No evidence file → describe the test files in the diff and say the witnesses are absent. -->
   </div>
 
   <div class="chapter">
     <div class="clabel">The proof</div>
-    <!-- SLOT: 40-70 words + evidence. With witnesses:
-         <div class="wit"><span class="tag red">RED</span><span>…failed first, right reason…</span></div>
-         <div class="wit"><span class="tag green">GREEN</span><span>…what made it pass…</span></div>
-         Gates: <div class="gate-row"><span class="gate-chip">pytest N passed</span>…</div>
-         Without evidence: CI check results as gate chips (class "fail" for red ones);
-         PR-body claims appear only attributed in prose, never as chips. -->
+    <!-- SLOT: 40-70 words + evidence. Gate numbers as chips:
+         <div class="gate-row"><span class="gate-chip">pytest 161 passed</span><span class="gate-chip">mypy strict</span></div>
+         Runtime evidence (screenshot, e2e run) as <img class="evidence" src="data:…">.
+         No evidence file → CI check results as chips (class "fail" for red ones);
+         PR-body claims appear only attributed in prose ("PR body reports: …"), never as chips. -->
   </div>
 
   <div class="chapter">
-    <div class="clabel">The limits</div>
-    <p><!-- SLOT: 40-60 words — what didn't change, non-goals, sharp edges --></p>
+    <div class="clabel">See for yourself</div>
+    <!-- SLOT: ≤ 40 words + one command block the reader can paste to confirm the change:
+         <div class="cmd"><span class="p">$</span> at update
+         <span class="out">demo-pack (extras) — up to date</span></div> -->
   </div>
 </div>


### PR DESCRIPTION
## What this is for

The shipped `/pr-explain` page read as dense and over-built — six word-budgeted chapters plus an abstract C4-component delta map — and stopped making PRs easier to read. This rebuilds it around **plain words** and a **real map of the files we touched**.

## The map

Two files: the skill spec and the page skeleton it fills.

- `skills/pr-explain/SKILL.md` — the new five-chapter contract, plain-words voice, and the annotated-tree build steps.
- `templates/pr-explain-page.html` — dropped the `.dmap`/`.n-*`/`.e-*`/`.map-legend`/`.sw` component-map classes, added the `.tree` and `.cmd` components. Theme tokens and the reusable chips are unchanged, so the two package extras keep their filenames and catalog wiring stays put.

## The new page — five chapters (prose ≤ 380 words)

1. **What this is for** — why we built it, what it is, what changes (60–100w)
2. **The map** — an annotated file tree of the *touched subtree*: one `●` row + `+adds −dels` per touched file, a plain callout under each non-test file, test files tagged and deferred to chapter 3; the "you are here" strip stays. Replaces the C4 map entirely.
3. **The tests** — the scenario in plain words + the RED→GREEN witnesses (50–90w)
4. **The proof** — gate chips + runtime evidence (40–70w)
5. **See for yourself** — commands the reader can paste to confirm it (≤40w)

Dropped "The limits". Voice is Thing Explainer plain words — sharp statements over bullets.

## Quality gates

Both gates stay. The Vale mechanical gate is unchanged; the critic-to-90 loop keeps its shape but the rubric is retargeted at the new contract: **Plain & simple** (weighted hardest), **Evidenced**, **Sharp & short**, **Complete map & confirm**.

## Proof

- `bash validate.sh` → `catalog OK — 27 units, 6 packages, 2 bundles`.
- Rendered against real PR #142 to check the design on live content: **[sample page](https://claude.ai/code/artifact/39599e26-c529-45e9-ae61-85da48565d4f)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LtsRdxUKd8Bk5SVYnzpfP