### PR TITLE
feat(skills): pr-explain walks the whole diff, enumerates tests, gates on proof

### DIFF
--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -1,23 +1,28 @@
 ---
 name: pr-explain
-description: Use when the user invokes /pr-explain or wants a reader-facing explainer page for a pull request — a short, plain-words page with five chapters (what it is for, a map of the touched files, the tests, the proof, and commands to try it), published as a private claude.ai artifact with a teaser in the PR body.
+description: Use when the user invokes /pr-explain or wants a reader-facing explainer page for a pull request — a plain-words page with five chapters (what & why, a walkthrough of the whole diff, every test enumerated, the proof, and confirm commands run with their real output), published as a private claude.ai artifact with a teaser in the PR body.
 argument-hint: "[#N | PR URL | blank = current branch's PR]"
 ---
 
 # PR Explain
 
-Write the page you would draw at a whiteboard for the person who owns this repo. They
-want to keep a clear mental model of code that agents typed. They are not hunting for
-bugs — a reviewer does that. They want to *understand the change fast*.
+Write the page you would produce pair-programming with the person who owns this repo:
+you at the keyboard, walking them through the change you just made. They want to keep a
+clear mental model of code that agents typed. They are not hunting for bugs — a reviewer
+does that. They want to *understand the whole change*, not a sampler of it.
 
-Two rules run through the whole page:
+Three rules run through the whole page:
 
 - **Plain words.** Say it the way you would to a smart friend who has not seen the code.
   If a code word is the only word that fits (`hash`, `symlink`, `CI`), say what it does in
   plain words right after — once. Short sentences, one idea each. Active voice. Talk to the
   reader: "you", "your". Start with the point; no wind-up.
-- **Sharp, not padded.** Every chapter is a few clean statements, not a wall and not a
-  bullet list. Cut any sentence that does not earn its place.
+- **The whole diff.** Every change in the PR is either shown and explained or named in a
+  roll-up line. A reader who finishes the walkthrough has seen the change — never two
+  excerpts from a hundred-line diff.
+- **Nothing unrun.** Output on the page is output you captured. Proof is something that
+  actually executed. If no proof can be written for a behavior change, the page says so —
+  that is a finding about the PR, not a gap to pad over.
 
 ## Arguments
 
@@ -30,9 +35,10 @@ Two rules run through the whole page:
 ## Runtime resolution
 
 - **Template**: `~/.claude/at/templates/pr-explain-page.html` — design tokens plus the
-  `.bottomline`, `.tree`, `.wit`, `.gate-chip`, and `.cmd` classes the chapters use. Missing?
-  Still ship: build a single-file HTML page with inline CSS that follows the chapter
-  contract. Visual polish degrades; the contract does not.
+  `.bottomline`, `.goals`, `.tree`, `.hunk-head`, `.testlist`, `.wit`, `.gate-chip`,
+  `.no-proof`, and `.cmd` classes the chapters use. Missing? Still ship: build a
+  single-file HTML page with inline CSS that follows the chapter contract. Visual polish
+  degrades; the contract does not.
 - **Vale config**: `~/.claude/at/templates/pr-explain.vale.ini`, staged with the template. It
   names the write-good / proselint / Google packages the mechanical prose gate runs. Missing,
   or `vale` not installed → the gate degrades to the `wc` + banned-word checks.
@@ -42,20 +48,26 @@ Two rules run through the whole page:
 
 ## The page — five chapters
 
-Each chapter answers one question. Keep to the budget; a budget is a ceiling, not a target.
-Drop an empty chapter, never pad it.
+The shape follows what the big open-source repos converged on for PR descriptions —
+Kubernetes ("what this PR does / why we need it"), Google's CL guide (a standalone
+imperative first line), React ("the exact commands you ran and their output") — retold in
+plain words. Each chapter answers one question. A budget is a ceiling, not a target; drop
+an empty chapter, never pad it.
 
 | # | Chapter | The question it answers | Budget |
 |---|---------|-------------------------|--------|
