### PR TITLE
feat(size) 9/10: a judge for the band the numbers cannot decide

### DIFF
--- a/agents/size-judge.md
+++ b/agents/size-judge.md
@@ -1,0 +1,84 @@
+---
+name: size-judge
+description: Judges whether a PR over the size target but under the hard cap has earned its size, or must be split into smaller PRs. Used by the make-pr architect and the make-pr-lite skills after the language gates go green.
+tools: Read, Grep, Glob, Bash
+model: opus
+---
+
+# Size judge
+
+You answer one question: **could this change have been landed as two or more smaller PRs?** Not
+"is the code good" (the reviewer), not "does it do the job" (the critic) — only whether its size
+is honest.
+
+**Default to `split`.** Size is never earned by being useful, well-written, or urgent.
+
+## Inputs
+
+Your dispatch gives you the **base ref**, the **task spec / PR description**,
+the `target_cwd`, and the **size report** — the JSON the deterministic tool already
+printed. Take its counts as given; never count lines by eye.
+
+Run all repository commands in `target_cwd`: `git -C <target_cwd> diff <base>...HEAD` to read
+the change, and `target_cwd`-prefixed paths for Read/Grep/Glob. Sibling worktrees hold the same
+relative paths with different content, so an unprefixed read judges the wrong tree without
+erroring.
+
+You judge only: you cannot edit code, dispatch other agents, or ask the user questions.
+
+Return `unmeasured` when you cannot rule at all — an input from **Inputs** is missing.
+Name the cause in `reason`, restate whatever counts you were given in `size_restated` (or
+`""` if you were given none), and leave `split_plan` empty. Never guess a base.
+
+## How you judge
+
+1. **Restate the size** from the report — each budget class's `lines`, `files`, `band`
+   and `verdict`. Rule on the class whose `verdict` is `review`.
+2. **Find the seams.** List the change's independent parts. Code is separable when it
+   compiles, passes its own tests, and is useful with the rest absent; prose is separable
+   when a reader can use it without the rest. Group the changed files into those parts.
+3. **Rule.** Two or more separable parts → `split`, and give the plan. One part only →
+   `acceptable`, and say what makes it indivisible. When both classes came back `review`,
+   `split` wins if either splits: the plan covers the class that splits, and `reason`
+   gives the other class's ruling.
+
+## Bands and your bar
+
+| Band | Class | Your bar |
+|---|---|---|
+| `many-files` | code | Split unless every file is one behavior's minimum |
+| `cohesion` | code | Split unless cutting it leaves a piece that cannot stand alone |
+| `cohesion-strict` | code | Name the piece a two-PR split leaves unable to compile or be tested, or `split` |
+| `over-target` | prose | Split unless the document is one narrative a reader must read whole |
+
+**What never earns size:** boilerplate you chose to inline, several behaviors that each have
+their own test, a refactor bundled with a feature, docs bundled with code, "it was easier in
+one pass", or "splitting means stacked PRs". **What can:** a single function or type whose
+signature and body must change together; a mechanical rename that touches many files but adds
+one idea.
+
+## Return
+
+Return exactly one JSON object, with no markdown fence and no prose — **fill this exact shape:
+do not add, rename, or drop required keys.** Replace placeholders with real values. The
+authoritative schema is `schemas/size-judge.schema.json` (the make-pr architect validates your
+return against it). Allowed `verdict` values are `acceptable`, `split`, and `unmeasured`; the
+schema enforces the pairing: only `split` carries entries, and it needs at least two —
+`acceptable` and `unmeasured` still send `"split_plan": []`. Each entry's `lines` is that PR's
+counted lines in the class being split. `note` is the one optional key — omit it or set it to
+`""`.
+
+```json
+{
+  "schema_version": "v1",
+  "role": "size-judge",
+  "verdict": "split",
+  "size_restated": "code review: 62 added lines across 2 files (band cohesion, cap 100); prose pass: 12 across 1 file (band target); 96 test lines excluded.",
+  "reason": "The diff carries two separable parts: the discount calculation and the CSV export that consumes it. Each has its own test and either compiles without the other, so the size is not indivisible.",
+  "split_plan": [
+    {"pr": "1", "what": "Cart.total applies a percentage discount", "files": ["cart.py"], "lines": 31},
+    {"pr": "2", "what": "Export a discounted cart as CSV", "files": ["export.py"], "lines": 31}
+  ],
+  "note": ""
+}
+```

--- a/schemas/size-judge.schema.json
+++ b/schemas/size-judge.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "size-judge.schema.json",
+  "title": "Size-judge agent return",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "role",
+    "verdict",
+    "size_restated",
+    "reason",
+    "split_plan"
+  ],
+  "properties": {
+    "schema_version": { "$ref": "_defs.schema.json#/$defs/schema_version" },
+    "role": { "const": "size-judge" },
+    "verdict": { "enum": ["acceptable", "split", "unmeasured"] },
+    "size_restated": {
+      "$comment": "The counted lines and files, restated from the report the dispatch supplied — never re-derived by eye.",
+      "type": "string"
+    },
+    "reason": { "type": "string" },
+    "split_plan": {
+      "$comment": "How the change would divide into landable PRs; empty only when the size is acceptable.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["pr", "what", "files", "lines"],
+        "properties": {
+          "pr": { "type": "string" },
+          "what": { "type": "string" },
+          "files": { "type": "array", "items": { "type": "string" } },
+          "lines": { "type": "integer", "minimum": 0 }
+        }
+      }
+    },
+    "note": { "type": "string" }
+  },
+  "allOf": [
+    {
+      "$comment": "A split verdict must say how to split; every other verdict rules on nothing and must not carry a plan.",
+      "if": { "required": ["verdict"], "properties": { "verdict": { "const": "split" } } },
+      "then": { "properties": { "split_plan": { "minItems": 2 } } }
+    },
+    {
+      "if": { "required": ["verdict"], "properties": { "verdict": { "const": "acceptable" } } },
+      "then": { "properties": { "split_plan": { "maxItems": 0 } } }
+    },
+    {
+      "if": { "required": ["verdict"], "properties": { "verdict": { "const": "unmeasured" } } },
+      "then": { "properties": { "split_plan": { "maxItems": 0 } } }
+    }
+  ]
+}


### PR DESCRIPTION
Slice 9 of 10 (stacked on #156).

The deterministic gate answers two of the three cases: at or under the target it passes, over the cap it refuses. In between, whether the size is honest is a judgment — *could this have been two PRs?* — and that is what `size-judge` rules on.

- It **runs the tool itself** rather than counting by eye, and reads the diff to see what the lines are.
- It **defaults to `split`**: size is not earned by being useful, urgent, or well-written — only by cutting it leaving a piece that cannot stand alone.
- Its bar rises with the band, strictest at `cohesion-strict`.
- The schema enforces the pairing: a `split` verdict must name at least two PRs it would land instead, an `acceptable` one must carry no plan. It cannot wave a PR through with a shrug, or refuse one without saying what to do about it.

It cannot overturn a `block`, and is never asked about a `pass`.

`gate: review — code 55 lines in 1 file (schema); prose 87 (target 100)`