### PR TITLE
feat(size) 0b/12: the vocabulary for what that cost buys

### DIFF
--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -9,3 +9,28 @@ from typing import Final
 # read new-file line numbers from.
 NEW_PATH_MARKER: Final[str] = "+++ b/"
 HUNK_HEADER: Final[re.Pattern[str]] = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)")
+
+# A file is a test when its directory or its name says so — one regex per question, so
+# a new language's convention is one more alternative, not a new branch.
+TEST_DIR_SEGMENTS: Final[frozenset[str]] = frozenset(
+    {"tests", "test", "__tests__", "spec", "specs", "e2e", "testdata", "fixtures"}
+)
+TEST_BASENAME: Final[re.Pattern[str]] = re.compile(
+    r"^(conftest\.py|test_[^/]+|[^/]+_test\.[a-z]+"
+    r"|[^/]+[._](test|spec)\.[a-z]+|[^/]+Tests?\.(java|kt|cs))$"
+)
+
+# Generated and vendored files are nobody's authorship: a lockfile is a byproduct of a
+# change, never the change a reviewer reads.
+GENERATED_DIR_SEGMENTS: Final[frozenset[str]] = frozenset(
+    {"vendor", "node_modules", "dist", "build", "target", "__snapshots__", ".venv"}
+)
+GENERATED_BASENAME: Final[re.Pattern[str]] = re.compile(
+    r"^([^/]*\.lock|[^/]*-lock\.json|go\.sum|[^/]+\.min\.(js|css)|[^/]+\.snap)$"
+)
+
+# Prose is the writing a change ships — prompts, docs, a README. Authored, so budgeted;
+# not code, so budgeted apart.
+PROSE_SUFFIXES: Final[frozenset[str]] = frozenset(
+    {".md", ".markdown", ".mdx", ".rst", ".txt", ".adoc"}
+)

--- a/scripts/pr_size/sizing.py
+++ b/scripts/pr_size/sizing.py
@@ -1,10 +1,49 @@
-"""What a diff costs: which lines it adds, and where they land in the new file."""
+"""What a diff costs, per file: where each added line lands, and which budget the
+file it landed in is charged to."""
 
 from __future__ import annotations
 
 import re
+from pathlib import PurePosixPath
 
-from .constants import HUNK_HEADER, NEW_PATH_MARKER
+from .constants import (
+    GENERATED_BASENAME,
+    GENERATED_DIR_SEGMENTS,
+    HUNK_HEADER,
+    NEW_PATH_MARKER,
+    PROSE_SUFFIXES,
+    TEST_BASENAME,
+    TEST_DIR_SEGMENTS,
+)
+from .types import ChangedFile, FileKind
+
+
+def changed_files(*, diff_text: str) -> tuple[ChangedFile, ...]:
+    """Every path the diff touches, classified, with the lines it gained."""
+    return tuple(
+        ChangedFile(path=path, kind=classify(path=path), lines=len(added), test_lines=0)
+        for path, added in added_line_numbers(diff_text=diff_text).items()
+    )
+
+
+def classify(*, path: str) -> FileKind:
+    """Which budget a changed path is charged to — the one decision per file.
+
+    Generated wins over test wins over prose: a lockfile under `tests/` is still
+    nobody's authorship, and a test fixture is still a test whatever its suffix.
+    """
+    pure: PurePosixPath = PurePosixPath(path)
+    directories: tuple[str, ...] = pure.parts[:-1]
+    name: str = pure.parts[-1]
+    if GENERATED_DIR_SEGMENTS.intersection(directories) or GENERATED_BASENAME.match(
+        name
+    ):
+        return FileKind.GENERATED
+    if TEST_DIR_SEGMENTS.intersection(directories) or TEST_BASENAME.match(name):
+        return FileKind.TEST
+    if pure.suffix.lower() in PROSE_SUFFIXES:
+        return FileKind.PROSE
+    return FileKind.CODE
 
 
 def added_line_numbers(*, diff_text: str) -> dict[str, tuple[int, ...]]:

--- a/scripts/pr_size/types.py
+++ b/scripts/pr_size/types.py
@@ -51,3 +51,55 @@ class Tally:
 
     files: int
     lines: int