-| 1 | What this is for | Why did we build this, what is it, and what changes once it merges? | 60-100 words |
-| 2 | The map | Which files did we touch, and what did we do in each? | tree + ≤ 40 words + ≤ 2 diffs |
-| 3 | The tests | What do the tests set up and check, and how did they go RED then GREEN? | 50-90 words |
-| 4 | The proof | What did we run to show it really works? | 40-70 words + evidence |
-| 5 | See for yourself | What can you paste to confirm it yourself? | ≤ 40 words + commands |
+| 1 | What & why | What does this PR do, why now, and what is true after it merges? | ≤ 80 words |
+| 2 | The walkthrough | What did we change, where is it, and why — across the whole diff | ≤ 40-word note per hunk |
+| 3 | The tests | Which tests pin this, one by one, and how they went RED then GREEN | one ≤ 14-word line per test |
+| 4 | The proof | What actually ran against this change, with real numbers | 40–70 words + evidence |
+| 5 | See for yourself | What can you paste to confirm it — with the output we got | ≤ 40 words + run blocks |
 
-Total prose ≤ 380 words. Code, diffs, the tree, and command blocks do not count, and each
-diff or command block caps at 10 lines. A tiny PR (docs, a version bump, one-line config)
-shrinks to Chapter 1, a one-line tree, and Chapter 5 — no forced tests or proof.
+Prose scales with the diff: chapters 1, 4, and 5 keep fixed budgets; the walkthrough grows
+one note per hunk and the test list one line per test. Code, diffs, trees, command blocks,
+captured output, and test names never count as prose. Each diff or command block caps at
+12 lines — trim to the lines that carry the decision. A tiny PR with no behavior (docs, a
+version bump, one-line config) shrinks to Chapter 1, a one-line tree, and Chapter 5 — no
+forced tests or proof; log the shrink and its reason in the report.
 
 ## Phase 1 — Gather
 
@@ -82,10 +94,7 @@ may not be the one you were asked about. `--json files` gives every touched path
   It carries `behaviors[]` (each with a RED and a GREEN witness), `gates[]` (real gate numbers
   from the run), and `runtime` (artifact paths relative to that dir). Chapters 3 and 4 quote it
   verbatim: the RED witness carries the failure reason, the GREEN witness what made it pass plus
-  `+<lines_added>`, one gate chip per `gates[]` row. **Never invent evidence.** No file → the
-  proof degrades to `gh pr checks` plus the test files in the diff. Checks empty too → cite the
-  diff's test files. Numbers claimed only in the PR body appear attributed ("PR body reports:
-  pytest 161 passed"), never as a verified chip.
+  `+<lines_added>`, one gate chip per `gates[]` row. **Never invent evidence.**
 
 ## Phase 2 — Understand (before writing a word)
 
@@ -94,26 +103,52 @@ may not be the one you were asked about. `--json files` gives every touched path
 2. **Split the touched files** into production and tests (path holds `test`, `spec`,
    `__tests__`, `.test.`, `.spec.`, or lives under `tests/`). Production files drive Chapter 2;
    test files drive Chapter 3.
