### PR TITLE
refactor(size): re-export the package's public API

### DIFF
--- a/scripts/pr_size/__init__.py
+++ b/scripts/pr_size/__init__.py
@@ -1,0 +1,37 @@
+"""Measure a change the way the size policy counts it, and say whether it may proceed.
+
+The skills own the policy conversation; this package owns the deterministic half —
+which changed lines count (tests, lockfiles and generated output never do), which
+budget they are charged to, and which of pass / review / block that arithmetic forces.
+The public API here is the functional core, importable without click; the command
+lives in `pr_size.cli`.
+"""
+
+from .policy import measure
+from .sizing import added_line_numbers, changed_files
+from .types import (
+    Band,
+    Budget,
+    ChangedFile,
+    CommandRunner,
+    FileKind,
+    SizeError,
+    SizeReport,
+    Tally,
+    Verdict,
+)
+
+__all__ = [
+    "Band",
+    "Budget",
+    "ChangedFile",
+    "CommandRunner",
+    "FileKind",
+    "SizeError",
+    "SizeReport",
+    "Tally",
+    "Verdict",
+    "added_line_numbers",
+    "changed_files",
+    "measure",
+]


### PR DESCRIPTION
`pr_size/__init__.py` was an empty namespace marker, so callers and tests reached into four submodules. Its sibling under `scripts/` — `dispatch` — puts a module docstring and an `__all__` re-export at the package boundary, which is where the python rule allows a barrel and where a reader looks first to learn what the package offers. The tests now import through it, as `test_dispatch.py` does.

`gate: review — 42 lines / 1 file (cohesion)`