### PR TITLE
feat(size): give the size report the house return envelope

### DIFF
--- a/scripts/pr_size/cli.py
+++ b/scripts/pr_size/cli.py
@@ -1,7 +1,9 @@
 """The imperative shell: real git subprocesses, JSON on stdout, verdict as exit code.
 
 Exit codes are the verdict — 0 pass, 1 review (a judge must rule), 2 block, 3 the gate
-could not measure — so an unmeasured change never reads as a passing one.
+could not measure — so an unmeasured change never reads as a passing one. A launch or
+usage failure exits 1 or 2 as well, which is why the JSON `verdict`, not the exit code,
+is what a caller routes on.
 """
 
 from __future__ import annotations
@@ -15,7 +17,13 @@ from typing import Any
 
 import click
 
-from .constants import EXIT_ERROR, GIT_DIFF_FLAGS, INLINE_TEST_SUFFIXES
+from .constants import (
+    EXIT_ERROR,
+    GIT_DIFF_FLAGS,
+    INLINE_TEST_SUFFIXES,
+    REPORT_ROLE,
+    SCHEMA_VERSION,
+)
 from .policy import measure
 from .sizing import added_line_numbers
 from .types import CommandRunner, SizeError, SizeReport, Verdict
@@ -50,7 +58,7 @@ def report_for(*, base: str, head: str, repo: str, run: CommandRunner) -> SizeRe
 
 
 def summarize(*, report: SizeReport) -> str:
-    """One line a human or a judge can act on: the counts, the caps, the call."""
+    """One line to act on: the counts, the caps, and the call."""
     return (
         f"{report.verdict}: code {report.code.lines} added lines across "
         f"{report.code.files} file(s) (target {report.code.target}, cap "
@@ -76,7 +84,8 @@ def run_cli(
         print(f"error: {error}", file=sys.stderr)
         return EXIT_ERROR
     payload: dict[str, Any] = {
-        "schema_version": "v1",
+        "schema_version": SCHEMA_VERSION,
+        "role": REPORT_ROLE,
         "base": base,
         "head": head,
         **asdict(report),

--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -97,3 +97,7 @@ GIT_DIFF_FLAGS: Final[tuple[str, ...]] = (
 # The gate could not measure — distinct from any verdict, so an unmeasured change is
 # never mistaken for a passing one.
 EXIT_ERROR: Final[int] = 3
+
+# The envelope the report is printed with, matching size-report.schema.json.
+SCHEMA_VERSION: Final[str] = "v1"
+REPORT_ROLE: Final[str] = "size-report"

--- a/scripts/pr_size/policy.py
+++ b/scripts/pr_size/policy.py
@@ -45,6 +45,7 @@ def verdict_of(*, band: Band) -> Verdict:
 
 
 def _code_band(*, files: int, lines: int, limit: int) -> Band:
+    """Name what a code count is, so the judge is told which bar to hold it to."""
     if lines <= CODE_TARGET_LINES:
         return Band.TARGET
     if lines > limit:
@@ -98,9 +99,13 @@ def _counts(*, files: tuple[ChangedFile, ...], kind: FileKind) -> dict[str, int]
 
 def _test_tally(*, files: tuple[ChangedFile, ...]) -> Tally:
     """Test lines, wherever they lived: their own files, and inside source files."""
-    inline: list[ChangedFile] = [file for file in files if file.test_lines > 0]
     counts: dict[str, int] = _counts(files=files, kind=FileKind.TEST)
+    carrying: set[str] = {
+        file.path
+        for file in files
+        if file.test_lines > 0 or (file.kind is FileKind.TEST and file.lines > 0)
+    }
     return Tally(
-        files=counts["files"] + len(inline),
-        lines=counts["lines"] + sum(file.test_lines for file in inline),
+        files=len(carrying),
+        lines=counts["lines"] + sum(file.test_lines for file in files),
     )

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -8,6 +8,7 @@ and the shell through an injected fake runner — never a real git.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Final
 
 import pytest
@@ -16,6 +17,9 @@ from pr_size.cli import report_for, run_cli
 from pr_size.policy import code_budget, measure
 from pr_size.sizing import added_line_numbers, changed_files, classify
 from pr_size.types import ChangedFile, FileKind, SizeError
+from validate_return import errors_against
+
+SCHEMAS: Final[Path] = Path(__file__).resolve().parents[2] / "schemas"
 
 
 def _diff(*, path: str, added: int, start: int = 1) -> str:
@@ -440,3 +444,20 @@ def test_a_test_attribute_inside_a_string_cannot_claim_the_code_after_it() -> No
     )
 
     assert files[0].lines == 4
+
+
+def test_the_printed_report_matches_its_schema(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The schema is the report's contract; nothing else pins the emitter to it."""
+    git: FakeGit = FakeGit(diff=_spread(files=4, lines=60))
+
+    run_cli(base="origin/main", head="HEAD", repo=".", run=git)
+
+    payload: dict[str, object] = json.loads(capsys.readouterr().out)
+    assert (
+        errors_against(
+            instance=payload, schema_path=SCHEMAS / "size-report.schema.json"
+        )
+        == []
+    )


### PR DESCRIPTION
The size report is a cross-component contract — the skills route on it, the size-judge is handed it, evidence records its `summary`, and metrics reads it to classify a run's outcome — but it was the only such JSON in the repo with no schema and no `role`. Every consumer had to duck-type it; `metrics/extractor.py` matched "role-less dict that has a `code` key", the exact fragility its own comments apologise for elsewhere.

It now carries `role: "size-report"`, and `schemas/size-report.schema.json` describes it, sitting beside the per-agent schemas and the non-agent `evidence.schema.json`. Verified: the tool's real output validates against it.

Also drops a leaked decision — `run_cli` re-derived the verdict-to-exit-code order with `list(Verdict).index(...)`, which is what `Verdict.severity` already owns.

`gate: review — code 63 lines / 2 files (band cohesion)`