### PR TITLE
feat(size) 7/10: report the measurement as JSON, the verdict as an exit code

### DIFF
--- a/scripts/pr_size/cli.py
+++ b/scripts/pr_size/cli.py
@@ -1,14 +1,22 @@
-"""The imperative shell: the real git subprocesses the measurement needs."""
+"""The imperative shell: real git subprocesses, JSON on stdout, verdict as exit code.
+
+Exit codes are the verdict — 0 pass, 1 review (a judge must rule), 2 block, 3 the gate
+could not measure — so an unmeasured change never reads as a passing one.
+"""
 
 from __future__ import annotations
 
+import json
 import shlex
 import subprocess
+import sys
+from dataclasses import asdict
+from typing import Any
 
-from .constants import GIT_DIFF_FLAGS, INLINE_TEST_SUFFIXES
+from .constants import EXIT_ERROR, GIT_DIFF_FLAGS, INLINE_TEST_SUFFIXES
 from .policy import measure
 from .sizing import added_line_numbers
-from .types import CommandRunner, SizeError, SizeReport
+from .types import CommandRunner, SizeError, SizeReport, Verdict
 
 
 def subprocess_runner(*, argv: tuple[str, ...]) -> str:
@@ -37,3 +45,40 @@ def report_for(*, base: str, head: str, repo: str, run: CommandRunner) -> SizeRe
             if path.endswith(tuple(INLINE_TEST_SUFFIXES))
         },
     )
+
+
+def summarize(*, report: SizeReport) -> str:
+    """One line a human or a judge can act on: the counts, the caps, the call."""
+    return (
+        f"{report.verdict}: code {report.code.lines} added lines across "
+        f"{report.code.files} file(s) (target {report.code.target}, cap "
+        f"{report.code.limit}, band {report.code.band}); prose {report.prose.lines} "
+        f"(target {report.prose.target}, cap {report.prose.limit}); "
+        f"{report.tests.lines} test and {report.generated.lines} generated lines "
+        f"excluded"
+    )
+
+
+def run_cli(
+    *, base: str, head: str, repo: str, run: CommandRunner | None = None
+) -> int:
+    """Measure `base...head` in `repo`, print the report, return the verdict's code."""
+    try:
+        report: SizeReport = report_for(
+            base=base,
+            head=head,
+            repo=repo,
+            run=run if run is not None else subprocess_runner,
+        )
+    except (SizeError, OSError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return EXIT_ERROR
+    payload: dict[str, Any] = {
+        "schema_version": "v1",
+        "base": base,
+        "head": head,
+        **asdict(report),
+        "summary": summarize(report=report),
+    }
+    print(json.dumps(payload, indent=2))
+    return list(Verdict).index(Verdict(report.verdict))

--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -70,3 +70,7 @@ GIT_DIFF_FLAGS: Final[tuple[str, ...]] = (
     "--no-color",
     "--find-renames",
 )
+
+# The gate could not measure — distinct from any verdict, so an unmeasured change is
+# never mistaken for a passing one.
+EXIT_ERROR: Final[int] = 3

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -7,14 +7,15 @@ and the shell through an injected fake runner — never a real git.
 
 from __future__ import annotations
 
+import json
 from typing import Final
 
 import pytest
 
-from pr_size.cli import report_for
+from pr_size.cli import report_for, run_cli
 from pr_size.policy import code_budget, measure
 from pr_size.sizing import added_line_numbers, changed_files, classify
-from pr_size.types import ChangedFile, FileKind
+from pr_size.types import ChangedFile, FileKind, SizeError
 
 
 def _diff(*, path: str, added: int, start: int = 1) -> str:
@@ -240,3 +241,46 @@ def test_the_shell_reads_rust_post_images_so_inline_tests_are_excluded() -> None
 
     assert report.code.lines == RUST_CODE_LINES
     assert ("git", "-C", "/repo", "show", f"HEAD:{path}") in git.calls
+
+
+def _spread(*, files: int, lines: int) -> str:
+    """A diff over `files` code files carrying `lines` added lines between them."""
+    each: list[int] = [1] * files
+    each[0] += lines - files
+    return "".join(
+        _diff(path=f"src/module{index}.py", added=added)
+        for index, added in enumerate(each)
+    )
+
+
+def test_the_report_is_printed_as_json_and_the_verdict_is_the_exit_code(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    git = FakeGit(diff=_spread(files=4, lines=60))
+
+    exit_code: int = run_cli(base="origin/main", head="HEAD", repo=".", run=git)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 2
+    assert payload["verdict"] == "block"
+    assert payload["code"] == {
+        "files": 4,
+        "lines": 60,
+        "target": 35,
+        "limit": 50,
+        "band": "over-limit",
+        "verdict": "block",
+    }
+    assert payload["summary"].startswith("block: code 60 added lines across 4 file(s)")
+
+
+def test_an_unmeasurable_change_exits_non_zero_without_a_verdict(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def explode(*, argv: tuple[str, ...]) -> str:
+        raise SizeError(f"bad revision: {argv[-1]}")
+
+    exit_code: int = run_cli(base="nope", head="HEAD", repo=".", run=explode)
+
+    assert exit_code not in {0, 1, 2}
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
Slice 7 of 10 (stacked on #154).

`run_cli` prints the whole report as JSON — both budgets, the excluded test and generated lines, the per-file breakdown — plus a one-line summary a human or a judge can act on without parsing anything.

The exit code **is** the verdict: `0` pass, `1` review, `2` block, `3` could not measure. A change the gate failed to measure gets its own code and prints nothing on stdout, so it can never be mistaken for a passing one.

`gate: review — code 52 added lines across 2 files (band cohesion)`