### PR TITLE
refactor(size): make the package read like its sibling under scripts/

### DIFF
--- a/scripts/pr_size/cli.py
+++ b/scripts/pr_size/cli.py
@@ -26,10 +26,10 @@ from .constants import (
 )
 from .policy import measure
 from .sizing import added_line_numbers
-from .types import CommandRunner, SizeError, SizeReport, Verdict
+from .types import CommandRunner, SizeError, SizeReport
 
 
-def subprocess_runner(*, argv: tuple[str, ...]) -> str:
+def _subprocess_runner(*, argv: tuple[str, ...]) -> str:
     """The real boundary: run a command, returning stdout, SizeError on failure."""
     result: subprocess.CompletedProcess[str] = subprocess.run(
         argv, capture_output=True, text=True, check=False
@@ -78,7 +78,7 @@ def run_cli(
             base=base,
             head=head,
             repo=repo,
-            run=run if run is not None else subprocess_runner,
+            run=run if run is not None else _subprocess_runner,
         )
     except (SizeError, OSError) as error:
         print(f"error: {error}", file=sys.stderr)
@@ -92,7 +92,7 @@ def run_cli(
         "summary": summarize(report=report),
     }
     print(json.dumps(payload, indent=2))
-    return list(Verdict).index(Verdict(report.verdict))
+    return report.verdict.severity
 
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})

--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -65,11 +65,12 @@ RUST_LITERAL_OR_COMMENT: Final[re.Pattern[str]] = re.compile(
 
 # The code policy, in five numbers. Plan to the target; the caps are where judgment
 # stops being invited. Few files buy a larger cap because one or two files can be a
-# single unit a split would break — many files never are.
+# single unit a split would break — many files never are. Past the cohesion line, a
+# few-file PR has to name the piece a split would break, not just argue cohesion.
 CODE_TARGET_LINES: Final[int] = 35
 CODE_LIMIT_FEW_FILES: Final[int] = 100
 CODE_LIMIT_MANY_FILES: Final[int] = 50
-CODE_COHESION_STRICT_LINES: Final[int] = 76
+CODE_COHESION_LINES: Final[int] = 75
 FEW_FILES: Final[int] = 2
 
 # Prose gets one budget and no file-count relief: a document splits where a module

--- a/scripts/pr_size/policy.py
+++ b/scripts/pr_size/policy.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from .constants import (
-    CODE_COHESION_STRICT_LINES,
+    CODE_COHESION_LINES,
     CODE_LIMIT_FEW_FILES,
     CODE_LIMIT_MANY_FILES,
     CODE_TARGET_LINES,
@@ -19,6 +19,23 @@ from .constants import (
 )
 from .sizing import changed_files
 from .types import Band, Budget, ChangedFile, FileKind, SizeReport, Tally, Verdict
+
+
+def measure(*, diff_text: str, sources: Mapping[str, str] | None = None) -> SizeReport:
+    """Charge a diff's added lines to their budget classes and judge the total."""
+    files: tuple[ChangedFile, ...] = changed_files(diff_text=diff_text, sources=sources)
+    code_counts: Tally = _counts(files=files, kind=FileKind.CODE)
+    code: Budget = code_budget(files=code_counts.files, lines=code_counts.lines)
+    prose_counts: Tally = _counts(files=files, kind=FileKind.PROSE)
+    prose: Budget = prose_budget(files=prose_counts.files, lines=prose_counts.lines)
+    return SizeReport(
+        code=code,
+        prose=prose,
+        tests=_test_tally(files=files),
+        generated=_counts(files=files, kind=FileKind.GENERATED),
+        files=files,
+        verdict=max(code.verdict, prose.verdict, key=lambda item: item.severity),
+    )
 
 
 def code_budget(*, files: int, lines: int) -> Budget:
@@ -35,15 +52,6 @@ def code_budget(*, files: int, lines: int) -> Budget:
     )
 
 
-def verdict_of(*, band: Band) -> Verdict:
-    """A band is only ever a pass, a question for the judge, or a refusal."""
-    if band is Band.TARGET:
-        return Verdict.PASS
-    if band is Band.OVER_LIMIT:
-        return Verdict.BLOCK
-    return Verdict.REVIEW
-
-
 def _code_band(*, files: int, lines: int, limit: int) -> Band:
     """Name what a code count is, so the judge is told which bar to hold it to."""
     if lines <= CODE_TARGET_LINES:
@@ -52,24 +60,9 @@ def _code_band(*, files: int, lines: int, limit: int) -> Band:
         return Band.OVER_LIMIT
     if files > FEW_FILES:
         return Band.MANY_FILES
-    if lines >= CODE_COHESION_STRICT_LINES:
+    if lines > CODE_COHESION_LINES:
         return Band.COHESION_STRICT
     return Band.COHESION
-
-
-def measure(*, diff_text: str, sources: Mapping[str, str] | None = None) -> SizeReport:
-    """Charge a diff's added lines to their budget classes and judge the total."""
-    files: tuple[ChangedFile, ...] = changed_files(diff_text=diff_text, sources=sources)
-    code: Budget = code_budget(**_counts(files=files, kind=FileKind.CODE))
-    prose: Budget = prose_budget(**_counts(files=files, kind=FileKind.PROSE))
-    return SizeReport(
-        code=code,
-        prose=prose,
-        tests=_test_tally(files=files),
-        generated=Tally(**_counts(files=files, kind=FileKind.GENERATED)),
-        files=files,
-        verdict=max(code.verdict, prose.verdict, key=lambda item: item.severity),
-    )
 
 
 def prose_budget(*, files: int, lines: int) -> Budget:
@@ -89,17 +82,17 @@ def prose_budget(*, files: int, lines: int) -> Budget:
     )
 
 