+
+
+class Verdict(StrEnum):
+    """What the gate says about a size, declared best-first: order is severity."""
+
+    PASS = "pass"
+    REVIEW = "review"
+    BLOCK = "block"
+
+    @property
+    def severity(self) -> int:
+        """So the worse of two budget classes can be taken without a lookup table."""
+        return list(Verdict).index(self)
+
+
+class Band(StrEnum):
+    """Where a count sits against its budget — the judge's dispatch key.
+
+    `target` needs no judgment and `over-limit` admits none; the rest are the grey
+    zone, and `cohesion-strict` is the one that must argue integrity to survive.
+    """
+
+    TARGET = "target"
+    MANY_FILES = "many-files"
+    COHESION = "cohesion"
+    COHESION_STRICT = "cohesion-strict"
+    OVER_TARGET = "over-target"
+    OVER_LIMIT = "over-limit"
+
+
+@dataclass(frozen=True)
+class Budget:
+    """A class's counted lines, judged against that class's target and cap."""
+
+    files: int
+    lines: int
+    target: int
+    limit: int
+    band: Band
+    verdict: Verdict
+
+
+@dataclass(frozen=True)
+class SizeReport:
+    """Every budget class, and the worst verdict among them."""
+
+    code: Budget
+    prose: Budget
+    tests: Tally
+    generated: Tally
+    files: tuple[ChangedFile, ...]
+    verdict: Verdict

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 from typing import Final
 
-from pr_size.sizing import added_line_numbers
+from pr_size.sizing import added_line_numbers, changed_files, classify
+from pr_size.types import ChangedFile, FileKind
 
 
 def _diff(*, path: str, added: int, start: int = 1) -> str:
@@ -48,3 +49,43 @@ def test_every_changed_path_is_reported_even_when_it_only_lost_lines() -> None:
 
     assert numbered["gone.py"] == ()
     assert len(numbered["cart.py"]) == SMALL_CHANGE
+
+
+BIG_CHANGE: Final[int] = 40
+
+
+def _kind_lines(*, diff_text: str, kind: FileKind) -> int:
+    return sum(
+        file.lines for file in changed_files(diff_text=diff_text) if file.kind is kind
+    )
+
+
+def test_a_code_file_is_reported_with_the_lines_it_gained() -> None:
+    files = changed_files(diff_text=_diff(path="cart.py", added=SMALL_CHANGE))
+
+    assert files == (
+        ChangedFile(
+            path="cart.py", kind=FileKind.CODE, lines=SMALL_CHANGE, test_lines=0
+        ),
+    )
+
+
+def test_tests_prose_and_generated_files_classify_apart_from_code() -> None:
+    diff_text: str = (
+        _diff(path="cart.py", added=SMALL_CHANGE)
+        + _diff(path="tests/test_cart.py", added=BIG_CHANGE)
+        + _diff(path="web/cart.test.ts", added=BIG_CHANGE)
+        + _diff(path="docs/guide.md", added=BIG_CHANGE)
+        + _diff(path="uv.lock", added=BIG_CHANGE)
+        + _diff(path="web/dist/bundle.js", added=BIG_CHANGE)
+    )
+
+    assert _kind_lines(diff_text=diff_text, kind=FileKind.CODE) == SMALL_CHANGE
+    assert _kind_lines(diff_text=diff_text, kind=FileKind.TEST) == BIG_CHANGE * 2
+    assert _kind_lines(diff_text=diff_text, kind=FileKind.PROSE) == BIG_CHANGE
+    assert _kind_lines(diff_text=diff_text, kind=FileKind.GENERATED) == BIG_CHANGE * 2
+
+
+def test_a_lockfile_under_tests_is_generated_not_a_test() -> None:
+    assert classify(path="tests/fixtures/uv.lock") is FileKind.GENERATED
+    assert classify(path="tests/fixtures/data.md") is FileKind.TEST


### PR DESCRIPTION
Second half of the shared types module (stacked on 0a). Split in two because the whole vocabulary is 105 lines in one file — five over the cap, and trimming docstrings to fit is exactly the "edit counted files to duck a band" move the gate forbids.

**This half — what the cost buys:** the three things the gate can say (`Verdict`), the band a count lands in (`Band`), one budget class judged against its target and cap (`Budget`), and the whole report (`SizeReport`).

Verdicts are declared best-first so taking the worse of two budget classes needs no lookup table.

`gate: review — code 52 lines / 1 file (band cohesion)`