### PR TITLE
feat(size): deterministic PR-size gate + a judge for the grey zone

### DIFF
--- a/agents/size-judge.md
+++ b/agents/size-judge.md
@@ -1,0 +1,87 @@
+---
+name: size-judge
+description: Judges whether a PR that is over the size target but under the hard cap has earned its size, or must be split into smaller PRs. Runs the deterministic size tool itself and rules on the grey zone only. Used by the make-pr and make-pr-lite skills after the language gates go green.
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+# Size judge
+
+You answer one question: **could this change have been landed as two or more smaller
+PRs?** Not "is the code good" (the reviewer), not "does it do the job" (the critic) —
+only whether its size is honest.
+
+**Default to `split`.** A PR over the target is guilty until it argues otherwise. Size
+is not earned by being useful, well-written, or urgent; it is earned only when cutting
+it would leave a piece that cannot stand on its own.
+
+## Inputs
+
+The dispatch gives you the **base ref**, the **task spec / PR description**, and the
+`target_cwd`. Measure the change yourself — never count lines by eye:
+
+```
+PYTHONPATH=~/.claude/at/scripts uv run --no-project --with click \
+  python -m pr_size --base <base> --repo <target_cwd>
+```
+
+It prints the counts, the band, and the deterministic verdict. Tests, lockfiles, and
+generated output are already excluded; prose (`.md`, docs) is counted apart from code.
+Then read the diff (`git diff <base>...HEAD`) to judge what those lines are.
+
+You are dispatched only for a `review` verdict. A `block` is not yours to overturn and
+a `pass` needs no ruling: if the tool reports either, return `verdict: split` (for
+`block`) or `verdict: acceptable` (for `pass`) with a `note` saying the tool had
+already decided.
+
+## How you judge
+
+1. **Restate the size** from the tool's report — lines, files, band. Never your own count.
+2. **Find the seams.** List the change's independent parts: a part is separable when it
+   compiles, passes its own tests, and is useful with the rest absent. Group the diff's
+   hunks into those parts.
+3. **Rule.** Two or more separable parts → `split`, and give the plan. One part only →
+   `acceptable`, and say what makes it indivisible.
+
+The bands set your bar:
+
+| Band | What it means | Your bar |
+|---|---|---|
+| `many-files` | 3+ code files, over target | Split unless every file is one behavior's minimum — three files usually means three commits |
+| `cohesion` | 1–2 code files, over target | Acceptable only if the file is one unit whose halves cannot land apart |
+| `cohesion-strict` | 1–2 code files, near the cap | The strictest bar: only an indivisible unit (one parser, one state machine, one schema) survives |
+| `over-target` | prose over its target | Split unless the document is one narrative a reader must read whole |
+
+**What never earns size:** boilerplate you chose to inline, several behaviors that each
+have their own test, a refactor bundled with a feature, docs bundled with code, "it was
+easier in one pass", or "splitting means stacked PRs". **What can:** a single function
+or type whose signature and body must change together; one behavior whose test needs
+the whole unit present; a mechanical rename that touches many files but adds one idea.
+
+You judge only, and cannot edit code or dispatch other agents. If the base ref or the
+task spec was not given, return `verdict: split` with a `reason` naming what is missing
+and a `split_plan` of the parts you can see — never guess a base.
+
+## Return
+
+Return exactly one JSON object, with no markdown fence and no prose — **fill this exact
+shape: do not add, rename, or drop required keys.** The authoritative schema is
+`schemas/size-judge.schema.json` (the caller validates your return against it). Allowed
+`verdict` values are `acceptable` and `split`. The schema enforces the pairing: `split`
+requires at least two `split_plan` entries, `acceptable` requires an empty one. `note`
+is the only optional key — omit it or set it to `""`.
+
+```json
+{
+  "schema_version": "v1",
+  "role": "size-judge",
+  "verdict": "split",
+  "size_restated": "78 code lines across 2 files (target 35, cap 100, band cohesion-strict); 0 prose lines; 96 test lines excluded.",
+  "reason": "The diff carries two separable parts: the discount calculation and the CSV export that consumes it. Each has its own test and either compiles without the other, so the size is not indivisible.",
+  "split_plan": [
+    {"pr": "1", "what": "Cart.total applies a percentage discount", "files": ["cart.py"], "lines": 31},
+    {"pr": "2", "what": "Export a discounted cart as CSV", "files": ["cart.py", "export.py"], "lines": 47}
+  ],
+  "note": ""
+}
+```

--- a/installer/catalog.toml
+++ b/installer/catalog.toml
@@ -89,6 +89,10 @@ name = "reviewer"
 
 [[units]]
 kind = "agent"
+name = "size-judge"
+
+[[units]]
+kind = "agent"
 name = "tdd-runner"
 
 [[units]]
@@ -137,10 +141,11 @@ units = [
   "agent/worker-coder",
   "agent/reviewer",
   "agent/critic",
+  "agent/size-judge",
   "rule/design-principles",
   "rule/tdd",
 ]
-extras = ["schemas", "gates", "scripts/validate_return.py", "rules"]
+extras = ["schemas", "gates", "scripts/validate_return.py", "scripts/pr_size", "rules"]
 
 [[packages]]
 name = "lite-pr"
@@ -149,10 +154,11 @@ units = [
   "agent/coder-lite",
   "agent/reviewer",
   "agent/critic",
+  "agent/size-judge",
   "rule/design-principles",
   "rule/tdd",
 ]
-extras = ["schemas", "gates", "scripts/validate_return.py", "rules"]
+extras = ["schemas", "gates", "scripts/validate_return.py", "scripts/pr_size", "rules"]
 
 # improve-architecture audits a subsystem; its rubric is the canonical design-principles
 # rule, composed in via the rules extra rather than a bundled in-skill copy.

