### PR TITLE
feat(size) 5/10: the prose budget, and the whole report a change earns

### DIFF
--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -53,3 +53,8 @@ CODE_LIMIT_FEW_FILES: Final[int] = 100
 CODE_LIMIT_MANY_FILES: Final[int] = 50
 CODE_COHESION_STRICT_LINES: Final[int] = 76
 FEW_FILES: Final[int] = 2
+
+# Prose gets one budget and no file-count relief: a document splits where a module
+# cannot, so the case that earns code its larger cap does not arise.
+PROSE_TARGET_LINES: Final[int] = 100
+PROSE_LIMIT_LINES: Final[int] = 150

--- a/scripts/pr_size/policy.py
+++ b/scripts/pr_size/policy.py
@@ -6,14 +6,19 @@ what they mean lives here.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from .constants import (
     CODE_COHESION_STRICT_LINES,
     CODE_LIMIT_FEW_FILES,
     CODE_LIMIT_MANY_FILES,
     CODE_TARGET_LINES,
     FEW_FILES,
+    PROSE_LIMIT_LINES,
+    PROSE_TARGET_LINES,
 )
-from .types import Band, Budget, Verdict
+from .sizing import changed_files
+from .types import Band, Budget, ChangedFile, FileKind, SizeReport, Tally, Verdict
 
 
 def code_budget(*, files: int, lines: int) -> Budget:
@@ -49,3 +54,53 @@ def _code_band(*, files: int, lines: int, limit: int) -> Band:
     if lines >= CODE_COHESION_STRICT_LINES:
         return Band.COHESION_STRICT
     return Band.COHESION
+
+
+def measure(*, diff_text: str, sources: Mapping[str, str] | None = None) -> SizeReport:
+    """Charge a diff's added lines to their budget classes and judge the total."""
+    files: tuple[ChangedFile, ...] = changed_files(diff_text=diff_text, sources=sources)
+    code: Budget = code_budget(**_counts(files=files, kind=FileKind.CODE))
+    prose: Budget = prose_budget(**_counts(files=files, kind=FileKind.PROSE))
+    return SizeReport(
+        code=code,
+        prose=prose,
+        tests=_test_tally(files=files),
+        generated=Tally(**_counts(files=files, kind=FileKind.GENERATED)),
+        files=files,
+        verdict=max(code.verdict, prose.verdict, key=lambda item: item.severity),
+    )
+
+
+def prose_budget(*, files: int, lines: int) -> Budget:
+    """Judge the prose lines: one budget, no file-count relief."""
+    band: Band = Band.TARGET
+    if lines > PROSE_LIMIT_LINES:
+        band = Band.OVER_LIMIT
+    elif lines > PROSE_TARGET_LINES:
+        band = Band.OVER_TARGET
+    return Budget(
+        files=files,
+        lines=lines,
+        target=PROSE_TARGET_LINES,
+        limit=PROSE_LIMIT_LINES,
+        band=band,
+        verdict=verdict_of(band=band),
+    )
+
+
+def _counts(*, files: tuple[ChangedFile, ...], kind: FileKind) -> dict[str, int]:
+    """One class's files and lines. A file that only lost lines is free."""
+    charged: list[ChangedFile] = [
+        file for file in files if file.kind is kind and file.lines > 0
+    ]
+    return {"files": len(charged), "lines": sum(file.lines for file in charged)}
+
+
+def _test_tally(*, files: tuple[ChangedFile, ...]) -> Tally:
+    """Test lines, wherever they lived: their own files, and inside source files."""
+    inline: list[ChangedFile] = [file for file in files if file.test_lines > 0]
+    counts: dict[str, int] = _counts(files=files, kind=FileKind.TEST)
+    return Tally(
+        files=counts["files"] + len(inline),
+        lines=counts["lines"] + sum(file.test_lines for file in inline),
+    )

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -11,7 +11,7 @@ from typing import Final
 
 import pytest
 
-from pr_size.policy import code_budget
+from pr_size.policy import code_budget, measure
 from pr_size.sizing import added_line_numbers, changed_files, classify
 from pr_size.types import ChangedFile, FileKind
 
@@ -175,3 +175,27 @@ def test_code_bands(files: int, lines: int, verdict: str, band: str) -> None:
 
     assert budget.verdict == verdict
     assert budget.band == band
+
+
+@pytest.mark.parametrize(
+    ("lines", "verdict"),
+    [(100, "pass"), (101, "review"), (150, "review"), (151, "block")],
+)
+def test_prose_bands(lines: int, verdict: str) -> None:
+    report = measure(diff_text=_diff(path="skills/thing/SKILL.md", added=lines))
+
+    assert report.prose.verdict == verdict
+    assert report.code.verdict == "pass"
+    assert report.verdict == verdict
+
+
+def test_a_change_is_only_as_good_as_its_worst_budget() -> None:
+    report = measure(
+        diff_text=_diff(path="cart.py", added=SMALL_CHANGE)
+        + _diff(path="README.md", added=200)
+        + _diff(path="tests/test_cart.py", added=BIG_CHANGE)
+    )
+
+    assert report.code.verdict == "pass"
+    assert report.verdict == "block"
+    assert report.tests.lines == BIG_CHANGE


### PR DESCRIPTION
Slice 5 of 10 (stacked on #152).

**Prose** gets one budget and no file-count relief — 100 target, 150 cap. A document splits where a module cannot, so the case that earns code its larger cap does not arise.

`measure` assembles the report: both budgets, the test and generated lines it excluded (test lines counted wherever they lived, including inside a Rust source file), the per-file breakdown, and one overall verdict. **A change is only as good as its worse class.**

Verdicts are declared best-first so taking the worse of two needs no lookup table.

`gate: review — code 86 added lines across 2 files (band cohesion-strict)`