### PR TITLE
docs(rules): ban dict-as-record in python, add phased-function split trigger

### DIFF
--- a/rules/design-principles.md
+++ b/rules/design-principles.md
@@ -34,6 +34,13 @@ module is its interface (what every caller must learn); the benefit is its imple
   nothing but together force the reader to chase the flow across files.
 - A method/function should have a clear, single abstraction. If you cannot state what it
   does in one short phrase without "and", it is doing too much.
+- The phrase test has a blind spot: a body that runs in **phases** — one block or loop per
+  sibling entity or step, separated by blank lines or section comments — still summarizes to
+  one phrase ("seed the catalog") while stacking several abstractions in one frame. Each phase
+  that has its own coherent job is a function waiting for its name: extract it, and let the
+  parent read as the list of phases. Treat any function past roughly a screen (~50 lines) as
+  this smell until proven otherwise. (This is not license for classitis — extract phases with
+  real jobs, not one-line fragments.)
 
 ```python
 # SHALLOW — interface as complex as the body; caller learns 3 knobs to save nothing
@@ -251,7 +258,10 @@ design, and sometimes a third that beats both.
 - **Temporal decomposition** — modules mirror execution order, not responsibilities.
 - **Overexposure** — using the common case forces the caller to learn rare options.
 - **Pass-through method / variable** — added layer carries no new abstraction.
-- **Repetition** — the same snippet appears more than twice.
+- **Repetition** — the same snippet appears more than twice — or a multi-line shape appears
+  even twice (two parallel per-entity loops already establish a pattern worth extracting).
+- **Phased function** — a long body in blank-line- or comment-separated phases; each phase
+  with a coherent job is an unextracted function.
 - **Special-general mixture** — special-purpose code embedded in a general-purpose mechanism.
 - **Multi-concern module** — one module owns two jobs that don't share information; the name needs an "and".
 - **Flag parameter** — a boolean argument selects between two behaviors; split the function instead.

--- a/rules/python.md
+++ b/rules/python.md
@@ -94,6 +94,13 @@ Prefer functions over classes unless state is needed. If a method doesn't use `s
 ## Data Modeling
 
 - Use `dataclasses` or Pydantic models for structured data
+- **Never use a dict as an ad-hoc record.** A `dict[str, object]` / `dict[str, Any]` whose
+  keys are a fixed field set known when the code is written is a dataclass wearing a disguise:
+  the annotation satisfies mypy while erasing every field type, and a typo'd key becomes a
+  runtime bug. This includes *local* value bags built just to feed `**kwargs` or an ORM
+  `values=` — define a frozen dataclass and convert with `dataclasses.asdict()` at the one
+  boundary that genuinely needs a mapping. Dicts are for homogeneous collections whose keys
+  arrive at runtime, never for records
 - Prefer frozen dataclasses (`frozen=True`) when mutability is not needed
 - Model closed sets of values with `enum.Enum` (`StrEnum`/`IntEnum` when serialized). This
   intentionally diverges from `typescript.md`'s enum ban — Python enums carry no runtime-emit cost


### PR DESCRIPTION
## Why

Owner review on FitnessBackend#125 ([review 4792537459](https://github.com/a1f/FitnessBackend/pull/125#pullrequestreview-4792537459)) caught two things the coder + reviewer should have, and the miss traces to genuine gaps in the rules, not agent sloppiness:

1. **`dict[str, object]` value bags** ("why is that dict? that should be dataclass", ×2). `python.md`'s Data Modeling said *use dataclasses for structured data* but never forbade the exact idiom produced: a fully annotated local `dict[str, object]` built to feed `Model(**values)` / `storage.update(values=...)`. That annotation satisfies `mypy --strict` — `object` erases every field type — so the mechanical gate is structurally blind to it, and the rule text gave the LLM reviewer nothing to pattern-match.
2. **95-line `seed_catalog`** ("that function is way too big, we need to split that"). `design-principles.md`'s only split trigger was the one-phrase test, which the function passes ("seed the catalog"). Its three per-entity phases also evaded the Repetition red flag, which required a snippet to appear *more than twice* — the upsert shape appears exactly twice.

## What

- `rules/python.md` (Data Modeling): explicit ban on dicts as ad-hoc records — a fixed, known-at-write-time key set means a frozen dataclass, converted with `dataclasses.asdict()` at the one boundary that genuinely needs a mapping; names the `**kwargs` / ORM `values=` case specifically.
- `rules/design-principles.md` (Deep modules): new phased-function trigger — a body running in blank-line/comment-separated per-entity phases stacks several abstractions even when the phrase test passes; ~50 lines is the presumption threshold; explicit anti-classitis caveat.
- `rules/design-principles.md` (Red flags): Repetition now counts a multi-line shape appearing twice; new **Phased function** red flag.

Note: neither rule is mechanically gateable today — ruff has no dict-as-record rule, and `C901`/`PLR0915` at any sane threshold don't trip on this function (~23 statements spread over 95 lines). These stay reviewer-enforced conventions, now with the exact idioms spelled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012b7n8y4mciRhJuLJicoHWH