-3. **Read the production hunks** and write, for each touched non-test file, one plain phrase
-   of what changed there — the tree callout. Pick at most **2** hunks that carry the decision
-   to show as real diff lines under the tree.
-4. **Build the tree** (Chapter 2): the touched subtree only. Group touched files under their
+3. **Take the hunk inventory.** List every hunk in `gh pr diff` (each `@@` block). Classify
+   each: a **decision** hunk changes behavior, an interface, or logic — anything you would
+   pause on while pair-programming; a **mechanical** hunk is imports, re-exports, wiring,
+   formatting, renames, lockfiles. Every decision hunk becomes a walkthrough entry with its
+   own diff lines and note. Mechanical hunks roll up into one named line per file ("plus the
+   import and route registration"). Shown or named — those are the only two options; a hunk
+   that is neither is a completeness failure the gate below catches.
+4. **Order the walkthrough by the call path**, not by filename: start where the request or
+   call enters and follow it down (route → interface → storage), the way you would narrate it
+   at the keyboard.
+5. **Take the test inventory.** For every test file in the diff, list each added or changed
+   test by its name in the code. Each becomes one Chapter 3 line.
+6. **Build the tree** (Chapter 2): the touched subtree only. Group touched files under their
    folders; show a touched file with a `●`, its name in bold, and `+adds −dels`; mark test
    files with a `test` tag and give them no callout. Add a couple of untouched siblings, dimmed
    with `·`, only when they help the reader place the change — do not print the whole folder.
    Cap the tree around 20 rows.
-5. **Build the "you are here" strip**: top-level git-tracked directories
+7. **Build the "you are here" strip**: top-level git-tracked directories
    (`git ls-tree -d --name-only HEAD`), byte-sorted, equal-width cells; light the ones that
    contain a touched file. Same strip, same order, every PR — it orients the reader in the
    whole repo without printing it.
 
-## Phase 3 — Write
+## Phase 3 — Run (capture real output)
+
+Before writing, run the change. Everything here executes in the target repo, on the PR's
+head; capture output verbatim for Chapters 4 and 5.
+
+- **Rerun the PR's tests** with the narrowest selector that covers the diff's test files
+  (`pytest tests/catalog/ -q`, `cargo test -p <crate>`, `vitest run <dir>`). A fresh green
+  run is first-class proof: chip it as `run here — <n> passed`.
+- **Run every Chapter 5 command yourself first.** Only ship a command you ran; paste its
+  real output next to it. A command the reader needs but you cannot run here (missing
+  credentials, no device) ships marked `not run here — needs <thing>`, never with imagined
+  output.
+- **Safe commands only**: test runners, linters, builds, read-only CLI and `curl` against a
+  server you started locally from the repo. Never migrations against shared databases,
+  deploys, publishes, or network writes. No documented way to run it → say so and fall back
+  to the evidence file and CI.
+
+## Phase 4 — Write
 
 Draft the prose in a scratch buffer under these rules:
 
 1. **One PR, one thing.** Chapter 1 leads with it. Secondary changes get one line, never an arc.
-2. **Every claim points at something the page shows** — a tree callout, a diff line, a gate
-   chip, a check, a screenshot. "Faster", "safer", "fixed" each arrive with a number or output.
+2. **Every claim points at something the page shows** — a walkthrough hunk, a test line, a
+   gate chip, captured output. "Faster", "safer", "fixed" each arrive with a number or output.
 3. **Concrete before abstract.** The failing command, the error, or the real line comes before
    any statement about it. Examples are trimmed from the actual diff, never invented.
 4. **Plain words, ≤ 25-word sentences, one idea per sentence, data over adjectives.**
@@ -125,35 +160,100 @@ simply, utilize, facilitate, ensures, significantly, various, clearly, essential
 moreover, "in order to", "it's worth noting", "not only… but also", and "should" when you mean
 what the code *does*.
 
+### Chapter 1 — What & why
+
+Three moves, in order, nothing else:
+
+- **One imperative sentence** that stands alone — what this PR does. A future reader finds
+  the PR by this line.
+- **One or two sentences of why** — what was missing or broken, and why now. From the issue
+  or PRD, not the diff.
+- **Goals** — two to four short bullets, each an outcome that is true after merge and
+  checkable on this page (by a walkthrough hunk, a test line, or a run).
+
+Example shape (not words to copy):
+
+> Add `rate_exercise` and `PUT /api/exercises/{id}/rating` so you can set or clear your own
+> rating. Nothing could write the personal rating until now; the tap-to-rate screen (W6) is
+> blocked on it.
+> **Goals** · a whole number 1–5 sets your rating, `null` clears it · the response returns the
+> full exercise, so the screen fetches nothing else · `true` and `"3"` are rejected, not coerced.
+
+### Chapter 2 — The walkthrough
+
+The heart of the page. For each decision hunk, in call-path order:
+
+- a `.hunk-head` line — the file and the function, route, or class the hunk lives in
+  ("`api.py` · `PUT /api/exercises/{id}/rating`");
+- the trimmed diff lines (≤ 12);
+- one note, ≤ 40 words, that answers all three: **what we do** here, **why** it is needed,
+  and **where it sits** in the flow ("this runs before any write reaches the database").
+
+Close each file's entries with its mechanical roll-up line if it has one. The tree's
+per-file callouts stay — they are the index; the hunks are the walkthrough.
+
+### Chapter 3 — The tests
+
+Enumerate, then witness. First the list: every test from the inventory, grouped under its
+file, one line each — the test's name from the code plus ≤ 14 plain words of what it checks.
+No test in the diff is left off the list. Then the RED → GREEN story from the witnesses,
+verbatim from the evidence file. No evidence file → the list stands alone and the page says
+the witnesses are absent.
+
+### Chapter 4 — The proof
+
+Proof is what actually executed, strongest first: your Phase 3 runs, then the evidence
+file's gates, then CI checks (`gh pr checks`). Chip each with its real number. Numbers
+claimed only in the PR body appear attributed ("PR body reports: pytest 161 passed"), never
+as a verified chip.
+
+**The proof gate is hard.** For a PR with behavior, this chapter can neither be dropped nor
+padded. If all three sources come up empty — nothing was ever run against this change — the
+chapter is the `.no-proof` verdict, verbatim: *"No proof exists: nothing was run to show
+this change works. A PR whose proof cannot be written had nothing to prove — that is a
+finding about the PR, not this page."* Carry a ⚠ into the teaser and the report. Never
+invent a chip to avoid the verdict.
+
+### Chapter 5 — See for yourself
+
+One or two command blocks the reader can paste to confirm *this* change, each followed by
+the output you captured in Phase 3. Commands you could not run here carry the
+`not run here — needs <thing>` mark instead of output.
+
 ### The bar
 
-The draft leaves Phase 3 only after both gates. Run them in order:
+The draft leaves Phase 4 only after both gates. Run them in order:
 
-- **Mechanical gate (always).** `wc -w` each chapter and cut anything over budget. `grep` the
-  draft for every banned word above and rewrite each hit. Then, **if `vale` is on PATH**, write
-  the draft to a scratch `.md` and run `vale --config ~/.claude/at/templates/pr-explain.vale.ini
-  <draft>.md` (run `vale --config … sync` once first if `StylesPath` is empty), rewriting every
-  alert. `vale` absent or `sync` can't reach the registry → degrade to the `wc` + banned-word
-  checks and note it in the report; never fail the run. The banned-word list stays owned by the
-  grep; Vale only adds fuzzy prose quality (weasel words, passive voice, wordiness).
+- **Mechanical gate (always).**
+  - *Coverage*: count hunks (`gh pr diff <N> | grep -c '^@@'`) and check every one is a
+    walkthrough entry or inside a named roll-up line. Grep each test name from the inventory
+    against the draft; every one appears.
+  - *Prose*: `wc -w` each budgeted unit and cut anything over. `grep` the draft for every
+    banned word above and rewrite each hit. Then, **if `vale` is on PATH**, write the draft
+    to a scratch `.md` and run `vale --config ~/.claude/at/templates/pr-explain.vale.ini
+    <draft>.md` (run `vale --config … sync` once first if `StylesPath` is empty), rewriting
+    every alert. `vale` absent or `sync` can't reach the registry → degrade to the `wc` +
+    banned-word checks and note it in the report; never fail the run. The banned-word list
+    stays owned by the grep; Vale only adds fuzzy prose quality.
 - **Critic pass (inline, one rubric, one loop).** Score the draft 0-100, four dimensions ×
   0-25:
   - **Plain & simple** — commonest words; any code word explained once; a first-time reader
     follows it without stopping. This is the point of the page — weight it hardest.
-  - **Evidenced** — every claim cites a tree callout / diff line / gate chip / check / screenshot
-    the page shows; no unevidenced faster / safer / fixed.
-  - **Sharp & short** — clean statements, not bullets and not a wall; ≤ 25-word sentences; every
-    chapter within budget.
-  - **Complete map & confirm** — the tree marks every touched file with a plain callout (tests
-    excepted), and Chapter 5's commands actually confirm *this* change.
+  - **Whole diff walked** — every hunk shown or named; each shown hunk's note answers what,
+    why, and where; the walkthrough reads in call-path order like a narration.
+  - **Enumerated & real** — every test in the diff is on the list with a plain line; every
+    output and chip on the page was actually run or quoted from evidence/CI; the no-proof
+    verdict, if present, is honest.
+  - **Sharp & short** — clean statements; ≤ 25-word sentences; every unit within budget;
+    Chapter 1 is the three moves and nothing more.
 
   Below **90** → apply the specific misses as one rewrite pass, then re-score once. After the
-  rewrite, re-run the banned-word `grep` and per-chapter `wc` — those are hard and must still
-  hold at publish.
+  rewrite, re-run the coverage greps and per-unit `wc` — those are hard and must still hold
+  at publish.
 - **Ship-flag.** Still < 90 after the rewrite → publish anyway and record the final score and
   the unmet dimensions in the report. Never block the publish or loop a third time.
 
-## Phase 4 — Build
+## Phase 5 — Build
 
 - Fill the template's `SLOT` comments. Keep its tokens, classes, and all four theme token
   blocks. Delete the whole `.chapter` div of any chapter you drop. Everything stays inline —
@@ -161,29 +261,39 @@ The draft leaves Phase 3 only after both gates. Run them in order:
 - **The tree**: use the `.row`, `.dir`, `.file`/`.file.hit`, `.dot`, `.stat`, `.is-test`, and
   `.note` classes exactly as the SLOT comment shows; indent rows with `l1`/`l2`/`l3`. A callout
   is a `.note` row directly under its file.
+- **The walkthrough**: one `.hunk-head` + `.diff` + `.diff-note` group per decision hunk;
+  roll-ups are a `.diff-note` alone.
+- **The test list**: `.testlist` with a `.tfile` row per file and a `.trow` per test.
 - Screenshots and e2e output embed as `data:` URIs via `img.evidence`.
 
-## Phase 5 — Publish
+## Phase 6 — Publish
 
 - Artifact tool: title `PR #<N> — <plain title, ≤ 8 words>`, favicon `📖` (stable across
   reruns), a one-sentence description.
 - Rerun in the same conversation → republish the same file path (same URL). Rerun in a later
   session → pass the teaser's artifact URL (from the Phase 1 body) as the `url` parameter.
-  Publishing with `url` fails (artifact deleted or not owned) → publish without it; Phase 6
+  Publishing with `url` fails (artifact deleted or not owned) → publish without it; Phase 7
   rewrites the teaser with the new link.
 
-## Phase 6 — The teaser
+## Phase 7 — The teaser
 
 Maintain exactly one marker-delimited block in the PR description:
 
 ```markdown
 <!-- pr-explain:begin -->
-### What this PR is for
-<the What-this-is-for chapter, verbatim>
+### What & why
+<the Chapter 1 summary and why, verbatim>
+
+**Goals**
+<the Chapter 1 goal bullets, verbatim>
 
 **[Read the explainer](<artifact-url>)** · <n> files touched
 <!-- pr-explain:end -->
 ```
+
+Chapter 1 doubles as the PR description the big repos would ask for — that is by design.
+If the page carries the no-proof verdict, append `· ⚠ no proof — see the explainer` to the
+link line.
 
 - Re-read the body with `gh pr view <N> --json body` — it may have changed since Phase 1.
   Replace the block between the markers in place (append if the markers are absent); write the
@@ -197,7 +307,9 @@ Maintain exactly one marker-delimited block in the PR description:
 
 ## Report
 
-End with: the artifact URL, total prose word count, chapters emitted vs dropped, the number of
-touched files in the tree, the PR whose teaser you updated, the mechanical gate result (Vale
-alerts fixed, or "vale unavailable — wc + grep only"), and the critic score — naming any
-dimension left under the bar when the page shipped flagged.
+End with: the artifact URL; hunks shown / rolled up / total; tests enumerated; commands run
+vs marked not-run; the proof verdict (sources used, or the ⚠ no-proof flag); chapters
+emitted vs dropped (with the tiny-PR shrink reason if used); the PR whose teaser you
+updated; the mechanical gate result (coverage greps, Vale alerts fixed, or "vale
+unavailable — wc + grep only"); and the critic score — naming any dimension left under the
+bar when the page shipped flagged.

--- a/templates/pr-explain-page.html
+++ b/templates/pr-explain-page.html
@@ -55,8 +55,11 @@
   .bottomline { border: 1px solid var(--line-strong); background: var(--card);
     border-radius: 8px; padding: 18px 22px; margin-top: 28px; }
   .bottomline p { margin: 6px 0 0; }
+  .goals { margin: 10px 0 0; padding-left: 1.15em; }
+  .goals li { margin: 4px 0; font-size: 15.5px; }
+  .goals li::marker { color: var(--accent); }
 
-  /* Chapter 2 — the map: one annotated file tree of the touched subtree. */
+  /* Chapter 2 — the walkthrough: the tree as index, then every decision hunk. */
   .minimap { display: flex; gap: 4px; margin: 6px 0 2px; }
   .mm-cell { flex: 1; border: 1px solid var(--line); border-radius: 4px;
     background: var(--code-bg); font-family: var(--mono); font-size: 10px;
@@ -81,15 +84,24 @@
     color: var(--ink-2); margin: 1px 0 6px; }
   .tree .note::before { content: "└ "; color: var(--accent); font-style: normal; }
 
+  .hunk-head { font-family: var(--mono); font-size: 12px; color: var(--ink-2);
+    margin: 22px 0 0; }
+  .hunk-head .fname { font-weight: 700; color: var(--ink); }
+  .hunk-head .scope { color: var(--accent); }
   .diff { font-family: var(--mono); font-size: 12.5px; line-height: 1.55;
-    background: var(--code-bg); border-radius: 6px; padding: 10px 12px; margin: 12px 0;
+    background: var(--code-bg); border-radius: 6px; padding: 10px 12px; margin: 8px 0 0;
     overflow-x: auto; white-space: pre; }
   .diff .ctx { color: var(--ink-3); }
   .diff .del { color: var(--red); background: var(--red-soft); display: inline-block; width: 100%; }
   .diff .add { color: var(--green); background: var(--green-soft); display: inline-block; width: 100%; }
   .diff-note { font-size: 15px; color: var(--ink-2); margin: 6px 0 0; }
 
-  /* Chapter 3 — the tests: RED → GREEN witnesses. */
+  /* Chapter 3 — the tests: every test enumerated, then RED → GREEN witnesses. */
+  .testlist { margin: 12px 0; }
+  .tfile { font-family: var(--mono); font-size: 11.5px; color: var(--ink-3); margin: 12px 0 4px; }
+  .trow { display: flex; gap: 10px; align-items: baseline; margin: 3px 0; font-size: 15px; }
+  .trow .tname { font-family: var(--mono); font-size: 12px; color: var(--ink); flex: none; }
+  .trow .tdesc { color: var(--ink-2); }
   .wit { display: flex; gap: 8px; align-items: baseline; font-size: 15px; margin: 8px 0; }
   .wit .tag { font-family: var(--mono); font-size: 10.5px; font-weight: 700;
     padding: 1px 7px; border-radius: 4px; flex: none; }
@@ -101,13 +113,18 @@
   .gate-chip { font-family: var(--mono); font-size: 11.5px; padding: 3px 9px;
     border-radius: 999px; background: var(--green-soft); color: var(--green); }
   .gate-chip.fail { background: var(--red-soft); color: var(--red); }
+  .no-proof { border: 1px solid var(--red); background: var(--red-soft); border-radius: 8px;
+    padding: 14px 18px; margin-top: 10px; font-size: 15.5px; }
+  .no-proof .tag { font-family: var(--mono); font-size: 10.5px; font-weight: 700;
+    color: var(--red); letter-spacing: 0.08em; display: block; margin-bottom: 4px; }
   img.evidence { max-width: 100%; border: 1px solid var(--line-strong); border-radius: 6px; margin-top: 12px; }
 
-  /* Chapter 5 — see for yourself: commands the reader can run. */
+  /* Chapter 5 — see for yourself: commands the reader can run, with output we captured. */
   .cmd { font-family: var(--mono); font-size: 12.5px; line-height: 1.65; background: var(--code-bg);
     border-radius: 6px; padding: 12px 14px; margin: 12px 0; overflow-x: auto; white-space: pre; }
   .cmd .p { color: var(--accent); font-weight: 700; }
   .cmd .out { color: var(--ink-3); }
+  .cmd .skip { color: var(--amber); font-style: italic; }
 </style>
 
 <div class="wrap">
@@ -116,12 +133,18 @@
   <div class="meta"><!-- SLOT: <span> items: branch, +adds −dels, date --></div>
 
   <div class="bottomline">
-    <div class="clabel">What this is for</div>
-    <!-- SLOT: 60-100 words, plain words — why we built it, what it is, what changes after it merges -->
+    <div class="clabel">What &amp; why</div>
+    <!-- SLOT: ≤ 80 words, three moves and nothing more:
+         <p>One imperative sentence — what this PR does, standing alone.
+            One or two sentences of why — what was missing or broken, and why now.</p>
+         <ul class="goals">
+           <li>an outcome true after merge, checkable on this page</li>
+           <li>2–4 bullets total</li>
+         </ul> -->
   </div>
 
   <div class="chapter">
-    <div class="clabel">The map</div>
+    <div class="clabel">The walkthrough</div>
     <div class="minimap"><!-- SLOT: one .mm-cell per git-tracked top-level dir, byte-sorted;
       add class "here" to dirs that contain a touched file --></div>
     <div class="mm-caption">you are here — every top folder in the repo; lit = we touched it</div>
@@ -134,36 +157,53 @@
            untouched sib:  <div class="row l2"><span class="file">catalog.toml</span>  <span class="stat">·</span></div>
       -->
     </div>
-    <!-- OPTIONAL: at most 2 key non-test changes shown as real lines, each with one plain sentence:
+    <!-- SLOT: the walkthrough — EVERY decision hunk in the diff, in call-path order.
+         One group per hunk:
+      <div class="hunk-head"><span class="fname">api.py</span> · <span class="scope">PUT /api/exercises/{id}/rating</span></div>
       <div class="diff"><span class="ctx">  context</span>
       <span class="del">- removed</span>
       <span class="add">+ added</span></div>
-      <p class="diff-note">Here we do X so that Y.</p>
+      <p class="diff-note">What we do here, why it is needed, where it sits in the flow. ≤ 40 words.</p>
+         Close each file with its mechanical roll-up as a bare note, so every hunk is shown or named:
+      <p class="diff-note">Plus the import and route registration in <code>api.py</code>.</p>
     -->
   </div>
 
   <div class="chapter">
     <div class="clabel">The tests</div>
-    <!-- SLOT: 50-90 words. First the scenario in plain words — what the test sets up and checks.
+    <!-- SLOT: enumerate first — every added/changed test, grouped by file, one line each:
+         <div class="testlist">
+           <div class="tfile">tests/catalog/test_api.py</div>
+           <div class="trow"><span class="tname">rating_of_3_sets_my_rating</span><span class="tdesc">≤ 14 plain words on what it checks</span></div>
+         </div>
          Then the RED → GREEN story from the witnesses:
          <div class="wit"><span class="tag red">RED</span><span>…failed first, and the exact reason…</span></div>
          <div class="wit"><span class="tag green">GREEN</span><span>…what made it pass…</span></div>
-         No evidence file → describe the test files in the diff and say the witnesses are absent. -->
+         No evidence file → the list stands alone; say the witnesses are absent. -->
   </div>
 
   <div class="chapter">
     <div class="clabel">The proof</div>
-    <!-- SLOT: 40-70 words + evidence. Gate numbers as chips:
-         <div class="gate-row"><span class="gate-chip">pytest 161 passed</span><span class="gate-chip">mypy strict</span></div>
+    <!-- SLOT: 40-70 words + evidence — only what actually ran, strongest first:
+         fresh runs from this session, then evidence-file gates, then CI. Chips carry real numbers:
+         <div class="gate-row"><span class="gate-chip">run here — pytest 161 passed</span><span class="gate-chip">mypy strict</span></div>
          Runtime evidence (screenshot, e2e run) as <img class="evidence" src="data:…">.
-         No evidence file → CI check results as chips (class "fail" for red ones);
-         PR-body claims appear only attributed in prose ("PR body reports: …"), never as chips. -->
+         CI check results as chips (class "fail" for red ones);
+         PR-body claims appear only attributed in prose ("PR body reports: …"), never as chips.
+         A behavior PR with NOTHING run → this verdict, verbatim, instead (never drop, never pad):
+         <div class="no-proof"><span class="tag">NO PROOF</span>No proof exists: nothing was run to
+         show this change works. A PR whose proof cannot be written had nothing to prove — that is
+         a finding about the PR, not this page.</div> -->
   </div>
 
   <div class="chapter">
     <div class="clabel">See for yourself</div>
-    <!-- SLOT: ≤ 40 words + one command block the reader can paste to confirm the change:
+    <!-- SLOT: ≤ 40 words + command blocks the reader can paste. Output is REAL — captured by
+         running the command in Phase 3, never imagined:
          <div class="cmd"><span class="p">$</span> at update
-         <span class="out">demo-pack (extras) — up to date</span></div> -->
+         <span class="out">demo-pack (extras) — up to date</span></div>
+         A command you could not run here:
+         <div class="cmd"><span class="p">$</span> flutter run
+         <span class="skip">not run here — needs a device</span></div> -->
   </div>
 </div>


### PR DESCRIPTION
Rework /pr-explain around owner feedback on a real page: two diff excerpts from a ~100-line PR is not an explanation, tests were summarized instead of listed, "See for yourself" shipped commands nobody had run, and "What this is for" read as narrative padding.

**Goals**
- The walkthrough covers the whole diff: every hunk is shown with a what/why/where note in call-path order, or named in a per-file mechanical roll-up — the ≤2-diff cap is deleted, and a coverage grep in the mechanical gate enforces it.
- Every added or changed test is enumerated by its code name with one plain line, before the RED/GREEN witnesses.
- The proof chapter is a hard gate: fresh runs > evidence gates > CI, and a behavior PR with nothing run gets an explicit NO PROOF verdict on the page plus a ⚠ in the teaser — "a PR whose proof cannot be written had nothing to prove."
- A new Run phase executes the confirm commands before writing, so Chapter 5 carries real captured output; un-runnable commands are marked, never faked.
- Chapter 1 follows the top-OSS PR-description convention (Kubernetes what/why, Google's imperative first line, React's test-plan): one standalone summary sentence, the why, then 2–4 goal bullets — short and sharp, and it doubles as the PR-body teaser.

Template gains `.goals`, `.hunk-head`, `.testlist`, `.no-proof`, and `.cmd .skip` to carry the new contract. `validate.sh` OK; 182 installer tests pass (extras paths unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kqLNWm5kgAbFwofpji9Yz