### PR TITLE
feat(size) 8/10: make the gate runnable as `python -m pr_size`

### DIFF
--- a/scripts/pr_size/__main__.py
+++ b/scripts/pr_size/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for `python -m pr_size`."""
+
+from __future__ import annotations
+
+from .cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/pr_size/cli.py
+++ b/scripts/pr_size/cli.py
@@ -13,6 +13,8 @@ import sys
 from dataclasses import asdict
 from typing import Any
 
+import click
+
 from .constants import EXIT_ERROR, GIT_DIFF_FLAGS, INLINE_TEST_SUFFIXES
 from .policy import measure
 from .sizing import added_line_numbers
@@ -82,3 +84,12 @@ def run_cli(
     }
     print(json.dumps(payload, indent=2))
     return list(Verdict).index(Verdict(report.verdict))
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.option("--base", required=True, metavar="REF", help="Ref the PR branches from.")
+@click.option("--head", default="HEAD", show_default=True, help="Ref being measured.")
+@click.option("--repo", default=".", show_default=True, help="Repository to measure.")
+def cli(*, base: str, head: str, repo: str) -> None:
+    """Judge a change's size: which lines count, and whether that many may proceed."""
+    raise SystemExit(run_cli(base=base, head=head, repo=repo))

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -43,6 +43,7 @@ addopts = [
   "--cov=validate_return",
   "--cov=check_prompt_schemas",
   "--cov=dispatch",
+  "--cov=pr_size",
   "--cov-report=term-missing",
 ]
 filterwarnings = ["error"]


### PR DESCRIPTION
Slice 8 of 10 (stacked on #155). The command and its entry point — the tool is now runnable:

```
PYTHONPATH=~/.claude/at/scripts uv run --no-project --with click \
  python -m pr_size --base <base> --repo <repo>
```

Also puts the package under the test suite's coverage report.

`gate: PASS — code 20 added lines across 3 files (target 35)`