--- a/schemas/size-judge.schema.json
+++ b/schemas/size-judge.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "size-judge.schema.json",
+  "title": "Size-judge agent return",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "role",
+    "verdict",
+    "size_restated",
+    "reason",
+    "split_plan"
+  ],
+  "properties": {
+    "schema_version": { "$ref": "_defs.schema.json#/$defs/schema_version" },
+    "role": { "const": "size-judge" },
+    "verdict": { "enum": ["acceptable", "split"] },
+    "size_restated": {
+      "$comment": "The counted lines and files, restated from the tool's report — never re-derived by eye.",
+      "type": "string"
+    },
+    "reason": { "type": "string" },
+    "split_plan": {
+      "$comment": "How the change would divide into landable PRs; empty only when the size is acceptable.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["pr", "what", "files"],
+        "properties": {
+          "pr": { "type": "string" },
+          "what": { "type": "string" },
+          "files": { "type": "array", "items": { "type": "string" } },
+          "lines": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "note": { "type": "string" }
+  },
+  "allOf": [
+    {
+      "$comment": "A split verdict must say how to split; an acceptable one must not carry a plan.",
+      "if": { "required": ["verdict"], "properties": { "verdict": { "const": "split" } } },
+      "then": { "properties": { "split_plan": { "minItems": 2 } } }
+    },
+    {
+      "if": {
+        "required": ["verdict"],
+        "properties": { "verdict": { "const": "acceptable" } }
+      },
+      "then": { "properties": { "split_plan": { "maxItems": 0 } } }
+    }
+  ]
+}

--- a/scripts/pr_size/__init__.py
+++ b/scripts/pr_size/__init__.py
@@ -1,0 +1,40 @@
+"""Measure a PR the way the size policy counts it, and say whether it may proceed.
+
+The skills own the policy conversation; this package owns the deterministic half —
+which changed lines count (tests and generated files never do), which budget they are
+charged to, and which of pass / review / block that arithmetic forces. The public API
+here is the functional core, importable without click; the command lives in
+`pr_size.cli`.
+"""
+
+from .budget import code_budget, prose_budget, worst
+from .sizing import changed_paths, classify, measure
+from .types import (
+    Band,
+    Budget,
+    ChangedFile,
+    CommandRunner,
+    FileKind,
+    SizeError,
+    SizeReport,
+    Tally,
+    Verdict,
+)
+
+__all__ = [
+    "Band",
+    "Budget",
+    "ChangedFile",
+    "CommandRunner",
+    "FileKind",
+    "SizeError",
+    "SizeReport",
+    "Tally",
+    "Verdict",
+    "changed_paths",
+    "classify",
+    "code_budget",
+    "measure",
+    "prose_budget",
+    "worst",
+]

--- a/scripts/pr_size/__main__.py
+++ b/scripts/pr_size/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for `python -m pr_size`."""
+
+from __future__ import annotations
+
+from .cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/pr_size/budget.py
+++ b/scripts/pr_size/budget.py
@@ -1,0 +1,76 @@
+"""The policy: how many counted lines a PR may carry before a human must weigh in.
+
+Code and prose are budgeted separately and a PR is only as good as its worse class.
+Nothing else in the package knows a threshold — change the policy here.
+"""
+
+from __future__ import annotations
+
+from .constants import (
+    BAND_VERDICTS,
+    CODE_COHESION_STRICT_LINES,
+    CODE_LIMIT_FEW_FILES,
+    CODE_LIMIT_MANY_FILES,
+    CODE_TARGET_LINES,
+    FEW_FILES,
+    PROSE_LIMIT_LINES,
+    PROSE_TARGET_LINES,
+    VERDICT_SEVERITY,
+)
+from .types import Band, Budget, Tally, Verdict
+
+
+def code_budget(*, tally: Tally) -> Budget:
+    """Judge the code lines: one or two files earn the larger cap, three never do."""
+    limit: int = (
+        CODE_LIMIT_FEW_FILES if tally.files <= FEW_FILES else CODE_LIMIT_MANY_FILES
+    )
+    band: Band = _code_band(tally=tally, limit=limit)
+    return Budget(
+        files=tally.files,
+        lines=tally.lines,
+        target=CODE_TARGET_LINES,
+        limit=limit,
+        band=band,
+        verdict=BAND_VERDICTS[band],
+    )
+
+
+def prose_budget(*, tally: Tally) -> Budget:
+    """Judge the prose lines: one budget, no file-count relief — prose splits freely."""
+    band: Band = _prose_band(tally=tally)
+    return Budget(
+        files=tally.files,
+        lines=tally.lines,
+        target=PROSE_TARGET_LINES,
+        limit=PROSE_LIMIT_LINES,
+        band=band,
+        verdict=BAND_VERDICTS[band],
+    )
+
+
+def worst(*, verdicts: tuple[Verdict, ...]) -> Verdict:
+    """A PR is only as good as its worst budget class."""
+    return max(
+        verdicts, key=lambda verdict: VERDICT_SEVERITY[verdict], default=Verdict.PASS
+    )
+
+
+def _prose_band(*, tally: Tally) -> Band:
+    if tally.lines > PROSE_LIMIT_LINES:
+        return Band.OVER_LIMIT
+    if tally.lines > PROSE_TARGET_LINES:
+        return Band.OVER_TARGET
+    return Band.TARGET
+
+
+def _code_band(*, tally: Tally, limit: int) -> Band:
+    if tally.lines <= CODE_TARGET_LINES:
+        return Band.TARGET
+    if tally.lines > limit:
+        return Band.OVER_LIMIT
+    if tally.files > FEW_FILES:
+        return Band.MANY_FILES
+    if tally.lines >= CODE_COHESION_STRICT_LINES:
+        return Band.COHESION_STRICT
+    return Band.COHESION

--- a/scripts/pr_size/cli.py
+++ b/scripts/pr_size/cli.py
@@ -1,0 +1,101 @@
+"""The imperative shell: real git subprocesses, JSON on stdout, verdict as exit code.
+
+Exit codes are the verdict: 0 pass, 1 review (a judge must rule), 2 block, 3 the gate
+could not measure (bad ref, not a repository). A usage error from click also exits
+non-zero, so a broken invocation can never read as a pass.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import sys
+from dataclasses import asdict
+from typing import Any
+
+import click
+
+from .constants import EXIT_CODES, EXIT_ERROR, GIT_DIFF_FLAGS, INLINE_TEST_SUFFIXES
+from .sizing import changed_paths, measure
+from .types import CommandRunner, SizeError, SizeReport, Verdict
+
+
+def _subprocess_runner(*, argv: tuple[str, ...]) -> str:
+    """The real boundary: run a command, returning stdout, SizeError on failure."""
+    result: subprocess.CompletedProcess[str] = subprocess.run(
+        argv, capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        detail: str = result.stderr.strip() or result.stdout.strip()
+        raise SizeError(f"{shlex.join(argv)} failed: {detail}")
+    return result.stdout
+
+
+def diff_text(*, run: CommandRunner, repo: str, base: str, head: str) -> str:
+    """The diff the PR would show: every line added on this branch since `base`."""
+    return run(argv=("git", "-C", repo, *GIT_DIFF_FLAGS, f"{base}...{head}"))
+
+
+def inline_test_sources(
+    *, run: CommandRunner, repo: str, head: str, paths: tuple[str, ...]
+) -> dict[str, str]:
+    """Post-image content of the changed files whose tests could live inside them."""
+    wanted: tuple[str, ...] = tuple(
+        path for path in paths if path.endswith(tuple(INLINE_TEST_SUFFIXES))
+    )
+    return {
+        path: run(argv=("git", "-C", repo, "show", f"{head}:{path}")) for path in wanted
+    }
+
+
+def summarize(*, report: SizeReport) -> str:
+    """One line a human or a judge can act on: the counts, the caps, the call."""
+    return (
+        f"{report.verdict}: code {report.code.lines} added lines across "
+        f"{report.code.files} file(s) (target {report.code.target}, cap "
+        f"{report.code.limit}, band {report.code.band}); prose {report.prose.lines} "
+        f"(target {report.prose.target}, cap {report.prose.limit}); "
+        f"{report.tests.lines} test and {report.generated.lines} generated lines "
+        f"excluded"
+    )
+
+
+def run_cli(
+    *,
+    base: str,
+    head: str,
+    repo: str,
+    run: CommandRunner | None = None,
+) -> int:
+    """Measure `base...head` in `repo`, print the report, return the verdict's code."""
+    runner: CommandRunner = run if run is not None else _subprocess_runner
+    try:
+        text: str = diff_text(run=runner, repo=repo, base=base, head=head)
+        report: SizeReport = measure(
+            diff_text=text,
+            sources=inline_test_sources(
+                run=runner, repo=repo, head=head, paths=changed_paths(diff_text=text)
+            ),
+        )
+    except (SizeError, OSError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return EXIT_ERROR
+    payload: dict[str, Any] = {
+        "schema_version": "v1",
+        "base": base,
+        "head": head,
+        **asdict(report),
+        "summary": summarize(report=report),
+    }
+    print(json.dumps(payload, indent=2))
+    return EXIT_CODES[Verdict(report.verdict)]
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--base", required=True, metavar="REF", help="Ref the PR branches from.")
+@click.option("--head", default="HEAD", show_default=True, help="Ref being measured.")
+@click.option("--repo", default=".", show_default=True, help="Repository to measure.")
+def cli(*, base: str, head: str, repo: str) -> None:
+    """Judge a PR's size: which lines count, and whether that many may proceed."""
+    raise SystemExit(run_cli(base=base, head=head, repo=repo))

--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -1,0 +1,102 @@
+"""Every literal the size policy is pinned to, in one place."""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+from .types import Band, Verdict
+
+# The policy, in six numbers. Plan to the target; the caps are where a human's judgment
+# stops being invited. Few files buy a larger cap because one or two files can be a
+# single unit whose integrity a split would break — many files never are.
+CODE_TARGET_LINES: Final[int] = 35
+CODE_LIMIT_FEW_FILES: Final[int] = 100
+CODE_LIMIT_MANY_FILES: Final[int] = 50
+FEW_FILES: Final[int] = 2
+CODE_COHESION_STRICT_LINES: Final[int] = 76
+PROSE_TARGET_LINES: Final[int] = 100
+PROSE_LIMIT_LINES: Final[int] = 150
+
+# A file is a test when its directory or its name says so. Kept as one regex per
+# question (where it lives / what it is called) so a new language convention is one
+# alternative, not a new branch in the classifier.
+TEST_DIR_SEGMENTS: Final[frozenset[str]] = frozenset(
+    {"tests", "test", "__tests__", "spec", "specs", "e2e", "testdata", "fixtures"}
+)
+TEST_BASENAME: Final[re.Pattern[str]] = re.compile(
+    r"^(conftest\.py"
+    r"|test_[^/]+"
+    r"|[^/]+_test\.[a-z]+"
+    r"|[^/]+[._](test|spec)\.[a-z]+"
+    r"|[^/]+Tests?\.(java|kt|cs))$"
+)
+
+# Languages whose tests can live inside the source file they exercise.
+INLINE_TEST_SUFFIXES: Final[frozenset[str]] = frozenset({".rs"})
+# `#[test]`, `#[cfg(test)]`, `#[cfg(all(test, …))]` — but never `#[cfg(not(test))]`.
+RUST_TEST_ATTRIBUTE: Final[re.Pattern[str]] = re.compile(
+    r"^#\[(test\]|cfg\((all\(|any\()?test[,)])"
+)
+RUST_LITERAL_OR_COMMENT: Final[re.Pattern[str]] = re.compile(
+    r"\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|//.*$"
+)
+
+# Generated and vendored files are nobody's authorship: a lockfile or a bundle is a
+# byproduct of a change, never the change a reviewer reads.
+GENERATED_DIR_SEGMENTS: Final[frozenset[str]] = frozenset(
+    {"vendor", "node_modules", "dist", "build", "target", "__snapshots__", ".venv"}
+)
+GENERATED_BASENAME: Final[re.Pattern[str]] = re.compile(
+    r"^([^/]*\.lock"
+    r"|[^/]*-lock\.json"
+    r"|go\.sum"
+    r"|[^/]+\.min\.(js|css)"
+    r"|[^/]+\.snap"
+    r"|[^/]+_pb2\.pyi?)$"
+)
+
+# Prose is the writing a change ships — prompts, docs, a README. It is authored, so it
+# is budgeted; it is not code, so it is budgeted apart, and more loosely.
+PROSE_SUFFIXES: Final[frozenset[str]] = frozenset(
+    {".md", ".markdown", ".mdx", ".rst", ".txt", ".adoc"}
+)
+
+# How the shell talks to git and back to its caller. `--unified=0` keeps the parse
+# honest (no context line can be mistaken for an addition); `core.quotePath=false`
+# keeps non-ASCII paths readable rather than octal-escaped.
+GIT_DIFF_FLAGS: Final[tuple[str, ...]] = (
+    "-c",
+    "core.quotePath=false",
+    "diff",
+    "--unified=0",
+    "--no-color",
+    "--find-renames",
+)
+EXIT_CODES: Final[dict[Verdict, int]] = {
+    Verdict.PASS: 0,
+    Verdict.REVIEW: 1,
+    Verdict.BLOCK: 2,
+}
+EXIT_ERROR: Final[int] = 3
+
+# How a band maps to a call, and how two calls compare. Kept beside the numbers they
+# read: the whole policy is one file to change.
+BAND_VERDICTS: Final[dict[Band, Verdict]] = {
+    Band.TARGET: Verdict.PASS,
+    Band.MANY_FILES: Verdict.REVIEW,
+    Band.COHESION: Verdict.REVIEW,
+    Band.COHESION_STRICT: Verdict.REVIEW,
+    Band.OVER_TARGET: Verdict.REVIEW,
+    Band.OVER_LIMIT: Verdict.BLOCK,
+}
+VERDICT_SEVERITY: Final[dict[Verdict, int]] = {
+    Verdict.PASS: 0,
+    Verdict.REVIEW: 1,
+    Verdict.BLOCK: 2,
+}
+
+# What the unified diff we ask git for looks like: the post-image path marker and the
+# hunk header we read the new-file line numbers from.
+NEW_PATH_MARKER: Final[str] = "+++ b/"
+HUNK_HEADER: Final[re.Pattern[str]] = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)")

--- a/scripts/pr_size/inline_tests.py
+++ b/scripts/pr_size/inline_tests.py
@@ -1,0 +1,49 @@
+"""Which lines of a source file are tests when the tests live in the file itself.
+
+Rust is the case that forces this: `#[cfg(test)] mod tests { … }` sits in the same file
+as the code it exercises, so a path-based classifier would charge a PR's test lines to
+its code budget. Brace matching over literal-stripped lines is a heuristic, not a
+parser: a raw string (`r#"…"#`) spanning lines with unbalanced braces can mis-size a
+region. It errs toward ending the region early, which charges test lines to code —
+never the reverse, so the gate cannot be widened by a crafted test module.
+"""
+
+from __future__ import annotations
+
+from .constants import (
+    INLINE_TEST_SUFFIXES,
+    RUST_LITERAL_OR_COMMENT,
+    RUST_TEST_ATTRIBUTE,
+)
+
+
+def test_line_numbers(*, path: str, source: str) -> frozenset[int]:
+    """The 1-based line numbers of `source` that belong to an in-file test item."""
+    if not path.endswith(tuple(INLINE_TEST_SUFFIXES)):
+        return frozenset()
+    lines: list[str] = source.splitlines()
+    numbers: set[int] = set()
+    index: int = 0
+    while index < len(lines):
+        if RUST_TEST_ATTRIBUTE.match(lines[index].strip()):
+            end: int = _item_end(lines=lines, start=index)
+            numbers.update(range(index + 1, end + 2))
+            index = end + 1
+            continue
+        index += 1
+    return frozenset(numbers)
+
+
+def _item_end(*, lines: list[str], start: int) -> int:
+    """The 0-based index of the line closing the item attributed at `start`."""
+    depth: int = 0
+    opened: bool = False
+    for index in range(start, len(lines)):
+        code: str = RUST_LITERAL_OR_COMMENT.sub("", lines[index])
+        depth += code.count("{") - code.count("}")
+        opened = opened or "{" in code
+        if opened and depth <= 0:
+            return index
+        if not opened and ";" in code:
+            return index
+    return len(lines) - 1

--- a/scripts/pr_size/sizing.py
+++ b/scripts/pr_size/sizing.py
@@ -1,0 +1,117 @@
+"""The functional core: a unified diff in, a size verdict out."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from pathlib import PurePosixPath
+
+from .budget import code_budget, prose_budget, worst
+from .constants import (
+    GENERATED_BASENAME,
+    GENERATED_DIR_SEGMENTS,
+    HUNK_HEADER,
+    NEW_PATH_MARKER,
+    PROSE_SUFFIXES,
+    TEST_BASENAME,
+    TEST_DIR_SEGMENTS,
+)
+from .inline_tests import test_line_numbers
+from .types import Budget, ChangedFile, FileKind, SizeReport, Tally
+
+
+def measure(*, diff_text: str, sources: Mapping[str, str] | None = None) -> SizeReport:
+    """Charge a diff's added lines to their budget classes and judge the total.
+
+    `sources` carries the post-image content of changed files whose tests live inside
+    them (Rust); a file absent from it is charged entirely by its path.
+    """
+    files: tuple[ChangedFile, ...] = tuple(
+        _charge(path=path, added=added, sources=sources or {})
+        for path, added in _added_line_numbers(diff_text=diff_text).items()
+    )
+    code: Budget = code_budget(tally=_tally(files=files, kind=FileKind.CODE))
+    prose: Budget = prose_budget(tally=_tally(files=files, kind=FileKind.PROSE))
+    return SizeReport(
+        code=code,
+        prose=prose,
+        tests=_tally(files=files, kind=FileKind.TEST),
+        generated=_tally(files=files, kind=FileKind.GENERATED),
+        files=files,
+        verdict=worst(verdicts=(code.verdict, prose.verdict)),
+    )
+
+
+def changed_paths(*, diff_text: str) -> tuple[str, ...]:
+    """Every post-image path the diff touches, in the order git reported them."""
+    return tuple(_added_line_numbers(diff_text=diff_text))
+
+
+def classify(*, path: str) -> FileKind:
+    """Which budget a changed path is charged to — the one policy decision per file.
+
+    Generated wins over test wins over prose: a lockfile under `tests/` is still
+    nobody's authorship, and a test fixture is still a test whatever its suffix.
+    """
+    pure: PurePosixPath = PurePosixPath(path)
+    parts: tuple[str, ...] = pure.parts
+    directories: tuple[str, ...] = parts[:-1]
+    name: str = parts[-1]
+    if GENERATED_DIR_SEGMENTS.intersection(directories) or GENERATED_BASENAME.match(
+        name
+    ):
+        return FileKind.GENERATED
+    if TEST_DIR_SEGMENTS.intersection(directories) or TEST_BASENAME.match(name):
+        return FileKind.TEST
+    if pure.suffix.lower() in PROSE_SUFFIXES:
+        return FileKind.PROSE
+    return FileKind.CODE
+
+
+def _charge(
+    *, path: str, added: tuple[int, ...], sources: Mapping[str, str]
+) -> ChangedFile:
+    """One file's added lines, split off any that are tests living inside it."""
+    kind: FileKind = classify(path=path)
+    inline: frozenset[int] = test_line_numbers(path=path, source=sources.get(path, ""))
+    charged: int = sum(1 for number in added if number not in inline)
+    return ChangedFile(
+        path=path, kind=kind, lines=charged, test_lines=len(added) - charged
+    )
+
+
+def _tally(*, files: tuple[ChangedFile, ...], kind: FileKind) -> Tally:
+    """Sum one class. A file that only lost lines is free — nothing to read."""
+    charged: list[ChangedFile] = [
+        file for file in files if file.kind is kind and file.lines > 0
+    ]
+    lines: int = sum(file.lines for file in charged)
+    if kind is not FileKind.TEST:
+        return Tally(files=len(charged), lines=lines)
+    inline: list[ChangedFile] = [file for file in files if file.test_lines > 0]
+    return Tally(
+        files=len(charged) + len(inline),
+        lines=lines + sum(file.test_lines for file in inline),
+    )
+
+
+def _added_line_numbers(*, diff_text: str) -> dict[str, tuple[int, ...]]:
+    """Which post-image line numbers each changed path gained, keyed by that path."""
+    added: dict[str, list[int]] = {}
+    path: str | None = None
+    line_number: int = 0
+    for line in diff_text.splitlines():
+        header: re.Match[str] | None = HUNK_HEADER.match(line)
+        if line.startswith(NEW_PATH_MARKER):
+            path = line.removeprefix(NEW_PATH_MARKER)
+            added.setdefault(path, [])
+        elif header is not None:
+            line_number = int(header.group(1))
+        elif path is None:
+            continue
+        elif line.startswith("+"):
+            added[path].append(line_number)
+            line_number += 1
+        elif line.startswith(" "):
+            line_number += 1
+    return {path: tuple(numbers) for path, numbers in added.items()}

--- a/scripts/pr_size/types.py
+++ b/scripts/pr_size/types.py
@@ -1,0 +1,95 @@
+"""The vocabulary the size gate speaks: what a change costs, and what that costs it."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+
+
+class SizeError(Exception):
+    """A diff or a repository the gate cannot measure."""
+
+
+class Verdict(StrEnum):
+    """What the deterministic gate says about a size; the worst class wins overall."""
+
+    PASS = "pass"
+    REVIEW = "review"
+    BLOCK = "block"
+
+
+class FileKind(StrEnum):
+    """Which budget a changed file's added lines are charged to, if any."""
+
+    CODE = "code"
+    PROSE = "prose"
+    TEST = "test"
+    GENERATED = "generated"
+
+
+class Band(StrEnum):
+    """Where a count sits against its budget — the judge's dispatch key.
+
+    `target` needs no judgment; `over-limit` admits none. The three between are the
+    grey zone, and `cohesion-strict` is the one that must argue integrity to survive.
+    """
+
+    TARGET = "target"
+    MANY_FILES = "many-files"
+    COHESION = "cohesion"
+    COHESION_STRICT = "cohesion-strict"
+    OVER_TARGET = "over-target"
+    OVER_LIMIT = "over-limit"
+
+
+@dataclass(frozen=True)
+class Tally:
+    """How much of one class a diff changed. Informational for excluded classes."""
+
+    files: int
+    lines: int
+
+
+@dataclass(frozen=True)
+class Budget:
+    """A tally of a budgeted class, judged against that class's target and cap."""
+
+    files: int
+    lines: int
+    target: int
+    limit: int
+    band: Band
+    verdict: Verdict
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    """One changed path: what it is, and what its added lines cost.
+
+    `lines` is charged to `kind`; `test_lines` is the remainder that lives inside the
+    file but belongs to the test budget (a Rust `#[cfg(test)]` block).
+    """
+
+    path: str
+    kind: FileKind
+    lines: int
+    test_lines: int
+
+
+@dataclass(frozen=True)
+class SizeReport:
+    """The whole verdict: every budget class, and the worst verdict among them."""
+
+    code: Budget
+    prose: Budget
+    tests: Tally
+    generated: Tally
+    files: tuple[ChangedFile, ...]
+    verdict: Verdict
+
+
+class CommandRunner(Protocol):
+    """Runs one argv, returning stdout; raises SizeError on a non-zero exit."""
+
+    def __call__(self, *, argv: tuple[str, ...]) -> str: ...

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -43,6 +43,7 @@ addopts = [
   "--cov=validate_return",
   "--cov=check_prompt_schemas",
   "--cov=dispatch",
+  "--cov=pr_size",
   "--cov-report=term-missing",
 ]
 filterwarnings = ["error"]

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -1,0 +1,247 @@
+"""Tests for the PR size gate (a unified diff -> a countable-lines verdict).
+
+The tool is a functional core (classify each changed path, count the added lines that
+count, apply the bands) behind a thin imperative shell (git subprocess). We test the
+core through `measure` on literal diff text and the shell through an injected fake
+runner — never a real git.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Final
+
+import pytest
+
+from pr_size import SizeError, measure
+from pr_size.cli import run_cli
+
+
+def _diff(*, path: str, added: int, start: int = 1) -> str:
+    """A minimal unified diff adding `added` lines to `path`."""
+    body: str = "".join(f"+line {index}\n" for index in range(added))
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        f"@@ -0,0 +{start},{added} @@\n"
+        f"{body}"
+    )
+
+
+def _whole_file_diff(*, path: str, content: str) -> str:
+    """A unified diff that adds `content` as a new file, so line numbers line up."""
+    lines: list[str] = content.splitlines()
+    body: str = "".join(f"+{line}\n" for line in lines)
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- /dev/null\n"
+        f"+++ b/{path}\n"
+        f"@@ -0,0 +1,{len(lines)} @@\n"
+        f"{body}"
+    )
+
+
+SMALL_CHANGE: Final[int] = 10
+BIG_CHANGE: Final[int] = 40
+
+RUST_WITH_INLINE_TESTS: Final[str] = """\
+pub fn total(items: &[u32]) -> u32 {
+    items.iter().sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sums_items() {
+        assert_eq!(total(&[1, 2]), 3);
+    }
+}
+"""
+RUST_CODE_LINES: Final[int] = 4
+
+
+def test_counts_added_lines_of_one_code_file() -> None:
+    report = measure(diff_text=_diff(path="cart.py", added=SMALL_CHANGE))
+
+    assert report.code.lines == SMALL_CHANGE
+    assert report.code.files == 1
+    assert report.verdict == "pass"
+
+
+def test_test_files_are_never_charged_to_the_code_budget() -> None:
+    report = measure(
+        diff_text=_diff(path="cart.py", added=SMALL_CHANGE)
+        + _diff(path="tests/test_cart.py", added=BIG_CHANGE)
+        + _diff(path="web/cart.test.ts", added=BIG_CHANGE)
+    )
+
+    assert report.code.lines == SMALL_CHANGE
+    assert report.code.files == 1
+    assert report.tests.lines == BIG_CHANGE * 2
+    assert report.verdict == "pass"
+
+
+def test_prose_and_generated_files_stay_out_of_the_code_budget() -> None:
+    report = measure(
+        diff_text=_diff(path="cart.py", added=SMALL_CHANGE)
+        + _diff(path="docs/guide.md", added=BIG_CHANGE)
+        + _diff(path="uv.lock", added=BIG_CHANGE)
+        + _diff(path="web/dist/bundle.js", added=BIG_CHANGE)
+    )
+
+    assert report.code.lines == SMALL_CHANGE
+    assert report.code.files == 1
+    assert report.prose.lines == BIG_CHANGE
+    assert report.prose.files == 1
+    assert report.generated.lines == BIG_CHANGE * 2
+
+
+def test_rust_cfg_test_block_is_charged_to_tests_not_code() -> None:
+    path: Final[str] = "src/cart.rs"
+
+    report = measure(
+        diff_text=_whole_file_diff(path=path, content=RUST_WITH_INLINE_TESTS),
+        sources={path: RUST_WITH_INLINE_TESTS},
+    )
+
+    assert report.code.lines == RUST_CODE_LINES
+    assert (
+        report.tests.lines == len(RUST_WITH_INLINE_TESTS.splitlines()) - RUST_CODE_LINES
+    )
+
+
+def _spread(*, files: int, lines: int) -> str:
+    """A diff over `files` code files carrying `lines` added lines between them."""
+    each: list[int] = [1] * files
+    each[0] += lines - files
+    return "".join(
+        _diff(path=f"src/module{index}.py", added=added)
+        for index, added in enumerate(each)
+    )
+
+
+@pytest.mark.parametrize(
+    ("files", "lines", "verdict"),
+    [
+        (1, 35, "pass"),
+        (5, 35, "pass"),
+        (3, 36, "review"),
+        (3, 50, "review"),
+        (3, 51, "block"),
+        (9, 51, "block"),
+        (1, 36, "review"),
+        (2, 100, "review"),
+        (2, 101, "block"),
+        (1, 400, "block"),
+    ],
+)
+def test_code_bands(files: int, lines: int, verdict: str) -> None:
+    report = measure(diff_text=_spread(files=files, lines=lines))
+
+    assert report.code.lines == lines
+    assert report.code.files == files
+    assert report.verdict == verdict
+    assert report.code.verdict == verdict
+
+
+@pytest.mark.parametrize(
+    ("lines", "verdict"),
+    [(100, "pass"), (101, "review"), (150, "review"), (151, "block")],
+)
+def test_prose_bands(lines: int, verdict: str) -> None:
+    report = measure(diff_text=_diff(path="skills/thing/SKILL.md", added=lines))
+
+    assert report.prose.lines == lines
+    assert report.prose.verdict == verdict
+    assert report.code.verdict == "pass"
+    assert report.verdict == verdict
+
+
+def test_a_pr_is_only_as_good_as_its_worst_budget() -> None:
+    report = measure(
+        diff_text=_diff(path="cart.py", added=SMALL_CHANGE)
+        + _diff(path="README.md", added=200)
+    )
+
+    assert report.code.verdict == "pass"
+    assert report.verdict == "block"
+
+
+class FakeGit:
+    """Answers the two git questions the shell asks, and records every argv."""
+
+    def __init__(self, *, diff: str, sources: dict[str, str] | None = None) -> None:
+        self.calls: list[tuple[str, ...]] = []
+        self._diff = diff
+        self._sources = sources or {}
+
+    def __call__(self, *, argv: tuple[str, ...]) -> str:
+        self.calls.append(argv)
+        if "diff" in argv:
+            return self._diff
+        if "show" in argv:
+            return self._sources[argv[-1].split(":", 1)[1]]
+        return ""
+
+
+def test_cli_prints_the_report_and_exits_on_the_verdict(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    git = FakeGit(diff=_spread(files=4, lines=60))
+
+    exit_code: int = run_cli(base="origin/main", head="HEAD", repo=".", run=git)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 2
+    assert payload["verdict"] == "block"
+    assert payload["code"] == {
+        "files": 4,
+        "lines": 60,
+        "target": 35,
+        "limit": 50,
+        "band": "over-limit",
+        "verdict": "block",
+    }
+    assert payload["summary"]
+
+
+def test_cli_reads_rust_post_images_so_inline_tests_are_excluded() -> None:
+    path: Final[str] = "src/cart.rs"
+    git = FakeGit(
+        diff=_whole_file_diff(path=path, content=RUST_WITH_INLINE_TESTS),
+        sources={path: RUST_WITH_INLINE_TESTS},
+    )
+
+    exit_code: int = run_cli(base="main", head="HEAD", repo="/repo", run=git)
+
+    assert exit_code == 0
+    assert ("git", "-C", "/repo", "show", f"HEAD:{path}") in git.calls
+
+
+def test_cli_exits_non_zero_without_a_verdict_when_git_fails(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def explode(*, argv: tuple[str, ...]) -> str:
+        raise SizeError(f"bad revision: {argv[-1]}")
+
+    exit_code: int = run_cli(base="nope", head="HEAD", repo=".", run=explode)
+
+    assert exit_code not in {0, 1, 2}
+    assert capsys.readouterr().out == ""
+
+
+def test_a_declared_test_module_does_not_swallow_the_code_below_it() -> None:
+    path: Final[str] = "src/lib.rs"
+    source: Final[str] = (
+        "#[cfg(test)]\nmod tests;\n\npub fn total() -> u32 {\n    3\n}\n"
+    )
+
+    report = measure(
+        diff_text=_whole_file_diff(path=path, content=source), sources={path: source}
+    )
+
+    assert report.tests.lines == 2
+    assert report.code.lines == 4

--- a/skills/make-pr-lite/SKILL.md
+++ b/skills/make-pr-lite/SKILL.md
@@ -43,12 +43,18 @@ guarantees that.)
   changed language with no profile → stop and report.
 - **rules to pass** — always `design-principles.md`; `tdd.md` for behavioral work; the language
   rule (`python.md`/`typescript.md`/`rust.md`) per changed file type.
+- **size budget** — the PR may add **35 counted lines**; past that it must argue, past the cap
+  it cannot land (step 4's size gate). Counted lines exclude tests (including Rust
+  `#[cfg(test)]` blocks), lockfiles, and generated output; prose (`.md`, docs) carries its own
+  budget. The measuring tool is the package staged at `~/.claude/at/scripts/pr_size` — it, not
+  your own count, decides.
 
 ## Agents
 
 | Agent | Count | Job |
 |---|---|---|
 | `coder-lite` | 1 (+ fix) | plan behaviors, self-TDD the whole PR, one commit |
+| `size-judge` | 1, only on a `review` size verdict | did this PR have to be this big, or does it split? |
 | `reviewer` | 3, parallel | the panel — each a focused lens-group |
 | `critic` | 1 (+1 on `partial`) | goal-fit: did the PR achieve the task? |
 
@@ -104,6 +110,27 @@ gate output, and the reviewers' findings. Each reviewer finding carries a 1–10
    | the `test` gate red | `mode: fix` — behavioral regression |
    | any other gate red | `mode: fix` — mechanical; name the gate |
    | gate `setup` itself fails | stop and report (environment, not a coder bug) |
+
+   **Size gate** — with the gates green and before the panel, run in `target_cwd`:
+
+   ```
+   PYTHONPATH=~/.claude/at/scripts uv run --no-project --with click \
+     python -m pr_size --base <base> --repo <target_cwd>
+   ```
+
+   It prints the counts and a `verdict` (also its exit code: 0 pass, 1 review, 2 block, 3
+   could not measure). Route — the table is total:
+
+   | verdict | Action |
+   |---|---|
+   | `pass` | continue to the panel |
+   | `review` | dispatch `size-judge` (base, task spec, `target_cwd`); validate its return against `~/.claude/at/schemas/size-judge.schema.json`; `acceptable` → continue, `split` → stop and report its `split_plan` |
+   | `block` | stop and report — over a hard cap (>50 code lines across 3+ files, >100 across 1–2, >150 prose). Give the tool's `files` breakdown and the smallest first PR you can name |
+   | could not measure | report the tool's error; never treat an unmeasured PR as passing |
+
+   Never route a size fix to the coder and never edit counted files to duck a band: an
+   oversized PR is re-scoped, not trimmed. A `block` is not waivable by you — only the human
+   may override it, and only explicitly.
 5. **Panel + critic (judgment — once, on the green diff).** Dispatch the 3 reviewers (one message),
    then the critic; read the returns directly. Each finding's `score` is severity (1–100, higher =
    worse). **Deduplicate by `(file:line)`** (fall back to `(file:issue)` when a finding has no line),
@@ -126,8 +153,8 @@ gate output, and the reviewers' findings. Each reviewer finding carries a 1–10
    coverage. One fix round (separate from step 4's budget); a second only if round 1 introduced a
    new blocker.
    Then Done, or escalate the remainder to the human as waive-or-rescope.
-7. **Done.** When all behaviors and gates are green, no CRITICAL / `>=70` / aggregate blocker, and
-   critic `achieved`. **Squash to one commit:**
+7. **Done.** When all behaviors and gates are green, the size gate `pass` or its judge
+   `acceptable`, no CRITICAL / `>=70` / aggregate blocker, and critic `achieved`. **Squash to one commit:**
    `git reset --soft <base> && git commit -m "<conventional subject>"` (no AI attribution).
    Confirm only boundary files changed (`git diff --name-only <base>...HEAD`). Write the evidence
    handoff `<run_root>/evidence/<branch-slug>/evidence.json` (schema

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -25,6 +25,7 @@ decide the next step.
 |-------|------|-----|
 | `tdd-runner` | RED, once per behavior | write ONE failing test, prove it fails for the right reason |
 | `worker-coder` | GREEN & REFACTOR (per behavior); non-behavioral edits | minimal code to pass the test, a behavior-preserving refactor, or an exact non-behavioral change; commit |
+| `size-judge` | at the size gate, only on a `review` verdict | did this PR have to be this big, or does it split? |
 | `reviewer` | after gates are green | quality + bugs + security + line-by-line rule conformance on the diff |
 | `critic` | with the reviewer, on the gate-green diff | goal-fit: did the PR achieve the task? |
 
@@ -84,6 +85,11 @@ Resolve before the first dispatch:
   of that profile's `triggers` globs in `~/.claude/at/gates/*.json` (the lists cover both
   root-level and nested forms). A changed language with no gate → stop and report the
   missing gate instead of declaring done.
+- **Size budget** — the PR may add **35 counted lines**; past that it must argue, and
+  past the cap it cannot land (see step 5's size gate). Counted lines exclude tests
+  (including Rust `#[cfg(test)]` blocks), lockfiles, and generated output; prose (`.md`,
+  docs) carries its own budget. The measuring tool is the package staged at
+  `~/.claude/at/scripts/pr_size` — it, not your own count, decides.
 
 ## Tool boundaries
 
@@ -114,7 +120,10 @@ Resolve before the first dispatch:
    failure.
 3. **Plan behaviors.** Per `tdd.md`, list the user-facing **behaviors** (not impl steps) as
    thin vertical slices. Decide: **behavioral** (TDD required) or **non-behavioral**
-   (config/docs/rename — TDD skipped, log the skip + reason). Non-behavioral: log the
+   (config/docs/rename — TDD skipped, log the skip + reason). **Size the plan here**: if
+   the behaviors together head past the 35-line target, stop for re-scope now — splitting
+   is cheapest before the code exists, and step 5's size gate does not negotiate after.
+   Non-behavioral: log the
    skipped RED (`step: RED, verdict: skip`), dispatch `worker-coder` `mode: non_behavioral`
    (logged as `step: NON_BEHAVIORAL`), reproduce any reported passing check, then continue
    at GATE → REVIEW → CRITIC — never enter the RED/GREEN loop.
@@ -152,6 +161,30 @@ Resolve before the first dispatch:
    `mode: non_behavioral` for format/lint/type/build, but a failing **test** gate is a
    behavioral regression that returns to that behavior's RED/GREEN cycle. Max **2 gate-fix
    rounds**, then stop / re-scope.
+
+   **Size gate** — once the language gates are green, and before any judgment pass, run in
+   `target_cwd`:
+
+   ```
+   PYTHONPATH=~/.claude/at/scripts uv run --no-project --with click \
+     python -m pr_size --base <base> --repo <target_cwd>
+   ```
+
+   It prints the counts and a `verdict` (also its exit code: 0 pass, 1 review, 2 block, 3
+   could not measure). Log the run (`step: SIZE, role: architect`) and route — the table is
+   total:
+
+   | verdict | Action |
+   |---|---|
+   | `pass` | continue to review + critic |
+   | `review` | dispatch `size-judge` (base, task spec, `target_cwd`); validate its return against `~/.claude/at/schemas/size-judge.schema.json`; `acceptable` → continue, `split` → **stop / re-scope**, reporting its `split_plan` |
+   | `block` | **stop / re-scope** — over a hard cap (>50 code lines across 3+ files, >100 across 1–2, >150 prose). Report the tool's `files` breakdown and the smallest first PR you can name |
+   | could not measure | report the tool's error; never treat an unmeasured PR as passing |
+
+   The size gate never routes a fix: an oversized PR is re-scoped, never trimmed to fit,
+   and you never edit the counted files to duck a band. **A `block` is not waivable by
+   you** — only the human may override it, and only as an explicit waiver row
+   (`step: SIZE, verdict: skip, note: "waived by human: <reason>"`).
 6. **Review + critic (the judgment pass — once, on the gate-green diff).** Dispatch
    `reviewer` with the base ref (it runs `git diff <base>...HEAD` itself), passing
    `design-principles.md`, the language rule per changed file type, and `tdd.md`. Then
@@ -184,8 +217,8 @@ Resolve before the first dispatch:
    blocker. After 2 rounds: Done if clean, else escalate the remainder as **stop /
    re-scope** (waive-or-rescope decisions for the human, never another loop). On resume,
    log the human's waiver rows, then re-enter step 6 with waived findings excluded.
-8. **Done** → only when: all behaviors green, all gates green, no unwaived blocker per step
-   6's waivability rule, critic `achieved`, and any step-7 fix re-verified per the
+8. **Done** → only when: all behaviors green, all gates green, the size gate `pass` or its
+   judge `acceptable`, no unwaived blocker per step 6's waivability rule, critic `achieved`, and any step-7 fix re-verified per the
    proportional rule. Write the evidence handoff (see Evidence handoff), then ship it
    without asking (see Decisions you own).
 
@@ -196,8 +229,8 @@ Append **one line per subagent call, TDD skip, gate run, and human waiver** to `
 create nested paths. Schema:
 
 ```json
-{"ts":"<ISO8601>","run":"<run-id>","step":"RED|GREEN|REFACTOR|NON_BEHAVIORAL|GATE|REVIEW|CRITIC",
- "role":"tdd-runner|coder|reviewer|critic|architect","prompt":"<full prompt you sent>",
+{"ts":"<ISO8601>","run":"<run-id>","step":"RED|GREEN|REFACTOR|NON_BEHAVIORAL|GATE|SIZE|REVIEW|CRITIC",
+ "role":"tdd-runner|coder|size-judge|reviewer|critic|architect","prompt":"<full prompt you sent>",
  "result":"<full agent return>","verdict":"pass|fail|skip","files":["<changed paths>"],
  "note":"<e.g. TDD skip reason, retry #, decision made>"}
 ```


### PR DESCRIPTION
Our PRs land at 300–1000 lines. The planning skills asked for ~100–200 LOC and nothing enforced it, so nothing held. This is the enforcement half.

## What counts

Added lines, excluding:
- **tests** — by path convention (`tests/`, `test_*.py`, `*.test.ts`, …) **and** Rust's in-file `#[cfg(test)]` / `#[test]` blocks, found by brace-walking the post-image with string/comment literals stripped
- **lockfiles and generated/vendored output** — `*.lock`, `go.sum`, `dist/`, `node_modules/`, `*.min.js`, snapshots

Comments and blank lines **do** count — they are lines a reviewer reads. Prose (`.md`, docs) is counted and budgeted apart from code.

## The bands

| class | files | lines | verdict |
|---|---|---|---|
| code | any | ≤ 35 | **pass** — the plan-time target |
| code | 3+ | 36–50 | judged |
| code | 3+ | > 50 | **block** |
| code | 1–2 | 36–75 | judged |
| code | 1–2 | 76–100 | judged, strictly (`cohesion-strict`) |
| code | 1–2 | > 100 | **block** |
| prose | any | ≤ 100 / ≤ 150 / > 150 | pass / judged / **block** |

A PR is only as good as its worse class. One or two files earn the larger cap because they can be a single unit a split would break; three files never are.

## Deterministic gate + judge

`pass` needs no agent. `block` admits none. Only the middle reaches the new `size-judge` agent, which runs the tool itself, reads the diff, **defaults to `split`**, and must name the PRs it would land instead (schema-enforced: a `split` verdict without a plan is invalid).

```
PYTHONPATH=~/.claude/at/scripts uv run --no-project --with click \
  python -m pr_size --base <base> --repo <repo>
```

Exit codes are the verdict — 0 pass, 1 review, 2 block, 3 unmeasurable — so a broken invocation fails closed rather than reading as a pass.

## Wiring

- **make-pr** — step 5, right after the language gates go green; logged as a `SIZE` row in the run JSONL
- **make-pr-lite** — step 4, before the reviewer panel
- Both intake steps now state the budget, and make-pr's plan step stops for re-scope *before* the code exists
- A block is **stop / re-scope**, never a fix: an oversized PR is re-scoped, not trimmed, and neither skill may waive it — only a human, explicitly

## This PR fails its own gate

`block: code 652 added lines across 11 file(s); prose 154; 247 test lines excluded`

Reported rather than hidden: the gate cannot pre-date itself, and a new module with a real test suite has a floor well above 35 lines. Worth deciding before this lands — see the note in the review thread.

## Verification

- 57 tests green (`ruff format`, `ruff check`, `mypy --strict`, `pytest -W error`); 182 installer tests green; `at validate` clean
- Band tables and the two safety behaviors (a git failure must not read as pass; `mod tests;` must not swallow the file below it) were mutation-checked — each mutant killed
- End-to-end against real git on a Rust file whose test module contains a `"{"` literal: 4 code lines charged, 10 test lines excluded