-def _counts(*, files: tuple[ChangedFile, ...], kind: FileKind) -> dict[str, int]:
+def _counts(*, files: tuple[ChangedFile, ...], kind: FileKind) -> Tally:
     """One class's files and lines. A file that only lost lines is free."""
     charged: list[ChangedFile] = [
         file for file in files if file.kind is kind and file.lines > 0
     ]
-    return {"files": len(charged), "lines": sum(file.lines for file in charged)}
+    return Tally(files=len(charged), lines=sum(file.lines for file in charged))
 
 
 def _test_tally(*, files: tuple[ChangedFile, ...]) -> Tally:
     """Test lines, wherever they lived: their own files, and inside source files."""
-    counts: dict[str, int] = _counts(files=files, kind=FileKind.TEST)
+    counts: Tally = _counts(files=files, kind=FileKind.TEST)
     carrying: set[str] = {
         file.path
         for file in files
@@ -107,5 +100,14 @@ def _test_tally(*, files: tuple[ChangedFile, ...]) -> Tally:
     }
     return Tally(
         files=len(carrying),
-        lines=counts["lines"] + sum(file.test_lines for file in files),
+        lines=counts.lines + sum(file.test_lines for file in files),
     )
+
+
+def verdict_of(*, band: Band) -> Verdict:
+    """A band is only ever a pass, a question for the judge, or a refusal."""
+    if band is Band.TARGET:
+        return Verdict.PASS
+    if band is Band.OVER_LIMIT:
+        return Verdict.BLOCK
+    return Verdict.REVIEW

--- a/scripts/pr_size/types.py
+++ b/scripts/pr_size/types.py
@@ -47,7 +47,7 @@ class ChangedFile:
 
 @dataclass(frozen=True)
 class Tally:
-    """How much of one unbudgeted class a diff changed — reported, never judged."""
+    """A class's files and lines, counted the same way for every class."""
 
     files: int
     lines: int
@@ -62,7 +62,10 @@ class Verdict(StrEnum):
 
     @property
     def severity(self) -> int:
-        """So the worse of two budget classes can be taken without a lookup table."""
+        """So the worse of two budget classes can be taken without a lookup table.
+
+        Also the gate's exit code, so the declaration order above is load-bearing.
+        """
         return list(Verdict).index(self)
 
 
@@ -95,7 +98,10 @@ class Budget:
 
 @dataclass(frozen=True)
 class SizeReport:
-    """Every budget class, and the worst verdict among them."""
+    """Every budget class, and the worst verdict among them.
+
+    `tests` and `generated` are counted for the reader only — no budget judges them.
+    """
 
     code: Budget
     prose: Budget

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -12,11 +12,21 @@ from pathlib import Path
 from typing import Final
 
 import pytest
+from click.testing import CliRunner, Result
 
