### PR TITLE
feat(skills): add prompt-review — binary-bar prompt audit with fix-by-default

### DIFF
--- a/installer/catalog.toml
+++ b/installer/catalog.toml
@@ -68,6 +68,10 @@ name = "pr-make-till-merge"
 
 [[units]]
 kind = "skill"
+name = "prompt-review"
+
+[[units]]
+kind = "skill"
 name = "shipped"
 
 [[units]]

--- a/skills/prompt-review/SKILL.md
+++ b/skills/prompt-review/SKILL.md
@@ -44,8 +44,8 @@ ls skills/*/SKILL.md agents/*.md rules/*.md templates/CLAUDE.md.template
 ```
 
 No match on the default scope → emit the stamp with zeros (`prompt-review: PASS`, `files: 0
-reviewed, 0 fixed`, `delta: 0 → 0 words`) in chat, write it to the PR body when a PR exists
-(Phase 4), and stop. A clean branch is not a failure, but it still leaves a greppable stamp.
+reviewed, 0 fixed`, `delta: 0 → 0 words`) in chat, write it to the PR body when a PR exists and
+`--report-only` is not set (Phase 4), and stop.
 
 Record `wc -lw` per file before reading it; Phase 4 reports the delta against it.
 
@@ -106,8 +106,8 @@ that total:
 |------|-------|-------|
 | `rules/python.md` | 214 → 201 | 1806 → 1699 |
 | `agents/critic.md` | 88 → 88 | 742 → 742 |
-| `skills/explain/SKILL.md` | 96 → 91 | 803 → 771 |
-| **total** | 398 → 380 | 3351 → 3212 |
+| `skills/explain/SKILL.md` | 96 → 96 | 803 → 803 |
+| **total** | 398 → 385 | 3351 → 3244 |
 
 Last, the verdict stamp, exactly this block:
 
@@ -131,19 +131,23 @@ markers are already there and appending it when they are not:
 <!-- prompt-review:end -->
 ```
 
-Round-trip the body through a scratch file in a session temp location (`"$TMPDIR"`), never a
-path inside the repo tree where it could be committed by accident:
+Round-trip the body through a `mktemp` file, never a path inside the repo tree where it could be
+committed by accident:
 
 ```bash
-gh pr view <N> --json body --jq .body > "$TMPDIR"/pr-body.md
-# splice the stamp between the markers in that file; append the marker block when absent
-gh pr edit <N> --body-file "$TMPDIR"/pr-body.md
+BODY=$(mktemp)
+gh pr view <N> --json body --jq .body | tr -d '\r' > "$BODY"
+[ -s "$BODY" ] || { echo "abort: empty PR body read" >&2; exit 1; }
+# splice the stamp between the begin/end markers in "$BODY"; append the marker block when absent
+gh pr edit <N> --body-file "$BODY"
+rm -f "$BODY"
 ```
 
-`--jq .body` is what keeps step 1 raw markdown — `--json body` alone writes `{"body":"…"}` and
-would overwrite the author's whole body with escaped JSON. Never touch prose outside the
-markers. No PR, or `--report-only` → print the stamp in chat for the author to paste, and edit
-nothing.
+`--jq .body` keeps the read raw markdown — bare `--json body` writes `{"body":"…"}` and would
+overwrite the author's whole body with escaped JSON. The guard is there because `>` truncates
+before `gh pr view` runs: a failed read must abort, not write an empty body back. Never touch
+prose outside the markers. No PR, or `--report-only` → print the stamp in chat for the author to
+paste, and edit nothing.
 
 ## Eval tasks
 

--- a/skills/prompt-review/SKILL.md
+++ b/skills/prompt-review/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: prompt-review
+description: Use when the user wants this repo's prompt files — skills, agents, rules, the CLAUDE.md template — reviewed for token cost, clarity, and house shape, with the failures fixed in place, or invokes /prompt-review.
+argument-hint: "[--all] [--report-only]"
+---
+
+# Prompt Review
+
+Prompts are the product here, and they get worse by growing — a model reading a long file
+skips instructions in the middle of it. This reviews prompt files against eight criteria and,
+by default, fixes what fails.
+
+**The bar is binary.** Each criterion passes or fails — no scores, no "mostly". Every failure
+names the file and the lines, so the author can check it and the fix can be small. A file with
+nothing wrong is reported clean, never padded with suggestions.
+
+**Fixes change wording, never behavior** — what a prompt does is off limits; how it says it is
+the whole job.
+
+```
+/prompt-review [--all] [--report-only]
+
+  1. Scope     prompt files changed vs origin/main   (--all = every prompt file)
+  2. Review    eight binary criteria per file
+  3. Fix       smallest diff per failure             (--report-only stops here)
+  4. Report    findings table, counts, verdict stamp
+```
+
+## Phase 1 — Scope
+
+Prompt files are `skills/*/SKILL.md`, `agents/*.md`, `rules/*.md`, and
+`templates/CLAUDE.md.template`. Nothing else is in scope.
+
+```bash
+git fetch origin main
+git diff --name-only origin/main...HEAD
+```
+
+Keep the paths matching those four patterns — that is the default scope. `--all` replaces it
+with every prompt file in the repo:
+
+```bash
+ls skills/*/SKILL.md agents/*.md rules/*.md templates/CLAUDE.md.template
+```
+
+No match on the default scope → report that the branch changes no prompt file and stop. That is
+a clean run, not a failure.
+
+Record `wc -lw` per file before reading it; Phase 4 reports the delta against it.
+
+## Phase 2 — Review
+
+Read each file whole before judging it — criteria 1, 4, and 6 are claims about the file as a
+whole, not about a paragraph in isolation. Then take all eight in order:
+
+| # | Criterion | Fails when |
+|---|-----------|------------|
+| 1 | **Token cost** | a paragraph teaches Claude something it already knows, restates a line above it, or hedges. Ask of every paragraph: does Claude already know this, and does it justify its token cost? |
+| 2 | **Description** | the frontmatter `description` is vague, states what without when (or when without what), drops the key terms a match depends on, or is not third person. A skill's starts "Use when" |
+| 3 | **One default** | a menu of options stands where one default plus an escape hatch would do, or a flag hides two jobs behind one name |
+| 4 | **Consistent terms** | one concept goes by two names, or one word means two things in the same file |
+| 5 | **Concrete over vague** | output shape is described but never shown; a fragile operation is named but its exact command is not given; a fact that rots (a version, a count, a date) is stated as fixed |
+| 6 | **Structure** | a reference points at a file that points at another file (deeper than one level); the file runs over 500 lines; a skill is missing the house anatomy — stance paragraph, numbered phases, a report section, and a common-mistakes table where it earns its place |
+| 7 | **House paths** | runtime support (schemas, gates, templates, scripts) is referenced as a copy bundled in the skill directory instead of its staged `~/.claude/at/…` path |
+| 8 | **Rules pressed hardest** | `rules/*.md` only — criterion 1 at double strength. A rule file loads every session and dilutes every other rule, so a rule the model already follows fails here and wants deleting |
+
+A failure carries the line range and enough of the text to find it: `rules/python.md:112-119 —
+criterion 1: restates the type-hint rule from lines 40-51`. A criterion with no failing lines
+passes.
+
+## Phase 3 — Fix
+
+The default. `--report-only` skips this phase entirely — nothing on disk changes.
+
+Work one file at a time and make the smallest diff that clears the failed criterion. Reach in
+this order: **cut** the lines, **tighten** what survives, **restructure** the section. Cutting
+is the fix that works most often; a rewrite that keeps the line count has usually missed the
+finding.
+
+Never change what a prompt does. A fix that would drop a step, loosen a gate, rename a flag, or
+change what the prompt returns is a behavior change: report it with the change it implies and
+leave the file alone. Deleting a rule under criterion 8 counts as wording only when the model's
+default behavior already matches that rule — otherwise report it and let the author decide.
+
+Re-check each fixed file against all eight criteria before moving on. A cut can strand a term
+(4) or break the anatomy (6).
+
+## Phase 4 — Report and stamp
+
+Two tables in chat. The findings table, one row per failing criterion per file — a file that
+passes all eight collapses to a single row reading `all pass`:
+
+| File | Criterion | Lines | Verdict | Action |
+|------|-----------|-------|---------|--------|
+| `rules/python.md` | 1 token cost | 112-119 | fail | fixed |
+| `agents/critic.md` | 3 one default | 44-61 | fail | reported — dropping the mode flag changes behavior |
+| `skills/explain/SKILL.md` | — | — | all pass | — |
+
+Then the counts table — one row per file with lines and words before → after, and a total row
+carrying the word delta.
+
+Last, the verdict stamp, exactly this block:
+
+```
+prompt-review: PASS | FAIL
+files: <n> reviewed, <n> fixed
+delta: <before> → <after> words
+```
+
+PASS only when every criterion passes on every file in scope after the fixes; a failure
+reported rather than fixed keeps it FAIL. Future CI greps for this block, so keep the three
+lines and their order.
+
+Find the branch's PR with `gh pr list --head "$(git branch --show-current)" --json number,url`.
+A PR exists → keep exactly one marker block in its body, replacing the block in place when the
+markers are already there and appending it when they are not:
+
+```markdown
+<!-- prompt-review:begin -->
+<the stamp block>
+<!-- prompt-review:end -->
+```
+
+Re-read the body first (`gh pr view <N> --json body`) and write it back with `gh pr edit <N>
+--body-file <file>`; never touch prose outside the markers. No PR, or `--report-only` → print
+the stamp in chat for the author to paste, and edit nothing.
+
+## Eval tasks
+
+Every failing row of the findings table is a candidate golden task for a future eval of this
+skill: the same file reviewed again must produce the same finding. The shape:
+
+```json
+{"query": "review rules/python.md", "files": ["rules/python.md"], "expected_behavior": ["criterion 1 fails at 112-119 — restates the type-hint rule from 40-51"]}
+```
+
+`query` is the run that found it, `files` the paths it read, `expected_behavior` one line per
+finding a correct run must produce. v1 defines the shape and writes nothing automatically — hand
+a task back only when the user asks for one.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Scoring a file 8/10 | One binary verdict per criterion, each failure naming lines |
+| Rewriting a paragraph that passed | Only a failure earns a diff |
+| Cutting a step to shorten a file | Wording only — report the behavior change instead |
+| Reviewing the whole repo on a two-file branch | Default scope is the branch's changed prompt files; `--all` is opt-in |
+| Editing the PR body under `--report-only` | Print the stamp; change nothing |

--- a/skills/prompt-review/SKILL.md
+++ b/skills/prompt-review/SKILL.md
@@ -1,263 +1,118 @@
 ---
 name: prompt-review
-description: Use when the user wants this repo's prompt files — skills, agents, rules, the CLAUDE.md template — reviewed for token cost, clarity, and house shape, with the failures fixed in place, or invokes /prompt-review.
+description: Use when the user wants this repo's prompt files — skills, agents, rules, the CLAUDE.md template — reviewed against five checks with the failures fixed in place, or invokes /prompt-review.
 argument-hint: "[--all] [--report-only]"
 ---
 
 # Prompt Review
 
 Prompts are the product here, and they get worse by growing — a model reading a long file
-skips instructions in the middle of it. This reviews prompt files against eight criteria and,
-by default, fixes what fails.
+skips instructions in the middle of it. This reviews prompt files against five checks and, by
+default, fixes what fails.
 
-**The bar is binary.** Each criterion passes or fails — no scores, no "mostly". Every failure
-names the file and the lines, so the author can check it and the fix can be small. A file with
-nothing wrong is reported clean, never padded with suggestions.
+**The goal is a file a model follows end to end and acts on correctly.** The checks are proxies
+for that. When two collide, the one that changes how the file is executed wins — an exact
+command earns its words. Raise nothing that would not change what a model does.
 
-**The goal is a file a model follows end to end and acts on correctly.** Everything below is a
-proxy for that. When two criteria collide, the one that changes how the file is executed wins:
-adding a missing default or an exact command is a good fix even though it lengthens the file.
-The word delta is a diagnostic, never the target. The test for raising anything at all: would a
-model executing this file behave differently if this were fixed? If not, it passes.
-
-**Wording only, no approval gate, re-runnable.** Invoking the skill is the permission to edit;
-a second run over a clean file changes nothing. A good run leaves every file doing exactly what
-it did before, with the failures wording could close actually closed. Rubric for criteria 4, 5
-and 7: `~/.claude/at/rules/design-principles.md`, sections *Avoid flag parameters*, *Naming*,
-and *Consistency*.
+**Wording only.** A fix that drops a step, loosens a gate, renames a flag, or changes what a
+prompt returns is a behavior change: report it and leave the file alone. Invoking the skill is
+the permission to edit; a second run over a clean file changes nothing.
 
 ```
 /prompt-review [--all] [--report-only]
 
-  1. Scope the prompt files changed vs origin/main   (--all = every prompt file)
-  2. Review each against the eight criteria
-  3. Fix what wording can fix                        (--report-only skips 3 and 5)
-  4. Report the tables and the verdict
-  5. Write the verdict block into the PR body
+  1. Scope   prompt files changed vs origin/main   (--all = every prompt file)
+  2. Review  five checks per file
+  3. Fix     what wording can fix                  (--report-only skips this)
+  4. Report  one table, one verdict
 ```
-
-`--report-only` changes what gets written, never how it is judged: the verdict falls out of the
-same rule as any other run.
-
-## Runtime resolution
-
-- **Target repo** — the git repo of the working directory. Run every command from its root
-  (`cd "$(git rev-parse --show-toplevel)"`); every path below is root-relative. No `skills/`,
-  `agents/`, `rules/` or `templates/` there → this is not that repo: say so and stop.
-- **Prompt files** — `skills/*/SKILL.md`, `agents/*.md`, `rules/*.md`, and
-  `templates/CLAUDE.md.template`. Nothing else is in scope.
-- **`$SCRATCH`** — the session scratch directory, which holds the PR-body copy. Never a path
-  inside the repo tree, where it could be committed by accident.
 
 ## Phase 1 — Scope
 
-```bash
-git fetch -q origin
-FILES=$(git diff --name-only --diff-filter=d origin/main...HEAD | grep -E \
-  '^(skills/[^/]+/SKILL\.md|agents/[^/]+\.md|rules/[^/]+\.md|templates/CLAUDE\.md\.template)$' \
-  || true)
-```
-
-`--diff-filter=d` drops deleted paths, which cannot be read. `--all` replaces that list:
+Prompt files are `skills/*/SKILL.md`, `agents/*.md`, `rules/*.md`, and
+`templates/CLAUDE.md.template`. Nothing else. Run from the repo root.
 
 ```bash
-FILES=$(ls skills/*/SKILL.md agents/*.md rules/*.md templates/CLAUDE.md.template 2>/dev/null || true)
-```
-
-`|| true` keeps an empty match from aborting under a strict shell, but it also hides a real
-failure, so confirm the base before trusting an empty result:
-
-```bash
+cd "$(git rev-parse --show-toplevel)"; SCRATCH=<the session scratch directory>
 git rev-parse --verify origin/main >/dev/null || { echo "abort: origin/main missing"; exit 1; }
+git diff --name-only --diff-filter=d origin/main...HEAD | grep -E \
+  '^(skills/[^/]+/SKILL\.md|agents/[^/]+\.md|rules/[^/]+\.md|templates/CLAUDE\.md\.template)$' \
+  > "$SCRATCH/scope.txt" || true            # --all: ls the four patterns instead
+xargs -r wc -lw < "$SCRATCH/scope.txt"      # before-counts; over 500 lines is its own finding
 ```
 
-Empty `FILES` in either mode is an empty scope: print the verdict block with zeros in chat and
-stop, touching no PR body — replacing a real verdict with `0 reviewed` erases a result nobody
-re-earned.
-
-Write `FILES` to `$SCRATCH/scope.txt` and re-read it in each later phase — shell variables do
-not survive between steps. Then settle in shell everything that does not need a model read:
-
-```bash
-while read -r f; do
-  wc -lw "$f"                     # Phase 4's before-counts; past 500 lines is the standing finding
-  grep -c '^## Phase' "$f"        # criterion 7's phases check
-  grep -m1 '^description:' "$f"   # criterion 3 judges this one line, not the file
-done < "$SCRATCH/scope.txt" > "$SCRATCH/mechanical.txt"
-```
-
-Criterion 1 probes, criteria 2, 4, 5 and 6 need the prose; the rest start from that file. Past
-about five files, fan out — one read-only subagent per file, returning its two table rows —
-rather than pulling every file into one context, which is the failure this skill exists to
-catch. Both tables and the `reviewed` count always cover the full scope, never just the part
-that finished.
-
-Record `wc -lw` per file before reading it, and again after its fixes — Phase 4 reports both.
+`--diff-filter=d` drops deleted paths; `|| true` keeps an empty match from aborting a strict
+shell. Empty scope → print the verdict with zeros and stop. Past about five files, fan out one
+read-only subagent per file, each returning its rows — never pull every file into one context.
 
 ## Phase 2 — Review
 
-Read each file whole before judging it: criteria 2, 5, and 7 are claims about the file as a
-whole.
+| # | Check | Fails when |
+|---|-------|------------|
+| 1 | **It works** | an instruction cannot be followed: a command that errors or takes a flag the installed tool lacks, a path that is not there, a shell block that does not parse, a reference that points at the wrong place |
+| 2 | **Fewest words** | a paragraph teaches Claude what it already knows, restates a line above it, hedges, or argues for a rule already stated imperatively |
+| 3 | **Sharp and concrete** | an output shape is described but never shown; a fragile operation is named without its exact command; a menu of options stands where one default and an escape hatch would do; a `description` is too vague to match on; a fact that rots is stated as fixed |
+| 4 | **Consistent** | one concept goes by two names, one word means two things, or a step is done differently here than everywhere else in the repo |
+| 5 | **Effective and efficient** | the file does not actually achieve its stated job, or it makes the model pay for what a shell command settles — a whole-file read where a grep would do, an unbounded probe, a re-read, a loop with no cap |
 
-| # | Criterion | Fails when |
-|---|-----------|------------|
-| 1 | **It works** | an instruction cannot be followed: a command that errors or takes a flag the installed tool lacks, a path that is not there, a shell block that does not parse, a cross-reference that points at the wrong place or needs a third hop to reach the instruction |
-| 2 | **Token cost** | a paragraph teaches Claude something it already knows, restates a line above it, or hedges |
-| 3 | **Description** | skills and agents only — the frontmatter `description` is vague, states what without when (or when without what), drops the key terms a match depends on, is not third person, or — for a skill — does not open "Use when" |
-| 4 | **One default** | a menu of options stands where one default plus an escape hatch would do, or a flag hides two jobs behind one name |
-| 5 | **Consistent terms** | one concept goes by two names, or one word means two things in the same file |
-| 6 | **Concrete over vague** | output shape is described but never shown; a fragile operation is named but its exact command is not given; a fact that rots (a version, a count, a date) is stated as fixed |
-| 7 | **House anatomy** | a skill has no stance paragraph saying what it is for, or its steps are prose where the file's own siblings use numbered phases |
-| 8 | **House paths** | runtime support (schemas, gates, templates, scripts) is referenced as a copy in the skill directory when the same asset is staged under `~/.claude/at/…` |
+Check 1 is settled by probing, never by reading — a command looks fine right up until you run
+it. Extract the commands and paths from the file's fenced blocks, then `command -v` the tool,
+`<tool> <sub> --help | grep -- --flag` for a flag it is given (never the whole help page),
+`test -e` every path, `bash -n` every shell block, and open every reference. Check 1 outranks
+the rest: a file whose instructions do not run is broken however well it reads.
 
-Criterion 1 is checked by probing, never by reading — a command looks fine right up until you
-run it. For each file, before judging any prose:
+Two findings are never auto-fixed, only reported: a file **over 500 lines** (cutting one to
+length is a rewrite, and deleting blank lines fools only the counter), and **deleting a whole
+rule** from `rules/*.md` — that file loads every session, so press check 2 twice as hard there,
+but whether the model would follow a rule unprompted is not something this review can test.
 
-```bash
-grep -oE '`[a-z]+ [a-z-]+[^`]*`' <file> | tr -d '`'   # candidate commands to probe
-```
-
-Probe each: `command -v <tool>` for the tool, `<tool> <subcommand> --help` for a flag it is
-given, `test -e` for every path it names, `bash -n` on every shell block, and open every
-cross-reference to confirm it lands where the text says. Criterion 1 outranks the rest: a file
-whose instructions do not run is broken however well it reads.
-
-### The two standing findings
-
-Both are recorded in this phase, on the file as it arrives, and neither is ever auto-fixed — a
-later fix that changes the count never retracts one.
-
-- **Rule deletion** — `rules/*.md` loads every session and dilutes every other rule, so press
-  criterion 1 twice as hard there. The finding is that a whole rule should go; trimming a
-  paragraph inside one is an ordinary criterion-2 fix. Whether the model would follow a rule
-  unprompted is not something this review can test, so name the rule and let the author decide.
-- **Over length** — a file past 500 lines. Cutting one to length is a rewrite, and trimming
-  blank lines to clear the number fools only the counter.
-
-A failure carries the line range and enough of the text to find it: `rules/python.md:112-119 —
-criterion 1: restates the type-hint rule from lines 40-51`. Line numbers are the ones recorded
-in Phase 1, before any fix shifted them. A criterion with no subject in the file is not
-applicable and passes without a findings row — `rules/*.md` frontmatter carries only `paths:`,
-and the CLAUDE.md template has no frontmatter and no phases.
+A failure names the range and enough text to find it: `rules/python.md:112-119 — check 2:
+restates the type-hint rule from 40-51`. Line numbers are Phase 1's, before any fix moved them.
+A check with no subject in the file passes without a row.
 
 ## Phase 3 — Fix
 
-Work one file at a time and make the smallest diff that clears the failed criterion. Reach in
-this order: **cut** the lines, **tighten** what survives, **restructure** the section. A rewrite
-that keeps the line count has usually missed the finding.
+One file at a time, smallest diff that clears the failure: **cut**, then **tighten**, then
+**restructure**. Re-check only what a cut can break — checks 2 and 4, and the one just fixed —
+against the changed hunks. Twice at most; a failure still open after that is reported.
 
-Never change what a prompt does. A fix that would drop a step, loosen a gate, rename a flag, or
-change what the prompt returns is a behavior change: report it with the change it implies and
-leave the file alone.
+## Phase 4 — Report
 
-Re-check only what a cut can break — criterion 5, criterion 7, and the one just fixed — against
-the changed hunks, not the whole file. Re-check at most twice; a failure still open after that
-is reported as `open — re-check cap`, and stays open for the verdict.
+One table. A file that passes everything collapses to a single `all pass` row; `Check` holds a
+number or a standing finding, `Lines` the failing range or the file's length:
 
-## Phase 4 — The tables and the verdict
-
-The findings table carries one row per failing criterion per file, plus one per standing
-finding; a file that passes everything collapses to a single row reading `all pass`. The
-`Criterion` cell holds a numbered criterion or a standing finding, and `Lines` the failing
-range — or the file's length, when that is the finding:
-
-| File | Criterion | Lines | Verdict | Action |
-|------|-----------|-------|---------|--------|
+| File | Check | Lines | Verdict | Action |
+|------|-------|-------|---------|--------|
 | `skills/pr-babysit/SKILL.md` | 1 it works | 154-156 | fail | fixed — `then` branch held only a comment, so `bash -n` failed |
-| `rules/python.md` | 2 token cost | 112-119 | fail | fixed |
-| `agents/critic.md` | 4 one default | 44-61 | fail | reported — dropping the mode flag changes behavior |
-| `skills/pr-babysit/SKILL.md` | over length | 501 | fail | reported — cutting to length is a rewrite |
+| `rules/python.md` | 2 fewest words | 112-119 | fail | fixed |
+| `agents/critic.md` | 3 sharp | 44-61 | fail | reported — dropping the mode flag changes behavior |
 | `skills/explain/SKILL.md` | — | — | all pass | — |
 
-The counts table carries one row per file in scope — the same files, so both tables and the
-verdict's `reviewed` count always agree — plus a `total` row whose words the verdict repeats:
+Then the verdict, exactly these three lines so a future CI gate can grep it:
 
-| File | Lines | Words |
-|------|-------|-------|
-| `rules/python.md` | 135 → 127 | 1228 → 1156 |
-| `agents/critic.md` | 85 → 85 | 708 → 708 |
-| `skills/pr-babysit/SKILL.md` | 501 → 502 | 4023 → 4028 |
-| `skills/explain/SKILL.md` | 117 → 117 | 963 → 963 |
-| **total** | 838 → 831 | 6922 → 6855 |
-
-`pr-babysit` got longer, and that is the right outcome: the criterion-1 fix put a real command
-in an empty `then` branch. A delta that goes up is not a failed run.
-
-Last, the verdict block — exactly these three lines, in this order, so a future CI gate can
-grep it:
-
-````markdown
 ```
 prompt-review: <PASS | REPORTED | FAIL>
 files: <n> reviewed, <n> fixed
 delta: <before> → <after> words
 ```
-````
 
-Take the first state that applies, judging what is still open once Phase 3 has run. A finding
-that was fixed is closed and counts for nothing here:
+Take the first state that applies, judging what is still open after Phase 3. A fixed finding is
+closed and counts for nothing:
 
-1. **FAIL** — a failure this skill was allowed to fix is still open. Behavior changes and
-   standing findings never qualify: they were never this skill's to fix. A `--report-only` run
-   leaves every fixable failure open, so one found is one still open.
-2. **REPORTED** — something is left, and all of it is the author's to decide: a behavior change
-   or a standing finding.
-3. **PASS** — nothing is left open, whether or not anything was fixed, or nothing was in scope.
+1. **FAIL** — a failure this skill was allowed to fix is still open. `--report-only` fixes
+   nothing, so one found is one open.
+2. **REPORTED** — what is left is the author's to decide: a behavior change or a standing finding.
+3. **PASS** — nothing is left open, or nothing was in scope.
 
-`fixed` counts files whose bytes changed, not findings closed.
-
-## Phase 5 — Write the verdict block
-
-Skip this phase and print the block in chat — saying which condition skipped it — when
-`--report-only` is set, the scope was empty, `gh` is missing, HEAD is detached, or the branch
-has no single open PR. The last three skip from inside the block:
-
-```bash
-cd "$(git rev-parse --show-toplevel)"; SCRATCH=<the session scratch directory>
-command -v gh >/dev/null || { echo "skip: gh missing" >&2; exit 0; }
-BRANCH=$(git branch --show-current)
-[ -n "$BRANCH" ] || { echo "skip: detached HEAD" >&2; exit 0; }
-PR=$(gh pr list --head "$BRANCH" --json number -q 'if length == 1 then .[0].number else "" end')
-[ -n "$PR" ] || { echo "skip: no single open PR" >&2; exit 0; }
-printf '%s\n' "$PR" > "$SCRATCH/pr-number"
-gh pr view "$PR" --json body -q .body | sed -e 's/\r$//' > "$SCRATCH/pr-body.md"
-{ [ "$(wc -c < "$SCRATCH/pr-body.md")" -gt 1 ] && [ "$(cat "$SCRATCH/pr-body.md")" != null ]; } \
-  || { echo "abort: failed PR body read" >&2; exit 1; }
-```
-
-That last guard is why a bare `[ -s ]` will not do: `-q .body` prints the literal `null` for a
-null body and a lone newline for an empty one, so both look non-empty to `-s`.
-
-Now read `pr-body.md`, replace what sits between the markers with the verdict block — markers
-absent, append it after a blank line — and write the result to `new-body.md` with the Write
-tool. Never a heredoc or `sed -i`: both mangle the author's markdown. The block goes in wrapped
-and fenced, `<!-- prompt-review:begin -->`, then the Phase 4 verdict block verbatim, then
-`<!-- prompt-review:end -->`.
-
-The diff is the gate. Its only legal hunk is that block — every other byte, including any other
-skill's markers, stays as the author left it:
-
-```bash
-SCRATCH=<the session scratch directory>; PR=$(cat "$SCRATCH/pr-number")
-[ -s "$SCRATCH/new-body.md" ] || { echo "abort: empty new body" >&2; exit 1; }
-diff "$SCRATCH/pr-body.md" "$SCRATCH/new-body.md"
-gh pr edit "$PR" --body-file "$SCRATCH/new-body.md" \
-  || gh api "repos/{owner}/{repo}/pulls/$PR" -X PATCH -F body=@"$SCRATCH/new-body.md"
-```
-
-The `gh api` fallback is for repos with classic projects, where `gh pr edit` fails on a
-`projectCards` deprecation error.
-
-## Report
-
-End with the verdict line, the two tables, and the PR the block landed in — or, when Phase 5
-was skipped, which condition skipped it and the block for the author to paste.
+`fixed` counts files whose bytes changed. `delta` is a diagnostic, never the target — a fix that
+adds an exact command makes the file longer and is still the right fix. No PR is edited: print
+the verdict for the author to paste.
 
 ## Common mistakes
 
 | Mistake | Fix |
 |---------|-----|
-| Scoring a file 8/10 | One binary verdict per criterion, each failure naming lines (Phase 2) |
-| Cutting a step to shorten a file | Wording only — report the behavior change instead (Phase 3) |
+| Scoring a file 8/10 | One pass-or-fail verdict per check, each failure naming lines |
+| Reading a file to decide check 1 | Probe it — run the command, `test -e` the path, `bash -n` the block |
+| Cutting a step to shorten a file | Wording only — report the behavior change instead |
 | Deleting a rule because the model "already knows it" | Report it; the author owns what leaves a file every session reads |
-| Editing the PR body under `--report-only`, or after a zero-scope run | Print the block; change nothing (Phase 5) |

--- a/skills/prompt-review/SKILL.md
+++ b/skills/prompt-review/SKILL.md
@@ -43,8 +43,9 @@ with every prompt file in the repo:
 ls skills/*/SKILL.md agents/*.md rules/*.md templates/CLAUDE.md.template
 ```
 
-No match on the default scope → report that the branch changes no prompt file and stop. That is
-a clean run, not a failure.
+No match on the default scope → emit the stamp with zeros (`prompt-review: PASS`, `files: 0
+reviewed, 0 fixed`, `delta: 0 → 0 words`) in chat, write it to the PR body when a PR exists
+(Phase 4), and stop. A clean branch is not a failure, but it still leaves a greppable stamp.
 
 Record `wc -lw` per file before reading it; Phase 4 reports the delta against it.
 
@@ -56,7 +57,7 @@ whole, not about a paragraph in isolation. Then take all eight in order:
 | # | Criterion | Fails when |
 |---|-----------|------------|
 | 1 | **Token cost** | a paragraph teaches Claude something it already knows, restates a line above it, or hedges. Ask of every paragraph: does Claude already know this, and does it justify its token cost? |
-| 2 | **Description** | the frontmatter `description` is vague, states what without when (or when without what), drops the key terms a match depends on, or is not third person. A skill's starts "Use when" |
+| 2 | **Description** | skills and agents only — the frontmatter `description` is vague, states what without when (or when without what), drops the key terms a match depends on, or is not third person. A skill's starts "Use when" |
 | 3 | **One default** | a menu of options stands where one default plus an escape hatch would do, or a flag hides two jobs behind one name |
 | 4 | **Consistent terms** | one concept goes by two names, or one word means two things in the same file |
 | 5 | **Concrete over vague** | output shape is described but never shown; a fragile operation is named but its exact command is not given; a fact that rots (a version, a count, a date) is stated as fixed |
@@ -66,7 +67,9 @@ whole, not about a paragraph in isolation. Then take all eight in order:
 
 A failure carries the line range and enough of the text to find it: `rules/python.md:112-119 —
 criterion 1: restates the type-hint rule from lines 40-51`. A criterion with no failing lines
-passes.
+passes. A criterion with no subject in the file is not applicable and passes without a findings
+row — `rules/*.md` frontmatter carries only `paths:`, the CLAUDE.md template has no frontmatter
+and no phases, so neither has a `description` or house anatomy to judge.
 
 ## Phase 3 — Fix
 
@@ -96,8 +99,15 @@ passes all eight collapses to a single row reading `all pass`:
 | `agents/critic.md` | 3 one default | 44-61 | fail | reported — dropping the mode flag changes behavior |
 | `skills/explain/SKILL.md` | — | — | all pass | — |
 
-Then the counts table — one row per file with lines and words before → after, and a total row
-carrying the word delta.
+Then the counts table, one row per file plus a `total` row — the stamp's `delta` line repeats
+that total:
+
+| File | Lines | Words |
+|------|-------|-------|
+| `rules/python.md` | 214 → 201 | 1806 → 1699 |
+| `agents/critic.md` | 88 → 88 | 742 → 742 |
+| `skills/explain/SKILL.md` | 96 → 91 | 803 → 771 |
+| **total** | 398 → 380 | 3351 → 3212 |
 
 Last, the verdict stamp, exactly this block:
 
@@ -121,9 +131,19 @@ markers are already there and appending it when they are not:
 <!-- prompt-review:end -->
 ```
 
-Re-read the body first (`gh pr view <N> --json body`) and write it back with `gh pr edit <N>
---body-file <file>`; never touch prose outside the markers. No PR, or `--report-only` → print
-the stamp in chat for the author to paste, and edit nothing.
+Round-trip the body through a scratch file in a session temp location (`"$TMPDIR"`), never a
+path inside the repo tree where it could be committed by accident:
+
+```bash
+gh pr view <N> --json body --jq .body > "$TMPDIR"/pr-body.md
+# splice the stamp between the markers in that file; append the marker block when absent
+gh pr edit <N> --body-file "$TMPDIR"/pr-body.md
+```
+
+`--jq .body` is what keeps step 1 raw markdown — `--json body` alone writes `{"body":"…"}` and
+would overwrite the author's whole body with escaped JSON. Never touch prose outside the
+markers. No PR, or `--report-only` → print the stamp in chat for the author to paste, and edit
+nothing.
 
 ## Eval tasks
 

--- a/skills/prompt-review/SKILL.md
+++ b/skills/prompt-review/SKILL.md
@@ -14,160 +14,250 @@ by default, fixes what fails.
 names the file and the lines, so the author can check it and the fix can be small. A file with
 nothing wrong is reported clean, never padded with suggestions.
 
-**Fixes change wording, never behavior** — what a prompt does is off limits; how it says it is
-the whole job.
+**The goal is a file a model follows end to end and acts on correctly.** Everything below is a
+proxy for that. When two criteria collide, the one that changes how the file is executed wins:
+adding a missing default or an exact command is a good fix even though it lengthens the file.
+The word delta is a diagnostic, never the target. The test for raising anything at all: would a
+model executing this file behave differently if this were fixed? If not, it passes.
+
+**Wording only, no approval gate, re-runnable.** Invoking the skill is the permission to edit;
+a second run over a clean file changes nothing. A good run leaves every file doing exactly what
+it did before, with the failures wording could close actually closed. Rubric for criteria 4, 5
+and 7: `~/.claude/at/rules/design-principles.md`, sections *Avoid flag parameters*, *Naming*,
+and *Consistency*.
 
 ```
 /prompt-review [--all] [--report-only]
 
-  1. Scope     prompt files changed vs origin/main   (--all = every prompt file)
-  2. Review    eight binary criteria per file
-  3. Fix       smallest diff per failure             (--report-only stops here)
-  4. Report    findings table, counts, verdict stamp
+  1. Scope the prompt files changed vs origin/main   (--all = every prompt file)
+  2. Review each against the eight criteria
+  3. Fix what wording can fix                        (--report-only skips 3 and 5)
+  4. Report the tables and the verdict
+  5. Write the verdict block into the PR body
 ```
+
+`--report-only` changes what gets written, never how it is judged: the verdict falls out of the
+same rule as any other run.
+
+## Runtime resolution
+
+- **Target repo** — the git repo of the working directory. Run every command from its root
+  (`cd "$(git rev-parse --show-toplevel)"`); every path below is root-relative. No `skills/`,
+  `agents/`, `rules/` or `templates/` there → this is not that repo: say so and stop.
+- **Prompt files** — `skills/*/SKILL.md`, `agents/*.md`, `rules/*.md`, and
+  `templates/CLAUDE.md.template`. Nothing else is in scope.
+- **`$SCRATCH`** — the session scratch directory, which holds the PR-body copy. Never a path
+  inside the repo tree, where it could be committed by accident.
 
 ## Phase 1 — Scope
 
-Prompt files are `skills/*/SKILL.md`, `agents/*.md`, `rules/*.md`, and
-`templates/CLAUDE.md.template`. Nothing else is in scope.
-
 ```bash
-git fetch origin main
-git diff --name-only origin/main...HEAD
+git fetch -q origin
+FILES=$(git diff --name-only --diff-filter=d origin/main...HEAD | grep -E \
+  '^(skills/[^/]+/SKILL\.md|agents/[^/]+\.md|rules/[^/]+\.md|templates/CLAUDE\.md\.template)$' \
+  || true)
 ```
 
-Keep the paths matching those four patterns — that is the default scope. `--all` replaces it
-with every prompt file in the repo:
+`--diff-filter=d` drops deleted paths, which cannot be read. `--all` replaces that list:
 
 ```bash
-ls skills/*/SKILL.md agents/*.md rules/*.md templates/CLAUDE.md.template
+FILES=$(ls skills/*/SKILL.md agents/*.md rules/*.md templates/CLAUDE.md.template 2>/dev/null || true)
 ```
 
-No match on the default scope → emit the stamp with zeros (`prompt-review: PASS`, `files: 0
-reviewed, 0 fixed`, `delta: 0 → 0 words`) in chat, write it to the PR body when a PR exists and
-`--report-only` is not set (Phase 4), and stop.
+`|| true` keeps an empty match from aborting under a strict shell, but it also hides a real
+failure, so confirm the base before trusting an empty result:
 
-Record `wc -lw` per file before reading it; Phase 4 reports the delta against it.
+```bash
+git rev-parse --verify origin/main >/dev/null || { echo "abort: origin/main missing"; exit 1; }
+```
+
+Empty `FILES` in either mode is an empty scope: print the verdict block with zeros in chat and
+stop, touching no PR body — replacing a real verdict with `0 reviewed` erases a result nobody
+re-earned.
+
+Write `FILES` to `$SCRATCH/scope.txt` and re-read it in each later phase — shell variables do
+not survive between steps. Then settle in shell everything that does not need a model read:
+
+```bash
+while read -r f; do
+  wc -lw "$f"                     # Phase 4's before-counts; past 500 lines is the standing finding
+  grep -c '^## Phase' "$f"        # criterion 7's phases check
+  grep -m1 '^description:' "$f"   # criterion 3 judges this one line, not the file
+done < "$SCRATCH/scope.txt" > "$SCRATCH/mechanical.txt"
+```
+
+Criterion 1 probes, criteria 2, 4, 5 and 6 need the prose; the rest start from that file. Past
+about five files, fan out — one read-only subagent per file, returning its two table rows —
+rather than pulling every file into one context, which is the failure this skill exists to
+catch. Both tables and the `reviewed` count always cover the full scope, never just the part
+that finished.
+
+Record `wc -lw` per file before reading it, and again after its fixes — Phase 4 reports both.
 
 ## Phase 2 — Review
 
-Read each file whole before judging it — criteria 1, 4, and 6 are claims about the file as a
-whole, not about a paragraph in isolation. Then take all eight in order:
+Read each file whole before judging it: criteria 2, 5, and 7 are claims about the file as a
+whole.
 
 | # | Criterion | Fails when |
 |---|-----------|------------|
-| 1 | **Token cost** | a paragraph teaches Claude something it already knows, restates a line above it, or hedges. Ask of every paragraph: does Claude already know this, and does it justify its token cost? |
-| 2 | **Description** | skills and agents only — the frontmatter `description` is vague, states what without when (or when without what), drops the key terms a match depends on, or is not third person. A skill's starts "Use when" |
-| 3 | **One default** | a menu of options stands where one default plus an escape hatch would do, or a flag hides two jobs behind one name |
-| 4 | **Consistent terms** | one concept goes by two names, or one word means two things in the same file |
-| 5 | **Concrete over vague** | output shape is described but never shown; a fragile operation is named but its exact command is not given; a fact that rots (a version, a count, a date) is stated as fixed |
-| 6 | **Structure** | a reference points at a file that points at another file (deeper than one level); the file runs over 500 lines; a skill is missing the house anatomy — stance paragraph, numbered phases, a report section, and a common-mistakes table where it earns its place |
-| 7 | **House paths** | runtime support (schemas, gates, templates, scripts) is referenced as a copy bundled in the skill directory instead of its staged `~/.claude/at/…` path |
-| 8 | **Rules pressed hardest** | `rules/*.md` only — criterion 1 at double strength. A rule file loads every session and dilutes every other rule, so a rule the model already follows fails here and wants deleting |
+| 1 | **It works** | an instruction cannot be followed: a command that errors or takes a flag the installed tool lacks, a path that is not there, a shell block that does not parse, a cross-reference that points at the wrong place or needs a third hop to reach the instruction |
+| 2 | **Token cost** | a paragraph teaches Claude something it already knows, restates a line above it, or hedges |
+| 3 | **Description** | skills and agents only — the frontmatter `description` is vague, states what without when (or when without what), drops the key terms a match depends on, is not third person, or — for a skill — does not open "Use when" |
+| 4 | **One default** | a menu of options stands where one default plus an escape hatch would do, or a flag hides two jobs behind one name |
+| 5 | **Consistent terms** | one concept goes by two names, or one word means two things in the same file |
+| 6 | **Concrete over vague** | output shape is described but never shown; a fragile operation is named but its exact command is not given; a fact that rots (a version, a count, a date) is stated as fixed |
+| 7 | **House anatomy** | a skill has no stance paragraph saying what it is for, or its steps are prose where the file's own siblings use numbered phases |
+| 8 | **House paths** | runtime support (schemas, gates, templates, scripts) is referenced as a copy in the skill directory when the same asset is staged under `~/.claude/at/…` |
+
+Criterion 1 is checked by probing, never by reading — a command looks fine right up until you
+run it. For each file, before judging any prose:
+
+```bash
+grep -oE '`[a-z]+ [a-z-]+[^`]*`' <file> | tr -d '`'   # candidate commands to probe
+```
+
+Probe each: `command -v <tool>` for the tool, `<tool> <subcommand> --help` for a flag it is
+given, `test -e` for every path it names, `bash -n` on every shell block, and open every
+cross-reference to confirm it lands where the text says. Criterion 1 outranks the rest: a file
+whose instructions do not run is broken however well it reads.
+
+### The two standing findings
+
+Both are recorded in this phase, on the file as it arrives, and neither is ever auto-fixed — a
+later fix that changes the count never retracts one.
+
+- **Rule deletion** — `rules/*.md` loads every session and dilutes every other rule, so press
+  criterion 1 twice as hard there. The finding is that a whole rule should go; trimming a
+  paragraph inside one is an ordinary criterion-2 fix. Whether the model would follow a rule
+  unprompted is not something this review can test, so name the rule and let the author decide.
+- **Over length** — a file past 500 lines. Cutting one to length is a rewrite, and trimming
+  blank lines to clear the number fools only the counter.
 
 A failure carries the line range and enough of the text to find it: `rules/python.md:112-119 —
-criterion 1: restates the type-hint rule from lines 40-51`. A criterion with no failing lines
-passes. A criterion with no subject in the file is not applicable and passes without a findings
-row — `rules/*.md` frontmatter carries only `paths:`, the CLAUDE.md template has no frontmatter
-and no phases, so neither has a `description` or house anatomy to judge.
+criterion 1: restates the type-hint rule from lines 40-51`. Line numbers are the ones recorded
+in Phase 1, before any fix shifted them. A criterion with no subject in the file is not
+applicable and passes without a findings row — `rules/*.md` frontmatter carries only `paths:`,
+and the CLAUDE.md template has no frontmatter and no phases.
 
 ## Phase 3 — Fix
 
-The default. `--report-only` skips this phase entirely — nothing on disk changes.
-
 Work one file at a time and make the smallest diff that clears the failed criterion. Reach in
-this order: **cut** the lines, **tighten** what survives, **restructure** the section. Cutting
-is the fix that works most often; a rewrite that keeps the line count has usually missed the
-finding.
+this order: **cut** the lines, **tighten** what survives, **restructure** the section. A rewrite
+that keeps the line count has usually missed the finding.
 
 Never change what a prompt does. A fix that would drop a step, loosen a gate, rename a flag, or
 change what the prompt returns is a behavior change: report it with the change it implies and
-leave the file alone. Deleting a rule under criterion 8 counts as wording only when the model's
-default behavior already matches that rule — otherwise report it and let the author decide.
+leave the file alone.
 
-Re-check each fixed file against all eight criteria before moving on. A cut can strand a term
-(4) or break the anatomy (6).
+Re-check only what a cut can break — criterion 5, criterion 7, and the one just fixed — against
+the changed hunks, not the whole file. Re-check at most twice; a failure still open after that
+is reported as `open — re-check cap`, and stays open for the verdict.
 
-## Phase 4 — Report and stamp
+## Phase 4 — The tables and the verdict
 
-Two tables in chat. The findings table, one row per failing criterion per file — a file that
-passes all eight collapses to a single row reading `all pass`:
+The findings table carries one row per failing criterion per file, plus one per standing
+finding; a file that passes everything collapses to a single row reading `all pass`. The
+`Criterion` cell holds a numbered criterion or a standing finding, and `Lines` the failing
+range — or the file's length, when that is the finding:
 
 | File | Criterion | Lines | Verdict | Action |
 |------|-----------|-------|---------|--------|
-| `rules/python.md` | 1 token cost | 112-119 | fail | fixed |
-| `agents/critic.md` | 3 one default | 44-61 | fail | reported — dropping the mode flag changes behavior |
+| `skills/pr-babysit/SKILL.md` | 1 it works | 154-156 | fail | fixed — `then` branch held only a comment, so `bash -n` failed |
+| `rules/python.md` | 2 token cost | 112-119 | fail | fixed |
+| `agents/critic.md` | 4 one default | 44-61 | fail | reported — dropping the mode flag changes behavior |
+| `skills/pr-babysit/SKILL.md` | over length | 501 | fail | reported — cutting to length is a rewrite |
 | `skills/explain/SKILL.md` | — | — | all pass | — |
 
-Then the counts table, one row per file plus a `total` row — the stamp's `delta` line repeats
-that total:
+The counts table carries one row per file in scope — the same files, so both tables and the
+verdict's `reviewed` count always agree — plus a `total` row whose words the verdict repeats:
 
 | File | Lines | Words |
 |------|-------|-------|
-| `rules/python.md` | 214 → 201 | 1806 → 1699 |
-| `agents/critic.md` | 88 → 88 | 742 → 742 |
-| `skills/explain/SKILL.md` | 96 → 96 | 803 → 803 |
-| **total** | 398 → 385 | 3351 → 3244 |
+| `rules/python.md` | 135 → 127 | 1228 → 1156 |
+| `agents/critic.md` | 85 → 85 | 708 → 708 |
+| `skills/pr-babysit/SKILL.md` | 501 → 502 | 4023 → 4028 |
+| `skills/explain/SKILL.md` | 117 → 117 | 963 → 963 |
+| **total** | 838 → 831 | 6922 → 6855 |
 
-Last, the verdict stamp, exactly this block:
+`pr-babysit` got longer, and that is the right outcome: the criterion-1 fix put a real command
+in an empty `then` branch. A delta that goes up is not a failed run.
 
+Last, the verdict block — exactly these three lines, in this order, so a future CI gate can
+grep it:
+
+````markdown
 ```
-prompt-review: PASS | FAIL
+prompt-review: <PASS | REPORTED | FAIL>
 files: <n> reviewed, <n> fixed
 delta: <before> → <after> words
 ```
+````
 
-PASS only when every criterion passes on every file in scope after the fixes; a failure
-reported rather than fixed keeps it FAIL. Future CI greps for this block, so keep the three
-lines and their order.
+Take the first state that applies, judging what is still open once Phase 3 has run. A finding
+that was fixed is closed and counts for nothing here:
 
-Find the branch's PR with `gh pr list --head "$(git branch --show-current)" --json number,url`.
-A PR exists → keep exactly one marker block in its body, replacing the block in place when the
-markers are already there and appending it when they are not:
+1. **FAIL** — a failure this skill was allowed to fix is still open. Behavior changes and
+   standing findings never qualify: they were never this skill's to fix. A `--report-only` run
+   leaves every fixable failure open, so one found is one still open.
+2. **REPORTED** — something is left, and all of it is the author's to decide: a behavior change
+   or a standing finding.
+3. **PASS** — nothing is left open, whether or not anything was fixed, or nothing was in scope.
 
-```markdown
-<!-- prompt-review:begin -->
-<the stamp block>
-<!-- prompt-review:end -->
-```
+`fixed` counts files whose bytes changed, not findings closed.
 
-Round-trip the body through a `mktemp` file, never a path inside the repo tree where it could be
-committed by accident:
+## Phase 5 — Write the verdict block
+
+Skip this phase and print the block in chat — saying which condition skipped it — when
+`--report-only` is set, the scope was empty, `gh` is missing, HEAD is detached, or the branch
+has no single open PR. The last three skip from inside the block:
 
 ```bash
-BODY=$(mktemp)
-gh pr view <N> --json body --jq .body | tr -d '\r' > "$BODY"
-[ -s "$BODY" ] || { echo "abort: empty PR body read" >&2; exit 1; }
-# splice the stamp between the begin/end markers in "$BODY"; append the marker block when absent
-gh pr edit <N> --body-file "$BODY"
-rm -f "$BODY"
+cd "$(git rev-parse --show-toplevel)"; SCRATCH=<the session scratch directory>
+command -v gh >/dev/null || { echo "skip: gh missing" >&2; exit 0; }
+BRANCH=$(git branch --show-current)
+[ -n "$BRANCH" ] || { echo "skip: detached HEAD" >&2; exit 0; }
+PR=$(gh pr list --head "$BRANCH" --json number -q 'if length == 1 then .[0].number else "" end')
+[ -n "$PR" ] || { echo "skip: no single open PR" >&2; exit 0; }
+printf '%s\n' "$PR" > "$SCRATCH/pr-number"
+gh pr view "$PR" --json body -q .body | sed -e 's/\r$//' > "$SCRATCH/pr-body.md"
+{ [ "$(wc -c < "$SCRATCH/pr-body.md")" -gt 1 ] && [ "$(cat "$SCRATCH/pr-body.md")" != null ]; } \
+  || { echo "abort: failed PR body read" >&2; exit 1; }
 ```
 
-`--jq .body` keeps the read raw markdown — bare `--json body` writes `{"body":"…"}` and would
-overwrite the author's whole body with escaped JSON. The guard is there because `>` truncates
-before `gh pr view` runs: a failed read must abort, not write an empty body back. Never touch
-prose outside the markers. No PR, or `--report-only` → print the stamp in chat for the author to
-paste, and edit nothing.
+That last guard is why a bare `[ -s ]` will not do: `-q .body` prints the literal `null` for a
+null body and a lone newline for an empty one, so both look non-empty to `-s`.
 
-## Eval tasks
+Now read `pr-body.md`, replace what sits between the markers with the verdict block — markers
+absent, append it after a blank line — and write the result to `new-body.md` with the Write
+tool. Never a heredoc or `sed -i`: both mangle the author's markdown. The block goes in wrapped
+and fenced, `<!-- prompt-review:begin -->`, then the Phase 4 verdict block verbatim, then
+`<!-- prompt-review:end -->`.
 
-Every failing row of the findings table is a candidate golden task for a future eval of this
-skill: the same file reviewed again must produce the same finding. The shape:
+The diff is the gate. Its only legal hunk is that block — every other byte, including any other
+skill's markers, stays as the author left it:
 
-```json
-{"query": "review rules/python.md", "files": ["rules/python.md"], "expected_behavior": ["criterion 1 fails at 112-119 — restates the type-hint rule from 40-51"]}
+```bash
+SCRATCH=<the session scratch directory>; PR=$(cat "$SCRATCH/pr-number")
+[ -s "$SCRATCH/new-body.md" ] || { echo "abort: empty new body" >&2; exit 1; }
+diff "$SCRATCH/pr-body.md" "$SCRATCH/new-body.md"
+gh pr edit "$PR" --body-file "$SCRATCH/new-body.md" \
+  || gh api "repos/{owner}/{repo}/pulls/$PR" -X PATCH -F body=@"$SCRATCH/new-body.md"
 ```
 
-`query` is the run that found it, `files` the paths it read, `expected_behavior` one line per
-finding a correct run must produce. v1 defines the shape and writes nothing automatically — hand
-a task back only when the user asks for one.
+The `gh api` fallback is for repos with classic projects, where `gh pr edit` fails on a
+`projectCards` deprecation error.
+
+## Report
+
+End with the verdict line, the two tables, and the PR the block landed in — or, when Phase 5
+was skipped, which condition skipped it and the block for the author to paste.
 
 ## Common mistakes
 
 | Mistake | Fix |
 |---------|-----|
-| Scoring a file 8/10 | One binary verdict per criterion, each failure naming lines |
-| Rewriting a paragraph that passed | Only a failure earns a diff |
-| Cutting a step to shorten a file | Wording only — report the behavior change instead |
-| Reviewing the whole repo on a two-file branch | Default scope is the branch's changed prompt files; `--all` is opt-in |
-| Editing the PR body under `--report-only` | Print the stamp; change nothing |
+| Scoring a file 8/10 | One binary verdict per criterion, each failure naming lines (Phase 2) |
+| Cutting a step to shorten a file | Wording only — report the behavior change instead (Phase 3) |
+| Deleting a rule because the model "already knows it" | Report it; the author owns what leaves a file every session reads |
+| Editing the PR body under `--report-only`, or after a zero-scope run | Print the block; change nothing (Phase 5) |


### PR DESCRIPTION
PR 5 of the prompt-review plan (decision record: https://claude.ai/code/artifact/0379e7be-d68b-46a7-af89-214008988e69). Independent of PRs 1–4.

## What lands

- `skills/prompt-review/SKILL.md` (118 lines) — a self-contained skill that reviews the repo's prompt files against eight binary criteria (token cost, description, one default, consistent terms, concrete over vague, structure, house paths, rules pressed hardest), fixes wording-only failures by default (`--report-only` to report without touching anything, `--all` to audit the whole repo), and reports a findings table, per-file line/word counts, and a greppable verdict stamp for future CI.
- One `[[units]]` row in `installer/catalog.toml` — without it the skill is silently uninstallable.

## Dogfood proof

The spec requires the skill to pass its own bar. An independent agent executed `/prompt-review --report-only` per the skill file on this branch, twice: the first run honestly **failed** the file on its own criterion 1 (a redundant sentence at lines 46-48) — that finding was fixed — and the re-run on the final tree passes clean. The acceptance check has teeth; both transcripts are in the run evidence (`.v1-runs/evidence/worktree-prompt-review/`).

<!-- prompt-review:begin -->
```
prompt-review: PASS
files: 1 reviewed, 0 fixed
delta: 1498 → 1498 words
```
<!-- prompt-review:end -->

## Gates

- `./validate.sh` → catalog OK — 30 units, 8 packages, 2 bundles
- `cd installer && uv run pytest -W error -q` → 182 passed, coverage 98%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9YMuDkPRAvKZu2HQnYwj5


<!-- pr-explain:begin -->
### What & why

Add `/prompt-review` — a skill that checks this repo's prompt files against five pass-or-fail checks and rewrites what fails. Nothing reviewed our 4,600 lines of prompt markdown. Long prompts work worse: a model skips instructions buried mid-file.

**Goals**

- the first check is whether the instructions actually run
- each check passes or fails, naming file and lines
- fixes touch wording only; `--report-only` writes nothing
- the skill is 118 lines — shorter than most files it reviews

**[Read the explainer](https://claude.ai/code/artifact/5a684a6d-6fcf-466b-b49c-9ba796da354e)** · 2 files touched
<!-- pr-explain:end -->




