### PR TITLE
feat(size) 3/10: charge a Rust #[cfg(test)] block to tests, not code

### DIFF
--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -34,3 +34,13 @@ GENERATED_BASENAME: Final[re.Pattern[str]] = re.compile(
 PROSE_SUFFIXES: Final[frozenset[str]] = frozenset(
     {".md", ".markdown", ".mdx", ".rst", ".txt", ".adoc"}
 )
+
+# Languages whose tests can live inside the source file they exercise. The attribute
+# matches `#[test]`, `#[cfg(test)]` and `#[cfg(all(test, …))]` — never `cfg(not(test))`.
+INLINE_TEST_SUFFIXES: Final[frozenset[str]] = frozenset({".rs"})
+RUST_TEST_ATTRIBUTE: Final[re.Pattern[str]] = re.compile(
+    r"^#\[(test\]|cfg\((all\(|any\()?test[,)])"
+)
+RUST_LITERAL_OR_COMMENT: Final[re.Pattern[str]] = re.compile(
+    r"\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|//.*$"
+)

--- a/scripts/pr_size/sizing.py
+++ b/scripts/pr_size/sizing.py
@@ -4,26 +4,89 @@ file it landed in is charged to."""
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from pathlib import PurePosixPath
 
 from .constants import (
     GENERATED_BASENAME,
     GENERATED_DIR_SEGMENTS,
     HUNK_HEADER,
+    INLINE_TEST_SUFFIXES,
     NEW_PATH_MARKER,
     PROSE_SUFFIXES,
+    RUST_LITERAL_OR_COMMENT,
+    RUST_TEST_ATTRIBUTE,
     TEST_BASENAME,
     TEST_DIR_SEGMENTS,
 )
 from .types import ChangedFile, FileKind
 
 
-def changed_files(*, diff_text: str) -> tuple[ChangedFile, ...]:
-    """Every path the diff touches, classified, with the lines it gained."""
+def changed_files(
+    *, diff_text: str, sources: Mapping[str, str] | None = None
+) -> tuple[ChangedFile, ...]:
+    """Every path the diff touches, classified, with the lines it gained.
+
+    `sources` carries the post-image content of files whose tests live inside them
+    (Rust); a file absent from it is charged entirely by its path, which can only
+    over-count code, never under-count it.
+    """
     return tuple(
-        ChangedFile(path=path, kind=classify(path=path), lines=len(added), test_lines=0)
+        _charge(path=path, added=added, sources=sources or {})
         for path, added in added_line_numbers(diff_text=diff_text).items()
     )
+
+
+def _charge(
+    *, path: str, added: tuple[int, ...], sources: Mapping[str, str]
+) -> ChangedFile:
+    """One file's added lines, split off any that are tests living inside it."""
+    inline: frozenset[int] = test_line_numbers(path=path, source=sources.get(path, ""))
+    charged: int = sum(1 for number in added if number not in inline)
+    return ChangedFile(
+        path=path,
+        kind=classify(path=path),
+        lines=charged,
+        test_lines=len(added) - charged,
+    )
+
+
+def test_line_numbers(*, path: str, source: str) -> frozenset[int]:
+    """The 1-based line numbers of `source` that belong to an in-file test item.
+
+    Brace matching over literal-stripped lines is a heuristic, not a parser: a raw
+    string (`r#"…"#`) spanning lines with unbalanced braces can mis-size a region. It
+    errs toward ending the region early, which charges test lines to code — never the
+    reverse, so the gate cannot be widened by a crafted test module.
+    """
+    if not path.endswith(tuple(INLINE_TEST_SUFFIXES)):
+        return frozenset()
+    lines: list[str] = source.splitlines()
+    numbers: set[int] = set()
+    index: int = 0
+    while index < len(lines):
+        if RUST_TEST_ATTRIBUTE.match(lines[index].strip()):
+            end: int = _item_end(lines=lines, start=index)
+            numbers.update(range(index + 1, end + 2))
+            index = end + 1
+            continue
+        index += 1
+    return frozenset(numbers)
+
+
+def _item_end(*, lines: list[str], start: int) -> int:
+    """The 0-based index of the line closing the item attributed at `start`."""
+    depth: int = 0
+    opened: bool = False
+    for index in range(start, len(lines)):
+        code: str = RUST_LITERAL_OR_COMMENT.sub("", lines[index])
+        depth += code.count("{") - code.count("}")
+        opened = opened or "{" in code
+        if opened and depth <= 0:
+            return index
+        if not opened and ";" in code:
+            return index
+    return len(lines) - 1
 
 
 def classify(*, path: str) -> FileKind:

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -89,3 +89,63 @@ def test_tests_prose_and_generated_files_classify_apart_from_code() -> None:
 def test_a_lockfile_under_tests_is_generated_not_a_test() -> None:
     assert classify(path="tests/fixtures/uv.lock") is FileKind.GENERATED
     assert classify(path="tests/fixtures/data.md") is FileKind.TEST
+
+
+RUST_WITH_INLINE_TESTS: Final[str] = """\
+pub fn total(items: &[u32]) -> u32 {
+    items.iter().sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sums_items() {
+        assert_eq!(total(&[1, 2]), 3);
+        assert_eq!(format!("{}", "{"), "{");
+    }
+}
+"""
+RUST_CODE_LINES: Final[int] = 4
+
+
+def _whole_file_diff(*, path: str, content: str) -> str:
+    """A unified diff that adds `content` as a new file, so line numbers line up."""
+    lines: list[str] = content.splitlines()
+    body: str = "".join(f"+{line}\n" for line in lines)
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- /dev/null\n"
+        f"+++ b/{path}\n"
+        f"@@ -0,0 +1,{len(lines)} @@\n"
+        f"{body}"
+    )
+
+
+def test_a_rust_cfg_test_block_is_charged_to_tests_not_to_code() -> None:
+    path: Final[str] = "src/cart.rs"
+
+    files = changed_files(
+        diff_text=_whole_file_diff(path=path, content=RUST_WITH_INLINE_TESTS),
+        sources={path: RUST_WITH_INLINE_TESTS},
+    )
+
+    assert files[0].lines == RUST_CODE_LINES
+    assert files[0].test_lines == (
+        len(RUST_WITH_INLINE_TESTS.splitlines()) - RUST_CODE_LINES
+    )
+
+
+def test_a_declared_test_module_does_not_swallow_the_code_below_it() -> None:
+    path: Final[str] = "src/lib.rs"
+    source: Final[str] = (
+        "#[cfg(test)]\nmod tests;\n\npub fn total() -> u32 {\n    3\n}\n"
+    )
+
+    files = changed_files(
+        diff_text=_whole_file_diff(path=path, content=source), sources={path: source}
+    )
+
+    assert files[0].test_lines == 2
+    assert files[0].lines == 4


### PR DESCRIPTION
Slice 3 of 10 (stacked on #150).

Rust puts `#[cfg(test)] mod tests { … }` in the same file as the code it exercises — the one case where "exclude tests" cannot be answered by a filename.

`test_line_numbers` walks the post-image, finds each item attributed `#[test]`, `#[cfg(test)]` or `#[cfg(all(test, …))]` (never `cfg(not(test))`), and brace-matches to its end over lines with string and comment literals stripped, so an `assert_eq!(s, "{")` inside a test cannot unbalance the count. A declared module (`mod tests;`) ends at its semicolon instead of swallowing the rest of the file.

It is a heuristic, not a parser, and it errs toward ending a region **early** — which charges test lines to code, never the reverse. The gate cannot be widened by a crafted test module.

`gate: review — code 77 added lines across 2 files (band cohesion-strict)`