### PR TITLE
feat(size) 4/10: the code budget — target 35, cap 50 or 100 by file count

### DIFF
--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -44,3 +44,12 @@ RUST_TEST_ATTRIBUTE: Final[re.Pattern[str]] = re.compile(
 RUST_LITERAL_OR_COMMENT: Final[re.Pattern[str]] = re.compile(
     r"\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|//.*$"
 )
+
+# The code policy, in five numbers. Plan to the target; the caps are where judgment
+# stops being invited. Few files buy a larger cap because one or two files can be a
+# single unit a split would break — many files never are.
+CODE_TARGET_LINES: Final[int] = 35
+CODE_LIMIT_FEW_FILES: Final[int] = 100
+CODE_LIMIT_MANY_FILES: Final[int] = 50
+CODE_COHESION_STRICT_LINES: Final[int] = 76
+FEW_FILES: Final[int] = 2

--- a/scripts/pr_size/policy.py
+++ b/scripts/pr_size/policy.py
@@ -1,0 +1,51 @@
+"""How many counted lines a change may carry before a human must weigh in.
+
+Nothing else in the package knows a threshold: the numbers live in `constants`, and
+what they mean lives here.
+"""
+
+from __future__ import annotations
+
+from .constants import (
+    CODE_COHESION_STRICT_LINES,
+    CODE_LIMIT_FEW_FILES,
+    CODE_LIMIT_MANY_FILES,
+    CODE_TARGET_LINES,
+    FEW_FILES,
+)
+from .types import Band, Budget, Verdict
+
+
+def code_budget(*, files: int, lines: int) -> Budget:
+    """Judge the code lines: one or two files earn the larger cap, three never do."""
+    limit: int = CODE_LIMIT_FEW_FILES if files <= FEW_FILES else CODE_LIMIT_MANY_FILES
+    band: Band = _code_band(files=files, lines=lines, limit=limit)
+    return Budget(
+        files=files,
+        lines=lines,
+        target=CODE_TARGET_LINES,
+        limit=limit,
+        band=band,
+        verdict=verdict_of(band=band),
+    )
+
+
+def verdict_of(*, band: Band) -> Verdict:
+    """A band is only ever a pass, a question for the judge, or a refusal."""
+    if band is Band.TARGET:
+        return Verdict.PASS
+    if band is Band.OVER_LIMIT:
+        return Verdict.BLOCK
+    return Verdict.REVIEW
+
+
+def _code_band(*, files: int, lines: int, limit: int) -> Band:
+    if lines <= CODE_TARGET_LINES:
+        return Band.TARGET
+    if lines > limit:
+        return Band.OVER_LIMIT
+    if files > FEW_FILES:
+        return Band.MANY_FILES
+    if lines >= CODE_COHESION_STRICT_LINES:
+        return Band.COHESION_STRICT
+    return Band.COHESION

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
+
+from pr_size.policy import code_budget
 from pr_size.sizing import added_line_numbers, changed_files, classify
 from pr_size.types import ChangedFile, FileKind
 
@@ -149,3 +152,26 @@ def test_a_declared_test_module_does_not_swallow_the_code_below_it() -> None:
 
     assert files[0].test_lines == 2
     assert files[0].lines == 4
+
+
+@pytest.mark.parametrize(
+    ("files", "lines", "verdict", "band"),
+    [
+        (1, 35, "pass", "target"),
+        (5, 35, "pass", "target"),
+        (3, 36, "review", "many-files"),
+        (3, 50, "review", "many-files"),
+        (3, 51, "block", "over-limit"),
+        (9, 400, "block", "over-limit"),
+        (1, 36, "review", "cohesion"),
+        (2, 75, "review", "cohesion"),
+        (2, 76, "review", "cohesion-strict"),
+        (2, 100, "review", "cohesion-strict"),
+        (2, 101, "block", "over-limit"),
+    ],
+)
+def test_code_bands(files: int, lines: int, verdict: str, band: str) -> None:
+    budget = code_budget(files=files, lines=lines)
+
+    assert budget.verdict == verdict
+    assert budget.band == band


### PR DESCRIPTION
Slice 4 of 10 (stacked on #151). The policy for code, in five numbers and one function:

| files | lines | verdict |
|---|---|---|
| any | ≤ 35 | **pass** — the target every plan aims at |
| 3+ | 36–50 | judged |
| 3+ | > 50 | **refused** |
| 1–2 | 36–75 | judged (`cohesion`) |
| 1–2 | 76–100 | judged strictly (`cohesion-strict`) |
| 1–2 | > 100 | **refused** |

One or two files earn the larger cap because they can be a single unit whose halves cannot land apart; three files never are.

The band is the judge's dispatch key: `target` needs no judgment, `over-limit` admits none, and `cohesion-strict` is the one that has to argue integrity to survive.

`gate: review — code 96 added lines across 2 files (band cohesion-strict)`