### PR TITLE
feat(skills): pr-explain requires screenshot proof for UI changes, editor-colored diffs

### DIFF
--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -21,8 +21,9 @@ Three rules run through the whole page:
   roll-up line. A reader who finishes the walkthrough has seen the change — never two
   excerpts from a hundred-line diff.
 - **Nothing unrun.** Output on the page is output you captured. Proof is something that
-  actually executed. If no proof can be written for a behavior change, the page says so —
-  that is a finding about the PR, not a gap to pad over.
+  actually executed. A change a person looks at is proven by a picture of it running —
+  never by text output about it. If no proof can be written for a behavior change, the
+  page says so — that is a finding about the PR, not a gap to pad over.
 
 ## Arguments
 
@@ -124,6 +125,10 @@ may not be the one you were asked about. `--json files` gives every touched path
    (`git ls-tree -d --name-only HEAD`), byte-sorted, equal-width cells; light the ones that
    contain a touched file. Same strip, same order, every PR — it orients the reader in the
    whole repo without printing it.
+8. **Spot the visual surface.** Does the diff touch anything a person looks at — an HTML
+   page or template, frontend components, CSS, a TUI or formatted terminal output, a chart,
+   an email body? If yes, Chapter 4 owes a screenshot of it running on this branch; plan
+   now how Phase 3 will launch and capture it.
 
 ## Phase 3 — Run (capture real output)
 
@@ -133,6 +138,13 @@ head; capture output verbatim for Chapters 4 and 5.
 - **Rerun the PR's tests** with the narrowest selector that covers the diff's test files
   (`pytest tests/catalog/ -q`, `cargo test -p <crate>`, `vitest run <dir>`). A fresh green
   run is first-class proof: chip it as `run here — <n> passed`.
+- **Screenshot every visual change.** Phase 2 spotted a visual surface → launch it on this
+  branch (start the server, open the page — the `run` skill knows the launch patterns) and
+  capture what a person sees: a headless-browser screenshot for a web page, the rendered
+  terminal for a TUI. Seed enough real data first that the surface shows its job, not an
+  empty frame. Status codes, byte counts, and greps prove the server answered — only a
+  screenshot proves the page renders. Genuinely cannot launch it here → that is a proof
+  gap Chapter 4 must declare, never a step to skip.
 - **Run every Chapter 5 command yourself first.** Only ship a command you ran; paste its
   real output next to it. A command the reader needs but you cannot run here (missing
   credentials, no device) ships marked `not run here — needs <thing>`, never with imagined
@@ -214,6 +226,13 @@ this change works. A PR whose proof cannot be written had nothing to prove — t
 finding about the PR, not this page."* Carry a ⚠ into the teaser and the report. Never
 invent a chip to avoid the verdict.
 
+**A visual change needs visual proof.** Phase 2 spotted a visual surface → at least one
+Phase 3 screenshot of it running embeds here (`img.evidence`, `data:` URI), each with a
+one-line `.evidence-cap` caption naming what the reader is looking at. Chips about the
+surface — curl status, byte counts, grep hits — do not substitute. No screenshot → the
+chapter says which surface shipped unseen and why, and a ⚠ carries into the teaser and
+the report exactly like the no-proof verdict.
+
 ### Chapter 5 — See for yourself
 
 One or two command blocks the reader can paste to confirm *this* change, each followed by
@@ -227,7 +246,8 @@ The draft leaves Phase 4 only after both gates. Run them in order:
 - **Mechanical gate (always).**
   - *Coverage*: count hunks (`gh pr diff <N> | grep -c '^@@'`) and check every one is a
     walkthrough entry or inside a named roll-up line. Grep each test name from the inventory
