### PR TITLE
feat(size) 2/10: classify each changed path into the budget it is charged to

### DIFF
--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -9,3 +9,28 @@ from typing import Final
 # read new-file line numbers from.
 NEW_PATH_MARKER: Final[str] = "+++ b/"
 HUNK_HEADER: Final[re.Pattern[str]] = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)")
+
+# A file is a test when its directory or its name says so — one regex per question, so
+# a new language's convention is one more alternative, not a new branch.
+TEST_DIR_SEGMENTS: Final[frozenset[str]] = frozenset(
+    {"tests", "test", "__tests__", "spec", "specs", "e2e", "testdata", "fixtures"}
+)
+TEST_BASENAME: Final[re.Pattern[str]] = re.compile(
+    r"^(conftest\.py|test_[^/]+|[^/]+_test\.[a-z]+"
+    r"|[^/]+[._](test|spec)\.[a-z]+|[^/]+Tests?\.(java|kt|cs))$"
+)
+
+# Generated and vendored files are nobody's authorship: a lockfile is a byproduct of a
+# change, never the change a reviewer reads.
+GENERATED_DIR_SEGMENTS: Final[frozenset[str]] = frozenset(
+    {"vendor", "node_modules", "dist", "build", "target", "__snapshots__", ".venv"}
+)
+GENERATED_BASENAME: Final[re.Pattern[str]] = re.compile(
+    r"^([^/]*\.lock|[^/]*-lock\.json|go\.sum|[^/]+\.min\.(js|css)|[^/]+\.snap)$"
+)
+
+# Prose is the writing a change ships — prompts, docs, a README. Authored, so budgeted;
+# not code, so budgeted apart.
+PROSE_SUFFIXES: Final[frozenset[str]] = frozenset(
+    {".md", ".markdown", ".mdx", ".rst", ".txt", ".adoc"}
+)

--- a/scripts/pr_size/sizing.py
+++ b/scripts/pr_size/sizing.py
@@ -1,10 +1,49 @@
-"""What a diff costs: which lines it adds, and where they land in the new file."""
+"""What a diff costs, per file: where each added line lands, and which budget the
+file it landed in is charged to."""
 
 from __future__ import annotations
 
 import re
+from pathlib import PurePosixPath
 
-from .constants import HUNK_HEADER, NEW_PATH_MARKER
+from .constants import (
+    GENERATED_BASENAME,
+    GENERATED_DIR_SEGMENTS,
+    HUNK_HEADER,
+    NEW_PATH_MARKER,
+    PROSE_SUFFIXES,
+    TEST_BASENAME,
+    TEST_DIR_SEGMENTS,
+)
+from .types import ChangedFile, FileKind
+
+
+def changed_files(*, diff_text: str) -> tuple[ChangedFile, ...]:
+    """Every path the diff touches, classified, with the lines it gained."""
+    return tuple(
+        ChangedFile(path=path, kind=classify(path=path), lines=len(added), test_lines=0)
+        for path, added in added_line_numbers(diff_text=diff_text).items()
+    )
+
+
+def classify(*, path: str) -> FileKind:
+    """Which budget a changed path is charged to — the one decision per file.
+
+    Generated wins over test wins over prose: a lockfile under `tests/` is still
+    nobody's authorship, and a test fixture is still a test whatever its suffix.
+    """
+    pure: PurePosixPath = PurePosixPath(path)
+    directories: tuple[str, ...] = pure.parts[:-1]
+    name: str = pure.parts[-1]
+    if GENERATED_DIR_SEGMENTS.intersection(directories) or GENERATED_BASENAME.match(
+        name
+    ):
+        return FileKind.GENERATED
+    if TEST_DIR_SEGMENTS.intersection(directories) or TEST_BASENAME.match(name):
+        return FileKind.TEST
+    if pure.suffix.lower() in PROSE_SUFFIXES:
+        return FileKind.PROSE
+    return FileKind.CODE
 
 
 def added_line_numbers(*, diff_text: str) -> dict[str, tuple[int, ...]]:

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 from typing import Final
 
-from pr_size.sizing import added_line_numbers
+from pr_size.sizing import added_line_numbers, changed_files, classify
+from pr_size.types import ChangedFile, FileKind
 
 
 def _diff(*, path: str, added: int, start: int = 1) -> str:
@@ -48,3 +49,43 @@ def test_every_changed_path_is_reported_even_when_it_only_lost_lines() -> None:
 
     assert numbered["gone.py"] == ()
     assert len(numbered["cart.py"]) == SMALL_CHANGE
+
+
+BIG_CHANGE: Final[int] = 40
+
+
+def _kind_lines(*, diff_text: str, kind: FileKind) -> int:
+    return sum(
+        file.lines for file in changed_files(diff_text=diff_text) if file.kind is kind
+    )
+
+
+def test_a_code_file_is_reported_with_the_lines_it_gained() -> None:
+    files = changed_files(diff_text=_diff(path="cart.py", added=SMALL_CHANGE))
+
+    assert files == (
+        ChangedFile(
+            path="cart.py", kind=FileKind.CODE, lines=SMALL_CHANGE, test_lines=0
+        ),
+    )
+
+
+def test_tests_prose_and_generated_files_classify_apart_from_code() -> None:
+    diff_text: str = (
+        _diff(path="cart.py", added=SMALL_CHANGE)
+        + _diff(path="tests/test_cart.py", added=BIG_CHANGE)
+        + _diff(path="web/cart.test.ts", added=BIG_CHANGE)
+        + _diff(path="docs/guide.md", added=BIG_CHANGE)
+        + _diff(path="uv.lock", added=BIG_CHANGE)
+        + _diff(path="web/dist/bundle.js", added=BIG_CHANGE)
+    )
+
+    assert _kind_lines(diff_text=diff_text, kind=FileKind.CODE) == SMALL_CHANGE
+    assert _kind_lines(diff_text=diff_text, kind=FileKind.TEST) == BIG_CHANGE * 2
+    assert _kind_lines(diff_text=diff_text, kind=FileKind.PROSE) == BIG_CHANGE
+    assert _kind_lines(diff_text=diff_text, kind=FileKind.GENERATED) == BIG_CHANGE * 2
+
+
+def test_a_lockfile_under_tests_is_generated_not_a_test() -> None:
+    assert classify(path="tests/fixtures/uv.lock") is FileKind.GENERATED
+    assert classify(path="tests/fixtures/data.md") is FileKind.TEST


### PR DESCRIPTION
Slice 2 of 10 (stacked on #149).

Four classes, decided per path: **code**, **prose**, **test**, **generated**. Precedence is generated over test over prose, so a lockfile under `tests/` is still nobody's authorship and a `.md` fixture under `tests/` is still a test.

- **test** — by directory (`tests/`, `spec/`, `e2e/`, …) or filename (`test_*.py`, `*_test.go`, `*.test.ts`, `conftest.py`, …)
- **generated** — lockfiles, `go.sum`, bundles, snapshots, vendored trees
- **prose** — `.md` and its neighbours: authored, so budgeted, but apart from code

No budget applied yet — this slice only says what a line *is*.

`gate: review — code 85 added lines across 2 files (band cohesion-strict)`. One idea; splitting test-detection from prose-detection would leave a classifier that lies about half its inputs.