### PR TITLE
feat(size) 0a/12: the vocabulary for what a change costs

### DIFF
--- a/scripts/pr_size/types.py
+++ b/scripts/pr_size/types.py
@@ -1,0 +1,53 @@
+"""The vocabulary the size gate speaks: what a change costs, and what that costs it.
+
+Every module shares these shapes — `sizing` produces the per-file records, `policy`
+judges them into budgets, `cli` reports the result — so they are declared once here
+rather than in whichever module happened to need them first.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+
+
+class SizeError(Exception):
+    """A diff or a repository the gate cannot measure."""
+
+
+class CommandRunner(Protocol):
+    """Runs one argv, returning stdout; raises SizeError on a non-zero exit."""
+
+    def __call__(self, *, argv: tuple[str, ...]) -> str: ...
+
+
+class FileKind(StrEnum):
+    """Which budget a changed file's added lines are charged to, if any."""
+
+    CODE = "code"
+    PROSE = "prose"
+    TEST = "test"
+    GENERATED = "generated"
+
+
+@dataclass(frozen=True)
+class ChangedFile:
+    """One changed path and what its added lines cost.
+
+    `lines` is charged to `kind`; `test_lines` is the remainder that lives inside the
+    file but belongs to the test budget (a Rust `#[cfg(test)]` block).
+    """
+
+    path: str
+    kind: FileKind
+    lines: int
+    test_lines: int
+
+
+@dataclass(frozen=True)
+class Tally:
+    """How much of one unbudgeted class a diff changed — reported, never judged."""
+
+    files: int
+    lines: int


### PR DESCRIPTION
New first slice, added in response to @a1f's `types.py` comment on #150: `FileKind` and `ChangedFile` were declared in `sizing.py`, against python.md ("place shared types in `types.py` modules") and the precedent `scripts/dispatch/types.py` already sets.

Rather than growing `types.py` alongside each module that needs it — which would push slices 2, 3, 4, 5 and 6 into a third file, dropping their cap from 100 to 50 and splitting each in two — the vocabulary is declared up front, in two halves that each fit the cap.

**This half — what a change costs:** which budget a file is charged to (`FileKind`), what one changed file cost (`ChangedFile`), how much of an unbudgeted class a diff moved (`Tally`), plus the error and the runner protocol every real git call goes through.

The whole stack was rebased onto this; no slice touches `types.py` again.

`gate: review — code 53 lines / 1 file (band cohesion)`