### PR TITLE
fix(size): a deleted file no longer adds a phantom line to the file before it

### DIFF
--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import re
 from typing import Final
 
-# The unified diff we ask git for: the post-image path marker, and the hunk header we
-# read new-file line numbers from.
+# The unified diff we ask git for: the post-image path marker, the header it shares
+# with a deletion's `+++ /dev/null`, and the hunk header we read new-file line numbers
+# from.
 NEW_PATH_MARKER: Final[str] = "+++ b/"
+POST_IMAGE_MARKER: Final[str] = "+++ "
 HUNK_HEADER: Final[re.Pattern[str]] = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)")

--- a/scripts/pr_size/sizing.py
+++ b/scripts/pr_size/sizing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-from .constants import HUNK_HEADER, NEW_PATH_MARKER
+from .constants import HUNK_HEADER, NEW_PATH_MARKER, POST_IMAGE_MARKER
 
 
 def added_line_numbers(*, diff_text: str) -> dict[str, tuple[int, ...]]:
@@ -21,6 +21,8 @@ def added_line_numbers(*, diff_text: str) -> dict[str, tuple[int, ...]]:
         if line.startswith(NEW_PATH_MARKER):
             path = line.removeprefix(NEW_PATH_MARKER)
             added.setdefault(path, [])
+        elif line.startswith(POST_IMAGE_MARKER):
+            path = None
         elif header is not None:
             line_number = int(header.group(1))
         elif path is None:

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -48,3 +48,17 @@ def test_every_changed_path_is_reported_even_when_it_only_lost_lines() -> None:
 
     assert numbered["gone.py"] == ()
     assert len(numbered["cart.py"]) == SMALL_CHANGE
+
+
+def test_a_deleted_file_adds_no_phantom_line_to_the_file_before_it() -> None:
+    """git writes `+++ /dev/null` for a deletion; it is a header, not an addition."""
+    diff_text: str = _diff(path="aaa.py", added=1) + (
+        "diff --git a/zzz.py b/zzz.py\n"
+        "deleted file mode 100644\n"
+        "--- a/zzz.py\n"
+        "+++ /dev/null\n"
+        "@@ -1,3 +0,0 @@\n"
+        "-one\n-two\n-three\n"
+    )
+
+    assert added_line_numbers(diff_text=diff_text) == {"aaa.py": (1,)}


### PR DESCRIPTION
Found by running the review cycle's **execution dry-run** over the size gate's own prompts — not by the test suite, which was green throughout.

## The bug

git writes `+++ /dev/null` as the post-image header of a deleted file. That is not `+++ b/<path>`, so it fell through to the generic `+` test in `added_line_numbers` and was counted as an **added line**, charged to whichever path was last seen.

Reproduced on a real repo — `aaa.py` modified (+1 line), `zzz.py` deleted:

```
$ python -m pr_size --base HEAD~1
code lines: 2   [('aaa.py', 2)]     ← aaa.py gained exactly 1
```

Every deletion that sorts *after* another changed file inflates that file's count by one. A cleanup PR removing ten files gains ten phantom lines — enough to push a change across a band boundary and have the gate refuse work that was never over the cap. Since a `block` is never waivable by the agent, the run dead-ends re-scoping a phantom.

## Why the suite missed it

The existing deletion test used a *modification whose every line was removed*, which still carries a `+++ b/` header. The RED test here builds a true deletion hunk, and fails on `{'aaa.py': (1, 2)} != {'aaa.py': (1,)}` — the phantom line 2 is visible in the assertion.

## The fix

An unattributable post-image header clears the current path instead of being counted, so nothing is charged until the next real file starts. Two lines plus a named constant.

`gate: PASS — code 7 added lines across 2 files (target 35)`