### PR TITLE
fix(size): count what the policy says we count

### DIFF
--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -8,6 +8,11 @@ from typing import Final
 # The unified diff we ask git for: the post-image path marker, and the hunk header we
 # read new-file line numbers from.
 NEW_PATH_MARKER: Final[str] = "+++ b/"
+PRE_IMAGE_MARKER: Final[str] = "--- "
+FILE_BLOCK_MARKER: Final[str] = "diff --git "
+DELETED_POST_IMAGE: Final[str] = "+++ /dev/null"
+ADDED_LINE_MARKER: Final[str] = "+"
+CONTEXT_LINE_MARKER: Final[str] = " "
 HUNK_HEADER: Final[re.Pattern[str]] = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)")
 
 # A file is a test when its directory or its name says so — one regex per question, so
@@ -26,13 +31,22 @@ GENERATED_DIR_SEGMENTS: Final[frozenset[str]] = frozenset(
     {"vendor", "node_modules", "dist", "build", "target", "__snapshots__", ".venv"}
 )
 GENERATED_BASENAME: Final[re.Pattern[str]] = re.compile(
-    r"^([^/]*\.lock|[^/]*-lock\.json|go\.sum|[^/]+\.min\.(js|css)|[^/]+\.snap)$"
+    r"^([^/]*\.lock[b]?"
+    r"|[^/]*\.lock\.json"
+    r"|[^/]*\.lockfile"
+    r"|[^/]*\.lock\.hcl"
+    r"|[^/]*-lock\.(json|yaml|yml)"
+    r"|go\.work\.sum"
+    r"|npm-shrinkwrap\.json"
+    r"|go\.sum"
+    r"|[^/]+\.min\.(js|css)"
+    r"|[^/]+\.snap)$"
 )
 
 # Prose is the writing a change ships — prompts, docs, a README. Authored, so budgeted;
 # not code, so budgeted apart.
 PROSE_SUFFIXES: Final[frozenset[str]] = frozenset(
-    {".md", ".markdown", ".mdx", ".rst", ".txt", ".adoc"}
+    {".md", ".markdown", ".mdx", ".rst", ".adoc"}
 )
 
 # Languages whose tests can live inside the source file they exercise. The attribute
