### PR TITLE
docs(skills): plan PRs at ~35 counted lines, not ~100–200 LOC

### DIFF
--- a/skills/course-correct/SKILL.md
+++ b/skills/course-correct/SKILL.md
@@ -121,7 +121,8 @@ Run them in parallel (one message, many calls); collect the findings.
 **ADD** / **REMOVE** / **RE-SCOPE** / **RE-ORDER** a slice (`#n` in Build plan —
 *Demoable as / Mode / Size / Blocked by*) or a PR row (`n.k` in PR breakdown —
 *What / LOC / Blocked by / Status / Done when*). Rows only, no coder prompts; PRs
-stay ~100–200 LOC excluding tests. Edits here change the table but not its PR-map
+stay at ~35 counted lines (added lines excluding tests, lockfiles, and generated
+output) — the size gate refuses over 50 across 3+ files, over 100 across 1–2. Edits here change the table but not its PR-map
 artifact — Phase 6 flags a re-run of `/pr-breakdown` to redraw it.
 
 Always write the rebuilt **Status block** to `status.md` — even on track, since

--- a/skills/improve-architecture/SKILL.md
+++ b/skills/improve-architecture/SKILL.md
@@ -142,7 +142,7 @@ Write `findings.md`, one block per surviving candidate:
 <red flag> — <one-line why it trips>
 Evidence: <callers / dep direction / N sites>
 Before: <interface sketch>   →   After: <interface sketch>
-Effort: <boundaries crossed; slice any >~200 LOC>   ·   Depth: <deep / shallow>
+Effort: <boundaries crossed; slice into ~35-counted-line PRs>   ·   Depth: <deep / shallow>
 ```
 
 Lead each headline with its op and the count it kills. **Gate: nothing is acted on
@@ -160,7 +160,7 @@ op, sketch two *After* options (design it twice). If it buckles, redesign with t
 user before any PR opens. Only then:
 
 - A multi-module reshape (several PRs) → `/breakdown` → PRD → slices → PR rows.
-- A single scoped refactor (one ~100–200 LOC PR) → `/make-pr`.
+- A single scoped refactor (one PR of ~35 counted lines) → `/make-pr`.
 
 Seed the pipeline with the candidate's *target · op · evidence · before→after* so it
 starts test-first from the audit. After handoff, offer to record the new boundary in

--- a/skills/pr-breakdown/SKILL.md
+++ b/skills/pr-breakdown/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: pr-breakdown
-description: Use when a PRD issue's slice plan needs breaking into small ~100–200 LOC pull requests recorded as a table in that same issue and drawn as a private claude.ai PR-map artifact, or invokes /pr-breakdown.
+description: Use when a PRD issue's slice plan needs breaking into small pull requests (~35 counted lines each, tests excluded) recorded as a table in that same issue and drawn as a private claude.ai PR-map artifact, or invokes /pr-breakdown.
 ---
 
 # PR Breakdown
 
-Break the slice plan in a PRD issue into **small PRs (~100–200 LOC, excluding tests)**
-and keep two views of them: a **table** in the same issue, one row per PR, and a **PR
+Break the slice plan in a PRD issue into **small PRs (~35 counted lines each)** and
+keep two views of them: a **table** in the same issue, one row per PR, and a **PR
 map** — a private claude.ai artifact laying the PRs out as waves, with blocked-by edges
 and a card per PR.
 
@@ -42,15 +42,19 @@ artifact).
 ## Phase 2 — Write the PR rows
 
 Split each slice into PRs — one cohesive, reviewable, demoable change each, foundations
-before the PRs that use them, over ~200 LOC means split again. **Rows only**: no coder
+before the PRs that use them. **Budget each PR at ~35 counted lines** — added lines
+excluding tests, lockfiles, and generated output, with prose (`.md`, docs) counted apart.
+A PR the size gate will not pass is a PR you must split now: **over 50 counted lines is
+unlandable once it touches 3+ files, over 100 on 1–2 files, over 150 of prose.** Estimate
+high: a row you guess at 40 lands at 60. More, smaller rows are always the right answer. **Rows only**: no coder
 prompts (module boundaries, acceptance criteria) — those come later, one PR at a time.
 
 ```markdown
 ### Slice 1 — <name> (2 PRs)
 | PR | What | LOC | Blocked by | Status | Done when |
 |----|------|-----|-----------|--------|-----------|
-| 1.1 | ... | ~120 | — | Todo | <observable result> |
-| 1.2 | ... | ~140 | 1.1 | Todo | ... |
+| 1.1 | ... | ~30 | — | Todo | <observable result> |
+| 1.2 | ... | ~35 | 1.1 | Todo | ... |
 ```
 
 Close the tables with `**Estimated total:** ~P PRs · W waves.`

--- a/skills/to-issues/SKILL.md
+++ b/skills/to-issues/SKILL.md
@@ -31,7 +31,8 @@ vocabulary; respect ADRs.
 Each slice carries a **Demoable as** line (how you'd demo or verify it — if you
 can't write one, it isn't end-to-end), a **Mode** (`AFK` = an agent runs it alone;
 `HITL` = needs the user: design taste, UX, a judgment call), a **Size** (`S`/`M`/`L`,
-a rough feel — real LOC come in pr-breakdown), and **Blocked by**.
+a rough feel — real line counts come in pr-breakdown, which budgets each PR at ~35
+counted lines, so an `L` slice means many PRs, never one big one), and **Blocked by**.
 
 ```markdown
 ## Build plan — vertical slices


### PR DESCRIPTION
The planning skills set the size expectation the pipeline then fails to meet. `pr-breakdown` budgeted each PR at ~100–200 LOC and its example rows said `~120` and `~140` — so a plan that looked correct produced PRs the new size gate (#147) blocks on sight.

Retargets the budget to **~35 counted lines** and states the hard caps where a planner will actually read them:

- **pr-breakdown** — the budget, the caps (>50 with 3+ files, >100 with 1–2, >150 prose), what "counted" excludes, and "estimate high: a row you guess at 40 lands at 60"; example rows now `~30` / `~35`
- **to-issues** — an `L` slice means *many* PRs, never one big one
- **course-correct** — the same budget when it re-scopes existing rows
- **improve-architecture** — a scoped refactor hands off as a ~35-line PR, and effort estimates slice to that

Independent of #147 — no dependency either way, though the two are only useful together.

Measured by the gate from #147: `pass: code 0 added lines; prose 16 (target 100, cap 150)`.