### PR TITLE
feat(size) 6/10: ask git for the diff, and for the sources tests hide in

### DIFF
--- a/scripts/pr_size/cli.py
+++ b/scripts/pr_size/cli.py
@@ -1,0 +1,39 @@
+"""The imperative shell: the real git subprocesses the measurement needs."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+
+from .constants import GIT_DIFF_FLAGS, INLINE_TEST_SUFFIXES
+from .policy import measure
+from .sizing import added_line_numbers
+from .types import CommandRunner, SizeError, SizeReport
+
+
+def subprocess_runner(*, argv: tuple[str, ...]) -> str:
+    """The real boundary: run a command, returning stdout, SizeError on failure."""
+    result: subprocess.CompletedProcess[str] = subprocess.run(
+        argv, capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        detail: str = result.stderr.strip() or result.stdout.strip()
+        raise SizeError(f"{shlex.join(argv)} failed: {detail}")
+    return result.stdout
+
+
+def report_for(*, base: str, head: str, repo: str, run: CommandRunner) -> SizeReport:
+    """Measure what `base...head` adds in `repo`.
+
+    Two questions for git: the diff, then the post-image of each file whose tests can
+    live inside it — the only way a `#[cfg(test)]` block can be told from code.
+    """
+    diff_text: str = run(argv=("git", "-C", repo, *GIT_DIFF_FLAGS, f"{base}...{head}"))
+    return measure(
+        diff_text=diff_text,
+        sources={
+            path: run(argv=("git", "-C", repo, "show", f"{head}:{path}"))
+            for path in added_line_numbers(diff_text=diff_text)
+            if path.endswith(tuple(INLINE_TEST_SUFFIXES))
+        },
+    )

--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -58,3 +58,15 @@ FEW_FILES: Final[int] = 2
 # cannot, so the case that earns code its larger cap does not arise.
 PROSE_TARGET_LINES: Final[int] = 100
 PROSE_LIMIT_LINES: Final[int] = 150
+
+# How the shell talks to git. `--unified=0` keeps the parse honest (no context line can
+# be mistaken for an addition); `core.quotePath=false` keeps non-ASCII paths readable
+# rather than octal-escaped.
+GIT_DIFF_FLAGS: Final[tuple[str, ...]] = (
+    "-c",
+    "core.quotePath=false",
+    "diff",
+    "--unified=0",
+    "--no-color",
+    "--find-renames",
+)

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -11,6 +11,7 @@ from typing import Final
 
 import pytest
 
+from pr_size.cli import report_for
 from pr_size.policy import code_budget, measure
 from pr_size.sizing import added_line_numbers, changed_files, classify
 from pr_size.types import ChangedFile, FileKind
@@ -199,3 +200,43 @@ def test_a_change_is_only_as_good_as_its_worst_budget() -> None:
     assert report.code.verdict == "pass"
     assert report.verdict == "block"
     assert report.tests.lines == BIG_CHANGE
+
+
+class FakeGit:
+    """Answers the two git questions the shell asks, and records every argv."""
+
+    def __init__(self, *, diff: str, sources: dict[str, str] | None = None) -> None:
+        self.calls: list[tuple[str, ...]] = []
+        self._diff = diff
+        self._sources = sources or {}
+
+    def __call__(self, *, argv: tuple[str, ...]) -> str:
+        self.calls.append(argv)
+        if "diff" in argv:
+            return self._diff
+        if "show" in argv:
+            return self._sources[argv[-1].split(":", 1)[1]]
+        return ""
+
+
+def test_the_shell_asks_git_for_the_diff_between_base_and_head() -> None:
+    git = FakeGit(diff=_diff(path="cart.py", added=SMALL_CHANGE))
+
+    report = report_for(base="origin/main", head="HEAD", repo="/repo", run=git)
+
+    assert report.code.lines == SMALL_CHANGE
+    assert git.calls[0][:3] == ("git", "-C", "/repo")
+    assert git.calls[0][-1] == "origin/main...HEAD"
+
+
+def test_the_shell_reads_rust_post_images_so_inline_tests_are_excluded() -> None:
+    path: Final[str] = "src/cart.rs"
+    git = FakeGit(
+        diff=_whole_file_diff(path=path, content=RUST_WITH_INLINE_TESTS),
+        sources={path: RUST_WITH_INLINE_TESTS},
+    )
+
+    report = report_for(base="main", head="HEAD", repo="/repo", run=git)
+
+    assert report.code.lines == RUST_CODE_LINES
+    assert ("git", "-C", "/repo", "show", f"HEAD:{path}") in git.calls


### PR DESCRIPTION
Slice 6 of 10 (stacked on #153). The imperative shell, without its command yet.

`report_for` puts two questions to git:
1. the diff of `base...head` at `--unified=0`, so no context line can be mistaken for an addition
2. the post-image of each file whose tests can live inside it — the only way a Rust `#[cfg(test)]` block can be told from the code around it

Every subprocess goes through an injected runner, so the measurement is tested against a fake git rather than a fixture repository.

`gate: review — code 61 added lines across 2 files (band cohesion)`