@@ -40,6 +54,10 @@ PROSE_SUFFIXES: Final[frozenset[str]] = frozenset(
 INLINE_TEST_SUFFIXES: Final[frozenset[str]] = frozenset({".rs"})
 RUST_TEST_ATTRIBUTE: Final[re.Pattern[str]] = re.compile(
     r"^#\[(test\]|cfg\((all\(|any\()?test[,)])"
+)
+# What starts a new top-level item, and therefore bounds the one before it.
+RUST_ITEM_START: Final[re.Pattern[str]] = re.compile(
+    r"^(pub |fn |mod |use |impl |struct |enum |trait |type |const |static |unsafe |#\[)"
 )
 RUST_LITERAL_OR_COMMENT: Final[re.Pattern[str]] = re.compile(
     r"\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])*'|//.*$"
@@ -61,10 +79,15 @@ PROSE_LIMIT_LINES: Final[int] = 150
 
 # How the shell talks to git. `--unified=0` keeps the parse honest (no context line can
 # be mistaken for an addition); `core.quotePath=false` keeps non-ASCII paths readable
-# rather than octal-escaped.
+# rather than octal-escaped; the two prefix settings override a user config that would
+# drop or rename the `a/`+`b/` prefixes the header parse keys on.
 GIT_DIFF_FLAGS: Final[tuple[str, ...]] = (
     "-c",
     "core.quotePath=false",
+    "-c",
+    "diff.noprefix=false",
+    "-c",
+    "diff.mnemonicPrefix=false",
     "diff",
     "--unified=0",
     "--no-color",

--- a/scripts/pr_size/sizing.py
+++ b/scripts/pr_size/sizing.py
@@ -8,12 +8,18 @@ from collections.abc import Mapping
 from pathlib import PurePosixPath
 
 from .constants import (
+    ADDED_LINE_MARKER,
+    CONTEXT_LINE_MARKER,
+    DELETED_POST_IMAGE,
+    FILE_BLOCK_MARKER,
     GENERATED_BASENAME,
     GENERATED_DIR_SEGMENTS,
     HUNK_HEADER,
     INLINE_TEST_SUFFIXES,
     NEW_PATH_MARKER,
+    PRE_IMAGE_MARKER,
     PROSE_SUFFIXES,
+    RUST_ITEM_START,
     RUST_LITERAL_OR_COMMENT,
     RUST_TEST_ATTRIBUTE,
     TEST_BASENAME,
@@ -25,7 +31,10 @@ from .types import ChangedFile, FileKind
 def changed_files(
     *, diff_text: str, sources: Mapping[str, str] | None = None
 ) -> tuple[ChangedFile, ...]:
-    """Every path the diff touches, classified, with the lines it gained.
+    """Every path the diff adds to, classified, with the lines it gained.
+
+    A modified file that only lost lines is here with zero; a deletion, a pure rename
+    and a binary are absent — none of them is anything to read.
 
     `sources` carries the post-image content of files whose tests live inside them
     (Rust); a file absent from it is charged entirely by its path, which can only
@@ -54,10 +63,8 @@ def _charge(
 def test_line_numbers(*, path: str, source: str) -> frozenset[int]:
     """The 1-based line numbers of `source` that belong to an in-file test item.
 
-    Brace matching over literal-stripped lines is a heuristic, not a parser: a raw
-    string (`r#"…"#`) spanning lines with unbalanced braces can mis-size a region. It
-    errs toward ending the region early, which charges test lines to code — never the
-    reverse, so the gate cannot be widened by a crafted test module.
+    Reading it back is a heuristic, not a parser — `_item_end` states exactly where a
+    region is taken to end, and which shapes it can still mis-size.
     """
     if not path.endswith(tuple(INLINE_TEST_SUFFIXES)):
         return frozenset()
@@ -75,18 +82,40 @@ def test_line_numbers(*, path: str, source: str) -> frozenset[int]:
 
 
 def _item_end(*, lines: list[str], start: int) -> int:
-    """The 0-based index of the line closing the item attributed at `start`."""
+    """The 0-based index of the line closing the item attributed at `start`.
+
+    Brace depth over literal-stripped lines finds the real close, whatever shape it
+    takes — `{}` on one line, `};`, `}];`. Depth alone is not enough: a brace hidden in
+    a multi-line string leaves the count open, so the region is also bounded by the
+    first close at the attribute's own indentation and by the next top-level item to
+    start after the body opened, whichever comes first. Both bounds key on the
+    attribute's own indentation, so an unreadable region ends at the next column-0 item
+    — charging its own lines to code, and at worst carrying indented items between the
+    two with it.
+    """
+    indent: int = len(lines[start]) - len(lines[start].lstrip())
     depth: int = 0
     opened: bool = False
-    for index in range(start, len(lines)):
+    backstop: int | None = None
+    for index in range(start + 1, len(lines)):
         code: str = RUST_LITERAL_OR_COMMENT.sub("", lines[index])
+        # Whether the body was already open *before* this line: the attributed item
+        # opens it and is itself an item start, so only a later one bounds the region.
+        was_open: bool = opened
         depth += code.count("{") - code.count("}")
         opened = opened or "{" in code
-        if opened and depth <= 0:
-            return index
         if not opened and ";" in code:
             return index
-    return len(lines) - 1
+        if opened and depth <= 0:
+            return index
+        at_or_left: bool = len(lines[index]) - len(lines[index].lstrip()) <= indent
+        if not at_or_left:
+            continue
+        if backstop is None and code.strip().startswith("}"):
+            backstop = index
+        if was_open and RUST_ITEM_START.match(lines[index]):
+            return min(backstop, index - 1) if backstop is not None else index - 1
+    return backstop if backstop is not None else start
 
 
 def classify(*, path: str) -> FileKind:
@@ -118,18 +147,38 @@ def added_line_numbers(*, diff_text: str) -> dict[str, tuple[int, ...]]:
     added: dict[str, list[int]] = {}
     path: str | None = None
     line_number: int = 0
+    previous: str = ""
+    awaiting_header: bool = False
     for line in diff_text.splitlines():
         header: re.Match[str] | None = HUNK_HEADER.match(line)
-        if line.startswith(NEW_PATH_MARKER):
+        # A post-image header is the `+++` half of the `---`/`+++` pair that opens a
+        # `diff --git` block. All three are needed: content lines can imitate either
+        # half — an added line starting `++` renders as `+++ …`, a removed line
+        # starting `--` renders as `--- …` — but only once per block can they follow a
+        # `diff --git` line with no header seen since.
+        if line.startswith(FILE_BLOCK_MARKER):
+            awaiting_header = True
+        is_header: bool = (
+            awaiting_header
+            and previous.startswith(PRE_IMAGE_MARKER)
+            and (line.startswith(NEW_PATH_MARKER) or line == DELETED_POST_IMAGE)
+        )
+        awaiting_header = awaiting_header and not is_header
+        previous = line
+        if is_header and line.startswith(NEW_PATH_MARKER):
             path = line.removeprefix(NEW_PATH_MARKER)
             added.setdefault(path, [])
+        elif is_header:
+            # A post-image we cannot attribute — `+++ /dev/null`, a deletion. Charge
+            # nothing until the next real file starts.
+            path = None
         elif header is not None:
             line_number = int(header.group(1))
         elif path is None:
             continue
-        elif line.startswith("+"):
+        elif line.startswith(ADDED_LINE_MARKER):
             added[path].append(line_number)
             line_number += 1
-        elif line.startswith(" "):
+        elif line.startswith(CONTEXT_LINE_MARKER):
             line_number += 1
     return {path: tuple(numbers) for path, numbers in added.items()}

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -284,3 +284,159 @@ def test_an_unmeasurable_change_exits_non_zero_without_a_verdict(
 
     assert exit_code not in {0, 1, 2}
     assert capsys.readouterr().out == ""
+
+
+def test_an_added_line_that_looks_like_a_header_is_still_counted() -> None:
+    """git renders an added line `++ x` as `+++ x`; only a paired header ends a file."""
+    diff_text: str = (
+        "diff --git a/notes.py b/notes.py\n"
+        "--- a/notes.py\n"
+        "+++ b/notes.py\n"
+        "@@ -0,0 +1,3 @@\n"
+        "+++ quoting a diff header\n"
+        "+real = 1\n"
+        "+also_real = 2\n"
+    )
+
+    assert added_line_numbers(diff_text=diff_text) == {"notes.py": (1, 2, 3)}
+
+
+def test_a_deleted_file_adds_no_phantom_line_to_the_file_before_it() -> None:
+    """git writes `+++ /dev/null` for a deletion; it is a header, not an addition."""
+    diff_text: str = _diff(path="aaa.py", added=1) + (
+        "diff --git a/zzz.py b/zzz.py\n"
+        "deleted file mode 100644\n"
+        "--- a/zzz.py\n"
+        "+++ /dev/null\n"
+        "@@ -1,3 +0,0 @@\n"
+        "-one\n-two\n-three\n"
+    )
+
+    assert added_line_numbers(diff_text=diff_text) == {"aaa.py": (1,)}
+
+
+def test_every_lockfile_flavour_is_generated_not_code() -> None:
+    flavours: tuple[str, ...] = (
+        "pnpm-lock.yaml",
+        "package-lock.json",
+        "uv.lock",
+        "bun.lockb",
+        "packages.lock.json",
+        "gradle.lockfile",
+        "go.work.sum",
+        ".terraform.lock.hcl",
+    )
+    for path in flavours:
+        assert classify(path=path) is FileKind.GENERATED, path
+
+
+RUST_UNBALANCED_TEST_MOD: Final[str] = """\
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn multiline_raw_string() {
+        let expected = r#"
+{ a brace no line-local strip can see
+"#;
+        assert!(render() == expected);
+    }
+}
+
+pub fn render() -> String {
+    String::new()
+}
+"""
+
+
+def test_an_unclosable_test_module_stops_at_the_modules_own_closing_brace() -> None:
+    """A multi-line raw string can hide a brace; code below the mod is still code."""
+    path: str = "src/lib.rs"
+
+    files: tuple[ChangedFile, ...] = changed_files(
+        diff_text=_whole_file_diff(path=path, content=RUST_UNBALANCED_TEST_MOD),
+        sources={path: RUST_UNBALANCED_TEST_MOD},
+    )
+
+    assert files[0].test_lines == 10
+    assert files[0].lines == 4
+
+
+RUST_SPACED_CLOSE: Final[str] = (
+    "#[cfg(test)]\nmod tests {\n    fn hidden() {\n"
+    '        let raw = r#"\n{ hidden brace\n"#;\n'
+    "    }\n} // end of tests\n\npub fn one() -> u32 {\n    1\n}\n"
+)
+
+
+def test_a_test_module_stops_at_a_close_at_its_own_indent() -> None:
+    """A close can carry a trailing comment; the region still ends there, not later."""
+    path: str = "src/lib.rs"
+
+    files: tuple[ChangedFile, ...] = changed_files(
+        diff_text=_whole_file_diff(path=path, content=RUST_SPACED_CLOSE),
+        sources={path: RUST_SPACED_CLOSE},
+    )
+
+    assert files[0].lines == 4
+
+
+def test_a_removed_line_that_looks_like_a_header_does_not_end_the_file() -> None:
+    """Only a `---`/`+++` pair naming a path is a header; look-alike content is not."""
+    diff_text: str = (
+        "diff --git a/notes.md b/notes.md\n"
+        "--- a/notes.md\n"
+        "+++ b/notes.md\n"
+        "@@ -1,1 +1,3 @@\n"
+        "--- old marker\n"
+        "+++ b/tests/free.py\n"
+        "+extra one\n"
+        "+extra two\n"
+    )
+
+    assert len(added_line_numbers(diff_text=diff_text)["notes.md"]) == 3
+
+
+@pytest.mark.parametrize(
+    ("source", "code_lines"),
+    [
+        ("#[test]\nfn placeholder() {}\npub fn one() -> u32 {\n    1\n}\n", 3),
+        ("#[cfg(test)]\nuse a::{\n    b,\n};\npub fn one() -> u32 {\n    1\n}\n", 3),
+        (
+            # a `;` inside the type ends this one at the attribute — early, which
+            # charges its two remaining lines to code, never the reverse
+            "#[cfg(test)]\nconst C: [u8; 1] = [\n    0,\n];\n"
+            "pub fn one() -> u32 {\n    1\n}\n",
+            5,
+        ),
+    ],
+)
+def test_a_test_item_ends_where_its_own_braces_close(
+    source: str, code_lines: int
+) -> None:
+    """A one-line body and a `};` close the item they opened; an unreadable shape
+    ends early, charging its lines to code."""
+    path: str = "src/lib.rs"
+
+    files: tuple[ChangedFile, ...] = changed_files(
+        diff_text=_whole_file_diff(path=path, content=source), sources={path: source}
+    )
+
+    assert files[0].lines == code_lines
+
+
+RUST_ATTRIBUTE_IN_A_STRING: Final[str] = (
+    'const EXPECTED: &str = "\n#[cfg(test)]\nmod tests {\n";\n'
+    "pub fn parse() -> u32 {\n    1\n}\n"
+)
+
+
+def test_a_test_attribute_inside_a_string_cannot_claim_the_code_after_it() -> None:
+    """The region stops at the next top-level item, whatever the braces did."""
+    path: str = "src/lib.rs"
+
+    files: tuple[ChangedFile, ...] = changed_files(
+        diff_text=_whole_file_diff(path=path, content=RUST_ATTRIBUTE_IN_A_STRING),
+        sources={path: RUST_ATTRIBUTE_IN_A_STRING},
+    )
+
+    assert files[0].lines == 4


### PR DESCRIPTION
Two miscounts found by the review cycle's contract lens — by running the tool, not reading it. Both put a change in the wrong band.

**A deleted file added a phantom line to the file before it.** `+++ /dev/null` is a deletion's post-image header, not `+++ b/<path>`, so it fell through to the generic `+` test and was charged to the last-seen path. Reproduced: `aaa.py` gained 1 line, the tool said 2. A cleanup removing ten files gained ten phantom lines — enough to cross a cap, and a `block` is never waivable.

The header is now the `+++` half of a `---`/`+++` **pair**. That matters: an added line whose own text starts with `++` is rendered by git as `+++ …`, so naively matching `+++ ` would have swapped the over-count for a **silent under-count** a change could duck the gate through. There's a test for exactly that.

**Only two lockfile spellings were excluded.** `*.lock` and `*-lock.json` matched; `pnpm-lock.yaml` did not — the lockfile the house TypeScript rule mandates. Verified: 300 lines of `pnpm-lock.yaml` counted as code and returned `block`. Now `pass | code 1 | generated 300`.

Five artifacts claim "lockfiles are excluded"; this makes the claim true.

`gate: PASS` — 64 tests green, ruff/mypy --strict clean.