-    against the draft; every one appears.
+    against the draft; every one appears. Phase 2 spotted a visual surface → grep the page
+    for `img.evidence`; zero hits fails the gate unless Chapter 4 carries the declared ⚠.
   - *Prose*: `wc -w` each budgeted unit and cut anything over. `grep` the draft for every
     banned word above and rewrite each hit. Then, **if `vale` is on PATH**, write the draft
     to a scratch `.md` and run `vale --config ~/.claude/at/templates/pr-explain.vale.ini
@@ -262,9 +282,13 @@ The draft leaves Phase 4 only after both gates. Run them in order:
   `.note` classes exactly as the SLOT comment shows; indent rows with `l1`/`l2`/`l3`. A callout
   is a `.note` row directly under its file.
 - **The walkthrough**: one `.hunk-head` + `.diff` + `.diff-note` group per decision hunk;
-  roll-ups are a `.diff-note` alone.
+  roll-ups are a `.diff-note` alone. Diff lines read like an editor: every token wears its
+  syntax color (`tok-kw`, `tok-fn`, `tok-str`, `tok-num`, `tok-type`, `tok-com`), added and
+  deleted lines open with a `.sign` `+`/`−`, and the red/green lives in the line background
+  and sign — never in the code text.
 - **The test list**: `.testlist` with a `.tfile` row per file and a `.trow` per test.
-- Screenshots and e2e output embed as `data:` URIs via `img.evidence`.
+- Screenshots and e2e output embed as `data:` URIs via `img.evidence`, each followed by
+  its one-line `.evidence-cap` caption.
 
 ## Phase 6 — Publish
 
@@ -308,7 +332,8 @@ link line.
 ## Report
 
 End with: the artifact URL; hunks shown / rolled up / total; tests enumerated; commands run
-vs marked not-run; the proof verdict (sources used, or the ⚠ no-proof flag); chapters
+vs marked not-run; the proof verdict (sources used, or the ⚠ no-proof flag); screenshots
+embedded, or the visual surface that shipped unseen and why (⚠); chapters
 emitted vs dropped (with the tiny-PR shrink reason if used); the PR whose teaser you
 updated; the mechanical gate result (coverage greps, Vale alerts fixed, or "vale
 unavailable — wc + grep only"); and the critic score — naming any dimension left under the

--- a/templates/pr-explain-page.html
+++ b/templates/pr-explain-page.html
@@ -11,6 +11,7 @@
     --accent: #14695A; --accent-soft: #E3EEEB; --line: #E1E5E0; --line-strong: #C9CFC9;
     --red: #AE362E; --red-soft: #F7E9E7; --green: #2C7A44; --green-soft: #E6F1E8;
     --amber: #8F6400; --amber-soft: #F4ECD6; --code-bg: #EFF1ED;
+    --syn-kw: #A626A4; --syn-fn: #4078F2; --syn-str: #50A14F; --syn-num: #986801; --syn-type: #C18401;
     --serif: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
     --mono: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace;
     --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
@@ -21,6 +22,7 @@
       --accent: #45B29B; --accent-soft: #1E2E2A; --line: #272D29; --line-strong: #39413C;
       --red: #E06A60; --red-soft: #33211F; --green: #5CBB77; --green-soft: #1E2E22;
       --amber: #D9A853; --amber-soft: #322A1B; --code-bg: #202622;
+      --syn-kw: #C678DD; --syn-fn: #61AFEF; --syn-str: #98C379; --syn-num: #D19A66; --syn-type: #E5C07B;
     }
   }
   :root[data-theme="light"] {
@@ -28,12 +30,14 @@
     --accent: #14695A; --accent-soft: #E3EEEB; --line: #E1E5E0; --line-strong: #C9CFC9;
     --red: #AE362E; --red-soft: #F7E9E7; --green: #2C7A44; --green-soft: #E6F1E8;
     --amber: #8F6400; --amber-soft: #F4ECD6; --code-bg: #EFF1ED;
+    --syn-kw: #A626A4; --syn-fn: #4078F2; --syn-str: #50A14F; --syn-num: #986801; --syn-type: #C18401;
   }
   :root[data-theme="dark"] {
     --paper: #141816; --card: #1B201D; --ink: #E7EBE8; --ink-2: #A6AFA9; --ink-3: #6F7873;
     --accent: #45B29B; --accent-soft: #1E2E2A; --line: #272D29; --line-strong: #39413C;
     --red: #E06A60; --red-soft: #33211F; --green: #5CBB77; --green-soft: #1E2E22;
     --amber: #D9A853; --amber-soft: #322A1B; --code-bg: #202622;
+    --syn-kw: #C678DD; --syn-fn: #61AFEF; --syn-str: #98C379; --syn-num: #D19A66; --syn-type: #E5C07B;
   }
   * { box-sizing: border-box; }
   body { margin: 0; background: var(--paper); color: var(--ink); font-family: var(--serif);
@@ -88,12 +92,23 @@
     margin: 22px 0 0; }
   .hunk-head .fname { font-weight: 700; color: var(--ink); }
   .hunk-head .scope { color: var(--accent); }
-  .diff { font-family: var(--mono); font-size: 12.5px; line-height: 1.55;
+  .diff { font-family: var(--mono); font-size: 12.5px; line-height: 1.55; color: var(--ink);
     background: var(--code-bg); border-radius: 6px; padding: 10px 12px; margin: 8px 0 0;
     overflow-x: auto; white-space: pre; }
-  .diff .ctx { color: var(--ink-3); }
-  .diff .del { color: var(--red); background: var(--red-soft); display: inline-block; width: 100%; }
-  .diff .add { color: var(--green); background: var(--green-soft); display: inline-block; width: 100%; }
+  /* Editor-style diff: the change lives in the line background and the gutter sign;
+     the code itself keeps its syntax colors (tok-*) on every line. */
+  .diff .ctx { opacity: 0.72; }
+  .diff .del { background: var(--red-soft); display: inline-block; width: 100%; }
+  .diff .add { background: var(--green-soft); display: inline-block; width: 100%; }
+  .diff .sign { display: inline-block; width: 1.2em; font-weight: 700; }
+  .diff .del .sign { color: var(--red); }
+  .diff .add .sign { color: var(--green); }
+  .diff .tok-kw { color: var(--syn-kw); }
+  .diff .tok-fn { color: var(--syn-fn); }
+  .diff .tok-str { color: var(--syn-str); }
+  .diff .tok-num { color: var(--syn-num); }
+  .diff .tok-type { color: var(--syn-type); }
+  .diff .tok-com { color: var(--ink-3); font-style: italic; }
   .diff-note { font-size: 15px; color: var(--ink-2); margin: 6px 0 0; }
 
   /* Chapter 3 — the tests: every test enumerated, then RED → GREEN witnesses. */
@@ -118,6 +133,7 @@
   .no-proof .tag { font-family: var(--mono); font-size: 10.5px; font-weight: 700;
     color: var(--red); letter-spacing: 0.08em; display: block; margin-bottom: 4px; }
   img.evidence { max-width: 100%; border: 1px solid var(--line-strong); border-radius: 6px; margin-top: 12px; }
+  .evidence-cap { font-family: var(--mono); font-size: 11.5px; color: var(--ink-3); margin: 4px 0 0; }
 
   /* Chapter 5 — see for yourself: commands the reader can run, with output we captured. */
   .cmd { font-family: var(--mono); font-size: 12.5px; line-height: 1.65; background: var(--code-bg);
@@ -158,11 +174,14 @@
       -->
     </div>
     <!-- SLOT: the walkthrough — EVERY decision hunk in the diff, in call-path order.
-         One group per hunk:
+         One group per hunk. Syntax-highlight every line like an editor — wrap tokens in
+         tok-kw (keyword), tok-fn (function/call), tok-str (string), tok-num (number),
+         tok-type (type), tok-com (comment). Added/deleted lines open with a .sign +/−;
+         the red/green is the line background and sign, NEVER the code text:
       <div class="hunk-head"><span class="fname">api.py</span> · <span class="scope">PUT /api/exercises/{id}/rating</span></div>
-      <div class="diff"><span class="ctx">  context</span>
-      <span class="del">- removed</span>
-      <span class="add">+ added</span></div>
+      <div class="diff"><span class="ctx">  <span class="tok-kw">def</span> <span class="tok-fn">rate</span>(exercise_id: <span class="tok-type">int</span>):</span>
+      <span class="del"><span class="sign">−</span>    <span class="tok-kw">raise</span> <span class="tok-fn">HTTPError</span>(<span class="tok-num">405</span>)</span>
+      <span class="add"><span class="sign">+</span>    rating = <span class="tok-fn">parse_rating</span>(request, <span class="tok-str">"rating"</span>)  <span class="tok-com"># 1–5 or null</span></span></div>
       <p class="diff-note">What we do here, why it is needed, where it sits in the flow. ≤ 40 words.</p>
          Close each file with its mechanical roll-up as a bare note, so every hunk is shown or named:
       <p class="diff-note">Plus the import and route registration in <code>api.py</code>.</p>
@@ -187,7 +206,11 @@
     <!-- SLOT: 40-70 words + evidence — only what actually ran, strongest first:
          fresh runs from this session, then evidence-file gates, then CI. Chips carry real numbers:
          <div class="gate-row"><span class="gate-chip">run here — pytest 161 passed</span><span class="gate-chip">mypy strict</span></div>
-         Runtime evidence (screenshot, e2e run) as <img class="evidence" src="data:…">.
+         A visual surface in the diff (page, TUI, chart) REQUIRES a screenshot of it running,
+         embedded as <img class="evidence" src="data:…"> with a
+         <p class="evidence-cap">one-line caption of what the reader sees</p> — text output
+         about the surface never substitutes; no screenshot → declare the gap + ⚠.
+         Other runtime evidence (e2e output) embeds the same way.
          CI check results as chips (class "fail" for red ones);
          PR-body claims appear only attributed in prose ("PR body reports: …"), never as chips.
          A behavior PR with NOTHING run → this verdict, verbatim, instead (never drop, never pad):


### PR DESCRIPTION
## What & why

Two gaps surfaced by the PR #41 (a1f/fx) explainer:

1. **A 263-line web page shipped with only curl output as proof.** The skill knew *how* to embed screenshots (`img.evidence`) but no phase ever *required* one, so the proof gate passed on status codes and byte counts. Now: Phase 2 spots the visual surface, Phase 3 must launch it and capture what a person sees (seeded with real data), Chapter 4 treats a missing screenshot exactly like the no-proof verdict (⚠ into teaser + report), and the mechanical gate greps the page for `img.evidence`.

2. **Diff snippets were flat red/green lines.** They now read like an editor: per-token syntax colors via hand-written `tok-*` spans (One Light / One Dark palettes in all four theme blocks — CSP blocks external highlighters), with add/delete carried by the line background plus a `+`/`−` gutter sign, never by coloring the code text.

Also adds the `.evidence-cap` caption class so every screenshot says what the reader is looking at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ddksu1rVZB2mupjKLaEMs