### PR TITLE
feat(size) 1/10: read a diff into the lines each file gained

### DIFF
--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -1,0 +1,11 @@
+"""Every literal the size policy is pinned to, in one place."""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+# The unified diff we ask git for: the post-image path marker, and the hunk header we
+# read new-file line numbers from.
+NEW_PATH_MARKER: Final[str] = "+++ b/"
+HUNK_HEADER: Final[re.Pattern[str]] = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)")

--- a/scripts/pr_size/sizing.py
+++ b/scripts/pr_size/sizing.py
@@ -1,0 +1,33 @@
+"""What a diff costs: which lines it adds, and where they land in the new file."""
+
+from __future__ import annotations
+
+import re
+
+from .constants import HUNK_HEADER, NEW_PATH_MARKER
+
+
+def added_line_numbers(*, diff_text: str) -> dict[str, tuple[int, ...]]:
+    """Which post-image line numbers each changed path gained, keyed by that path.
+
+    Line numbers, not a count, because a language can hide tests inside a source file:
+    excluding those needs to know which lines an addition landed on.
+    """
+    added: dict[str, list[int]] = {}
+    path: str | None = None
+    line_number: int = 0
+    for line in diff_text.splitlines():
+        header: re.Match[str] | None = HUNK_HEADER.match(line)
+        if line.startswith(NEW_PATH_MARKER):
+            path = line.removeprefix(NEW_PATH_MARKER)
+            added.setdefault(path, [])
+        elif header is not None:
+            line_number = int(header.group(1))
+        elif path is None:
+            continue
+        elif line.startswith("+"):
+            added[path].append(line_number)
+            line_number += 1
+        elif line.startswith(" "):
+            line_number += 1
+    return {path: tuple(numbers) for path, numbers in added.items()}

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -1,0 +1,50 @@
+"""Tests for the PR size gate (a unified diff -> what it costs, by budget class).
+
+The tool is a functional core (parse the diff, classify each path, apply the bands)
+behind a thin imperative shell (git subprocess). We test the core on literal diff text
+and the shell through an injected fake runner — never a real git.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from pr_size.sizing import added_line_numbers
+
+
+def _diff(*, path: str, added: int, start: int = 1) -> str:
+    """A minimal unified diff adding `added` lines to `path` at `start`."""
+    body: str = "".join(f"+line {index}\n" for index in range(added))
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        f"@@ -0,0 +{start},{added} @@\n"
+        f"{body}"
+    )
+
+
+SMALL_CHANGE: Final[int] = 10
+
+
+def test_added_lines_are_numbered_from_their_hunk_header() -> None:
+    diff_text: str = _diff(path="cart.py", added=3, start=40)
+
+    assert added_line_numbers(diff_text=diff_text) == {"cart.py": (40, 41, 42)}
+
+
+def test_every_changed_path_is_reported_even_when_it_only_lost_lines() -> None:
+    deletion: str = (
+        "diff --git a/gone.py b/gone.py\n"
+        "--- a/gone.py\n"
+        "+++ b/gone.py\n"
+        "@@ -1,3 +0,0 @@\n"
+        "-one\n-two\n-three\n"
+    )
+
+    numbered: dict[str, tuple[int, ...]] = added_line_numbers(
+        diff_text=deletion + _diff(path="cart.py", added=SMALL_CHANGE)
+    )
+
+    assert numbered["gone.py"] == ()
+    assert len(numbered["cart.py"]) == SMALL_CHANGE


### PR DESCRIPTION
First of ten slices replacing #147, which I had to close: it was 652 lines across 11 files — the exact thing the gate it added exists to refuse. Each slice here measures itself with the tool and stays inside the caps; the number in each title is its position in the stack.

**This slice:** `added_line_numbers` turns a unified diff into the post-image line numbers each path gained.

Numbers rather than a count because Rust hides tests inside the source file they exercise (slice 3): excluding those needs to know *which* lines an addition landed on, which a bare count throws away.

`pass: gate says review — code 44 added lines across 2 files (target 35, cap 100, band cohesion)`