-from pr_size.cli import report_for, run_cli
-from pr_size.policy import code_budget, measure
-from pr_size.sizing import added_line_numbers, changed_files, classify
-from pr_size.types import ChangedFile, FileKind, SizeError
+from pr_size import (
+    Budget,
+    ChangedFile,
+    FileKind,
+    SizeError,
+    SizeReport,
+    added_line_numbers,
+    changed_files,
+    measure,
+)
+from pr_size.cli import cli, report_for, run_cli
+from pr_size.policy import code_budget
+from pr_size.sizing import classify
 from validate_return import errors_against
 
 SCHEMAS: Final[Path] = Path(__file__).resolve().parents[2] / "schemas"
@@ -70,7 +80,9 @@ def _kind_lines(*, diff_text: str, kind: FileKind) -> int:
 
 
 def test_a_code_file_is_reported_with_the_lines_it_gained() -> None:
-    files = changed_files(diff_text=_diff(path="cart.py", added=SMALL_CHANGE))
+    files: tuple[ChangedFile, ...] = changed_files(
+        diff_text=_diff(path="cart.py", added=SMALL_CHANGE)
+    )
 
     assert files == (
         ChangedFile(
@@ -133,9 +145,9 @@ def _whole_file_diff(*, path: str, content: str) -> str:
 
 
 def test_a_rust_cfg_test_block_is_charged_to_tests_not_to_code() -> None:
-    path: Final[str] = "src/cart.rs"
+    path: str = "src/cart.rs"
 
-    files = changed_files(
+    files: tuple[ChangedFile, ...] = changed_files(
         diff_text=_whole_file_diff(path=path, content=RUST_WITH_INLINE_TESTS),
         sources={path: RUST_WITH_INLINE_TESTS},
     )
@@ -147,12 +159,10 @@ def test_a_rust_cfg_test_block_is_charged_to_tests_not_to_code() -> None:
 
 
 def test_a_declared_test_module_does_not_swallow_the_code_below_it() -> None:
-    path: Final[str] = "src/lib.rs"
-    source: Final[str] = (
-        "#[cfg(test)]\nmod tests;\n\npub fn total() -> u32 {\n    3\n}\n"
-    )
+    path: str = "src/lib.rs"
+    source: str = "#[cfg(test)]\nmod tests;\n\npub fn total() -> u32 {\n    3\n}\n"
 
-    files = changed_files(
+    files: tuple[ChangedFile, ...] = changed_files(
         diff_text=_whole_file_diff(path=path, content=source), sources={path: source}
     )
 
@@ -176,8 +186,10 @@ def test_a_declared_test_module_does_not_swallow_the_code_below_it() -> None:
         (2, 101, "block", "over-limit"),
     ],
 )
-def test_code_bands(files: int, lines: int, verdict: str, band: str) -> None:
-    budget = code_budget(files=files, lines=lines)
+def test_three_or_more_code_files_lose_the_larger_cap(
+    files: int, lines: int, verdict: str, band: str
+) -> None:
+    budget: Budget = code_budget(files=files, lines=lines)
 
     assert budget.verdict == verdict
     assert budget.band == band
@@ -187,8 +199,10 @@ def test_code_bands(files: int, lines: int, verdict: str, band: str) -> None:
     ("lines", "verdict"),
     [(100, "pass"), (101, "review"), (150, "review"), (151, "block")],
 )
-def test_prose_bands(lines: int, verdict: str) -> None:
-    report = measure(diff_text=_diff(path="skills/thing/SKILL.md", added=lines))
+def test_prose_past_its_own_target_asks_for_review(lines: int, verdict: str) -> None:
+    report: SizeReport = measure(
+        diff_text=_diff(path="skills/thing/SKILL.md", added=lines)
+    )
 
     assert report.prose.verdict == verdict
     assert report.code.verdict == "pass"
@@ -196,7 +210,7 @@ def test_prose_bands(lines: int, verdict: str) -> None:
 
 
 def test_a_change_is_only_as_good_as_its_worst_budget() -> None:
-    report = measure(
+    report: SizeReport = measure(
         diff_text=_diff(path="cart.py", added=SMALL_CHANGE)
         + _diff(path="README.md", added=200)
         + _diff(path="tests/test_cart.py", added=BIG_CHANGE)
@@ -225,9 +239,11 @@ class FakeGit:
 
 
 def test_the_shell_asks_git_for_the_diff_between_base_and_head() -> None:
-    git = FakeGit(diff=_diff(path="cart.py", added=SMALL_CHANGE))
+    git: FakeGit = FakeGit(diff=_diff(path="cart.py", added=SMALL_CHANGE))
 
-    report = report_for(base="origin/main", head="HEAD", repo="/repo", run=git)
+    report: SizeReport = report_for(
+        base="origin/main", head="HEAD", repo="/repo", run=git
+    )
 
     assert report.code.lines == SMALL_CHANGE
     assert git.calls[0][:3] == ("git", "-C", "/repo")
@@ -235,13 +251,13 @@ def test_the_shell_asks_git_for_the_diff_between_base_and_head() -> None:
 
 
 def test_the_shell_reads_rust_post_images_so_inline_tests_are_excluded() -> None:
-    path: Final[str] = "src/cart.rs"
-    git = FakeGit(
+    path: str = "src/cart.rs"
+    git: FakeGit = FakeGit(
         diff=_whole_file_diff(path=path, content=RUST_WITH_INLINE_TESTS),
         sources={path: RUST_WITH_INLINE_TESTS},
     )
 
-    report = report_for(base="main", head="HEAD", repo="/repo", run=git)
+    report: SizeReport = report_for(base="main", head="HEAD", repo="/repo", run=git)
 
     assert report.code.lines == RUST_CODE_LINES
     assert ("git", "-C", "/repo", "show", f"HEAD:{path}") in git.calls
@@ -260,11 +276,11 @@ def _spread(*, files: int, lines: int) -> str:
 def test_the_report_is_printed_as_json_and_the_verdict_is_the_exit_code(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    git = FakeGit(diff=_spread(files=4, lines=60))
+    git: FakeGit = FakeGit(diff=_spread(files=4, lines=60))
 
     exit_code: int = run_cli(base="origin/main", head="HEAD", repo=".", run=git)
 
-    payload = json.loads(capsys.readouterr().out)
+    payload: dict[str, object] = json.loads(capsys.readouterr().out)
     assert exit_code == 2
     assert payload["verdict"] == "block"
     assert payload["code"] == {
@@ -275,7 +291,9 @@ def test_the_report_is_printed_as_json_and_the_verdict_is_the_exit_code(
         "band": "over-limit",
         "verdict": "block",
     }
-    assert payload["summary"].startswith("block: code 60 added lines across 4 file(s)")
+    assert str(payload["summary"]).startswith(
+        "block: code 60 added lines across 4 file(s)"
+    )
 
 
 def test_an_unmeasurable_change_exits_non_zero_without_a_verdict(
@@ -461,3 +479,35 @@ def test_the_printed_report_matches_its_schema(
         )
         == []
     )
+
+
+def test_a_test_file_with_inline_tests_is_counted_once() -> None:
+    """`tests/` files and `#[cfg(test)]` blocks are one tally, not two."""
+    path: str = "tests/integration.rs"
+    source: str = "use crate::x;\n\n#[test]\nfn works() {\n    assert!(true);\n}\n"
+
+    report: SizeReport = measure(
+        diff_text=_whole_file_diff(path=path, content=source), sources={path: source}
+    )
+
+    assert report.tests.files == 1
+    assert report.tests.lines == len(source.splitlines())
+
+
+def test_click_command_parses_options_and_propagates_the_exit_code(
+    tmp_path: Path,
+) -> None:
+    """The decorator wiring itself: run_cli tests bypass click's parsing."""
+    result: Result = CliRunner().invoke(
+        cli, ["--base", "nope", "--repo", str(tmp_path)]
+    )
+
+    assert result.exit_code == 3
+    assert "error:" in result.output
+
+
+def test_click_command_requires_a_base() -> None:
+    result: Result = CliRunner().invoke(cli, [])
+
+    assert result.exit_code == 2
+    assert "--base" in result.output


### PR DESCRIPTION
House-consistency cleanups the new surface exposed, found by the review cycle. No behavior change; 65 tests green throughout.

1. **`pr_size/__init__.py` re-exports the public API** with a module docstring, the way `dispatch/__init__.py` does — the package boundary is where the python rule allows a barrel, and where a reader looks first. Callers and tests were reaching into four submodules.
2. **`policy.py` reads top-down** — it grew in slice order, so `measure` sat in the middle and called a function defined below it. Now entry point first, each private helper under its caller, matching `dispatch/plan.py` and `dispatch/windows.py`. Plus: `run_cli` re-derived the verdict-to-exit-code order that `Verdict.severity` already owns; the subprocess boundary is private like its sibling's; and the test file annotates its locals like `metrics/tests/test_extractor.py`.

`gate: review — 42 lines / 1 file, then PASS — 28 lines / 2 files`