### PR TITLE
feat(scripts): prompt_lint — frontmatter + ceiling checker for repo prompts (PR 1)

### DIFF
--- a/scripts/prompt_lint/__main__.py
+++ b/scripts/prompt_lint/__main__.py
@@ -1,0 +1,13 @@
+"""Entry point for `python -m prompt_lint`, run with the prompt tree as the cwd."""
+
+from __future__ import annotations
+
+
+def main() -> int:
+    """Reports how the prompt tree at the current directory breaks its conventions."""
+    # No convention is checked yet; later slices add them one behaviour at a time.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prompt_lint/__main__.py
+++ b/scripts/prompt_lint/__main__.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+from .checks import lint_tree
+
 
 def main() -> int:
     """Reports how the prompt tree at the current directory breaks its conventions."""
-    # No convention is checked yet; later slices add them one behaviour at a time.
-    return 0
+    violations: list[str] = list(lint_tree(root=Path.cwd()))
+    for violation in violations:
+        print(violation)
+    return 1 if violations else 0
 
 
 if __name__ == "__main__":

--- a/scripts/prompt_lint/checks.py
+++ b/scripts/prompt_lint/checks.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from pathlib import Path
 
-from .constants import DESCRIPTION_PREFIX, FENCE, REQUIRED_KEYS
+from .constants import DESCRIPTION_PREFIX, FENCE, REQUIRED_KEYS, SKILL_FILE
 
 
 def _frontmatter(*, text: str) -> dict[str, str]:
@@ -30,10 +30,11 @@ def lint_tree(*, root: Path) -> Iterator[str]:
             for key in required:
                 if key not in fields:
                     yield f"{where}:1: frontmatter is missing {key!r}"
-            # An absent key is reported above, so it defaults to a conforming value.
-            name: str = fields.get("name", prompt.parent.name)
+            # A skill is named for its directory; only it needs the trigger prefix.
+            is_skill: bool = prompt.name == SKILL_FILE
+            expected: str = prompt.parent.name if is_skill else prompt.stem
             blurb: str = fields.get("description", DESCRIPTION_PREFIX)
-            if name != prompt.parent.name:
-                yield f"{where}:1: name must be {prompt.parent.name!r}"
-            if not blurb.startswith(DESCRIPTION_PREFIX):
+            if fields.get("name", expected) != expected:
+                yield f"{where}:1: name must be {expected!r}"
+            if is_skill and not blurb.startswith(DESCRIPTION_PREFIX):
                 yield f"{where}:1: description must open with {DESCRIPTION_PREFIX!r}"

--- a/scripts/prompt_lint/checks.py
+++ b/scripts/prompt_lint/checks.py
@@ -1,0 +1,39 @@
+"""Each convention a prompt tree must satisfy, reported as `path:line: message`."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from .constants import DESCRIPTION_PREFIX, FENCE, REQUIRED_KEYS
+
+
+def _frontmatter(*, text: str) -> dict[str, str]:
+    """Hand-rolled `key: value` scan, so a prompt lint needs no YAML dependency."""
+    fields: dict[str, str] = {}
+    if not text.startswith(f"{FENCE}\n"):
+        return fields
+    for line in text.splitlines()[1:]:
+        if line == FENCE:
+            break
+        key, _, value = line.partition(":")
+        fields[key.strip()] = value.strip()
+    return fields
+
+
+def lint_tree(*, root: Path) -> Iterator[str]:
+    """Every way the prompt tree at root breaks a convention, one diagnostic each."""
+    for pattern, required in REQUIRED_KEYS.items():
+        for prompt in sorted(root.glob(pattern)):
+            fields: dict[str, str] = _frontmatter(text=prompt.read_text())
+            where: Path = prompt.relative_to(root)
+            for key in required:
+                if key not in fields:
+                    yield f"{where}:1: frontmatter is missing {key!r}"
+            # An absent key is reported above, so it defaults to a conforming value.
+            name: str = fields.get("name", prompt.parent.name)
+            blurb: str = fields.get("description", DESCRIPTION_PREFIX)
+            if name != prompt.parent.name:
+                yield f"{where}:1: name must be {prompt.parent.name!r}"
+            if not blurb.startswith(DESCRIPTION_PREFIX):
+                yield f"{where}:1: description must open with {DESCRIPTION_PREFIX!r}"

--- a/scripts/prompt_lint/checks.py
+++ b/scripts/prompt_lint/checks.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from pathlib import Path
 
-from .constants import DESCRIPTION_PREFIX, FENCE, REQUIRED_KEYS, SKILL_FILE
+from .constants import DESCRIPTION_PREFIX, FENCE, REQUIRED_KEYS, SKILL_CAP, SKILL_FILE
 
 
 def _frontmatter(*, text: str) -> dict[str, str]:
@@ -38,3 +38,5 @@ def lint_tree(*, root: Path) -> Iterator[str]:
                 yield f"{where}:1: name must be {expected!r}"
             if is_skill and not blurb.startswith(DESCRIPTION_PREFIX):
                 yield f"{where}:1: description must open with {DESCRIPTION_PREFIX!r}"
+            if is_skill and (count := len(prompt.read_text().splitlines())) > SKILL_CAP:
+                yield f"{where}:{count}: {count} lines (cap {SKILL_CAP})"

--- a/scripts/prompt_lint/constants.py
+++ b/scripts/prompt_lint/constants.py
@@ -13,4 +13,5 @@ SKILL_FILE: Final[str] = "SKILL.md"
 REQUIRED_KEYS: Final[dict[str, tuple[str, ...]]] = {
     f"skills/*/{SKILL_FILE}": ("name", "description"),
     "agents/*.md": ("name", "description", "tools", "model"),
+    "rules/*.md": ("paths",),
 }

--- a/scripts/prompt_lint/constants.py
+++ b/scripts/prompt_lint/constants.py
@@ -1,0 +1,14 @@
+"""Every literal the prompt conventions are pinned to, in one place."""
+
+from __future__ import annotations
+
+from typing import Final
+
+FENCE: Final[str] = "---"
+DESCRIPTION_PREFIX: Final[str] = "Use when"
+
+# Which prompt files carry frontmatter, and the keys each declares — one row per kind,
+# so a new convention is a row here rather than another function.
+REQUIRED_KEYS: Final[dict[str, tuple[str, ...]]] = {
+    "skills/*/SKILL.md": ("name", "description"),
+}

--- a/scripts/prompt_lint/constants.py
+++ b/scripts/prompt_lint/constants.py
@@ -6,9 +6,11 @@ from typing import Final
 
 FENCE: Final[str] = "---"
 DESCRIPTION_PREFIX: Final[str] = "Use when"
+SKILL_FILE: Final[str] = "SKILL.md"
 
 # Which prompt files carry frontmatter, and the keys each declares — one row per kind,
 # so a new convention is a row here rather than another function.
 REQUIRED_KEYS: Final[dict[str, tuple[str, ...]]] = {
-    "skills/*/SKILL.md": ("name", "description"),
+    f"skills/*/{SKILL_FILE}": ("name", "description"),
+    "agents/*.md": ("name", "description", "tools", "model"),
 }

--- a/scripts/prompt_lint/constants.py
+++ b/scripts/prompt_lint/constants.py
@@ -7,6 +7,7 @@ from typing import Final
 FENCE: Final[str] = "---"
 DESCRIPTION_PREFIX: Final[str] = "Use when"
 SKILL_FILE: Final[str] = "SKILL.md"
+SKILL_CAP: Final[int] = 500  # lines; past this a skill is too long to hold in one read
 
 # Which prompt files carry frontmatter, and the keys each declares — one row per kind,
 # so a new convention is a row here rather than another function.

--- a/scripts/tests/test_prompt_lint.py
+++ b/scripts/tests/test_prompt_lint.py
@@ -1,0 +1,76 @@
+"""Tests for the prompt linter (a prompt tree -> the conventions its files violate).
+
+The checker's contract is a CLI over whatever tree it is run in, so the test builds a
+real fixture tree in tmp_path and runs the module as a subprocess — the way a gate
+invokes it — rather than reaching for an internal entry point.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Final
+
+SCRIPTS_DIR: Final[Path] = Path(__file__).resolve().parent.parent
+
+# A tree that satisfies every convention the checker knows: the skill's name matches its
+# directory and its description opens with "Use when", the agent carries all four keys
+# with a name matching its file stem, and the rule declares the paths it governs.
+CONFORMING_TREE: Final[dict[str, str]] = {
+    "skills/demo/SKILL.md": (
+        "---\n"
+        "name: demo\n"
+        "description: Use when testing the prompt linter.\n"
+        "---\n"
+        "\n"
+        "# demo\n"
+        "\n"
+        "A conforming skill.\n"
+    ),
+    "agents/helper.md": (
+        "---\n"
+        "name: helper\n"
+        "description: Helps with one step of a test fixture.\n"
+        "tools: Read\n"
+        "model: opus\n"
+        "---\n"
+        "\n"
+        "# helper\n"
+        "\n"
+        "A conforming agent.\n"
+    ),
+    "rules/python.md": (
+        '---\npaths: "**/*.py"\n---\n\n# Python Rules\n\nA conforming rule.\n'
+    ),
+}
+
+
+def _write_conforming_tree(*, root: Path) -> None:
+    for relative_path, content in CONFORMING_TREE.items():
+        prompt: Path = root / relative_path
+        prompt.parent.mkdir(parents=True, exist_ok=True)
+        prompt.write_text(content)
+
+
+def _run_prompt_lint(*, root: Path) -> subprocess.CompletedProcess[str]:
+    """Runs the CLI the way a gate does: cwd is the tree, scripts/ is on the path."""
+    environment: dict[str, str] = {**os.environ, "PYTHONPATH": str(SCRIPTS_DIR)}
+    return subprocess.run(
+        [sys.executable, "-m", "prompt_lint"],
+        cwd=root,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_conforming_tree_exits_zero_with_no_output(tmp_path: Path) -> None:
+    _write_conforming_tree(root=tmp_path)
+
+    result: subprocess.CompletedProcess[str] = _run_prompt_lint(root=tmp_path)
+
+    assert result.returncode == 0, f"prompt_lint failed: {result.stderr}"
+    assert result.stdout == ""

--- a/scripts/tests/test_prompt_lint.py
+++ b/scripts/tests/test_prompt_lint.py
@@ -105,6 +105,23 @@ OFFENDING_AGENTS: Final[dict[str, str]] = {
 }
 
 
+# One rule per way the sole rule convention can break, so each rule carries exactly one
+# violation: no frontmatter at all, and frontmatter that opens without declaring the
+# 'paths' it governs. A rule answers to nothing else — no 'name', no 'description'.
+OFFENDING_RULES: Final[dict[str, str]] = {
+    "rules/no-frontmatter.md": "# no-frontmatter\n\nA rule that never opens.\n",
+    "rules/unscoped.md": (
+        "---\n"
+        "applies_to: everything\n"
+        "---\n"
+        "\n"
+        "# unscoped\n"
+        "\n"
+        "A rule that never says which files it governs.\n"
+    ),
+}
+
+
 def _write_prompts(*, root: Path, prompts: Mapping[str, str]) -> None:
     for relative_path, content in prompts.items():
         prompt: Path = root / relative_path
@@ -181,6 +198,31 @@ def test_offending_agent_frontmatter_is_reported_with_path_and_line(
     for offending_path in OFFENDING_AGENTS:
         assert any(offending_path in line for line in reported_lines), (
             f"{offending_path} broke an agent rule unreported: {result.stdout!r}"
+        )
+    for conforming_path in CONFORMING_TREE:
+        assert conforming_path not in result.stdout, (
+            f"{conforming_path} conforms but was reported: {result.stdout!r}"
+        )
+
+
+def test_rule_without_paths_frontmatter_is_reported_with_path_and_line(
+    tmp_path: Path,
+) -> None:
+    _write_conforming_tree(root=tmp_path)
+    _write_prompts(root=tmp_path, prompts=OFFENDING_RULES)
+
+    result: subprocess.CompletedProcess[str] = _run_prompt_lint(root=tmp_path)
+
+    assert result.returncode == 1, f"expected a failing lint, got: {result.stderr}"
+    reported_lines: list[str] = result.stdout.splitlines()
+    assert reported_lines, f"expected a diagnostic per violation: {result.stderr}"
+    for reported_line in reported_lines:
+        assert DIAGNOSTIC_LINE.match(reported_line) is not None, (
+            f"not a `path:line: message` diagnostic: {reported_line!r}"
+        )
+    for offending_path in OFFENDING_RULES:
+        assert any(offending_path in line for line in reported_lines), (
+            f"{offending_path} declares no paths unreported: {result.stdout!r}"
         )
     for conforming_path in CONFORMING_TREE:
         assert conforming_path not in result.stdout, (

--- a/scripts/tests/test_prompt_lint.py
+++ b/scripts/tests/test_prompt_lint.py
@@ -122,6 +122,14 @@ OFFENDING_RULES: Final[dict[str, str]] = {
 }
 
 
+# A skill that breaks nothing but its own length. The count sits far past the limit
+# rather than one line over it, so a diagnostic quoting the file's length cannot be
+# confused with one that merely points at the first line past the limit.
+OVERSIZED_SKILL_PATH: Final[str] = "skills/sprawling/SKILL.md"
+OVERSIZED_SKILL_LINES: Final[int] = 617
+LINE_COUNT: Final[re.Pattern[str]] = re.compile(rf"\b{OVERSIZED_SKILL_LINES}\b")
+
+
 def _write_prompts(*, root: Path, prompts: Mapping[str, str]) -> None:
     for relative_path, content in prompts.items():
         prompt: Path = root / relative_path
@@ -131,6 +139,24 @@ def _write_prompts(*, root: Path, prompts: Mapping[str, str]) -> None:
 
 def _write_conforming_tree(*, root: Path) -> None:
     _write_prompts(root=root, prompts=CONFORMING_TREE)
+
+
+def _oversized_skill_prompt(*, lines: int) -> dict[str, str]:
+    """A skill with clean frontmatter whose body runs it to exactly `lines` lines."""
+    opening: list[str] = [
+        "---",
+        "name: sprawling",
+        "description: Use when a skill outgrows what a reader will hold.",
+        "---",
+        "",
+        "# sprawling",
+        "",
+    ]
+    body: list[str] = [
+        f"Paragraph {paragraph}, one more thing this skill also explains."
+        for paragraph in range(lines - len(opening))
+    ]
+    return {OVERSIZED_SKILL_PATH: "\n".join([*opening, *body]) + "\n"}
 
 
 def _run_prompt_lint(*, root: Path) -> subprocess.CompletedProcess[str]:
@@ -224,6 +250,36 @@ def test_rule_without_paths_frontmatter_is_reported_with_path_and_line(
         assert any(offending_path in line for line in reported_lines), (
             f"{offending_path} declares no paths unreported: {result.stdout!r}"
         )
+    for conforming_path in CONFORMING_TREE:
+        assert conforming_path not in result.stdout, (
+            f"{conforming_path} conforms but was reported: {result.stdout!r}"
+        )
+
+
+def test_overlong_skill_is_reported_with_its_line_count(tmp_path: Path) -> None:
+    _write_conforming_tree(root=tmp_path)
+    _write_prompts(
+        root=tmp_path, prompts=_oversized_skill_prompt(lines=OVERSIZED_SKILL_LINES)
+    )
+
+    result: subprocess.CompletedProcess[str] = _run_prompt_lint(root=tmp_path)
+
+    assert result.returncode == 1, f"expected a failing lint, got: {result.stderr}"
+    reported_lines: list[str] = result.stdout.splitlines()
+    assert reported_lines, f"expected a diagnostic per violation: {result.stderr}"
+    for reported_line in reported_lines:
+        assert DIAGNOSTIC_LINE.match(reported_line) is not None, (
+            f"not a `path:line: message` diagnostic: {reported_line!r}"
+        )
+    about_the_skill: list[str] = [
+        line for line in reported_lines if OVERSIZED_SKILL_PATH in line
+    ]
+    assert about_the_skill, (
+        f"{OVERSIZED_SKILL_PATH} runs past the limit unreported: {result.stdout!r}"
+    )
+    assert any(LINE_COUNT.search(line) is not None for line in about_the_skill), (
+        f"no diagnostic gives its {OVERSIZED_SKILL_LINES} lines: {about_the_skill!r}"
+    )
     for conforming_path in CONFORMING_TREE:
         assert conforming_path not in result.stdout, (
             f"{conforming_path} conforms but was reported: {result.stdout!r}"

--- a/scripts/tests/test_prompt_lint.py
+++ b/scripts/tests/test_prompt_lint.py
@@ -80,6 +80,31 @@ OFFENDING_SKILLS: Final[dict[str, str]] = {
 }
 
 
+# One agent per way the agent frontmatter rules can break, so each agent carries exactly
+# one violation: a missing 'tools'/'model' pair, and a name that disagrees with the file
+# stem — an agent is named after its file, not after the directory it sits in.
+OFFENDING_AGENTS: Final[dict[str, str]] = {
+    "agents/missing-keys.md": (
+        "---\n"
+        "name: missing-keys\n"
+        "description: Runs without declaring its tools or its model.\n"
+        "---\n"
+        "\n"
+        "# missing-keys\n"
+    ),
+    "agents/mismatched-stem.md": (
+        "---\n"
+        "name: renamed\n"
+        "description: Answers to a name its own file does not carry.\n"
+        "tools: Read\n"
+        "model: opus\n"
+        "---\n"
+        "\n"
+        "# mismatched-stem\n"
+    ),
+}
+
+
 def _write_prompts(*, root: Path, prompts: Mapping[str, str]) -> None:
     for relative_path, content in prompts.items():
         prompt: Path = root / relative_path
@@ -131,6 +156,31 @@ def test_offending_skill_frontmatter_is_reported_with_path_and_line(
     for offending_path in OFFENDING_SKILLS:
         assert any(offending_path in line for line in reported_lines), (
             f"{offending_path} broke a skill rule unreported: {result.stdout!r}"
+        )
+    for conforming_path in CONFORMING_TREE:
+        assert conforming_path not in result.stdout, (
+            f"{conforming_path} conforms but was reported: {result.stdout!r}"
+        )
+
+
+def test_offending_agent_frontmatter_is_reported_with_path_and_line(
+    tmp_path: Path,
+) -> None:
+    _write_conforming_tree(root=tmp_path)
+    _write_prompts(root=tmp_path, prompts=OFFENDING_AGENTS)
+
+    result: subprocess.CompletedProcess[str] = _run_prompt_lint(root=tmp_path)
+
+    assert result.returncode == 1, f"expected a failing lint, got: {result.stderr}"
+    reported_lines: list[str] = result.stdout.splitlines()
+    assert reported_lines, f"expected a diagnostic per violation: {result.stderr}"
+    for reported_line in reported_lines:
+        assert DIAGNOSTIC_LINE.match(reported_line) is not None, (
+            f"not a `path:line: message` diagnostic: {reported_line!r}"
+        )
+    for offending_path in OFFENDING_AGENTS:
+        assert any(offending_path in line for line in reported_lines), (
+            f"{offending_path} broke an agent rule unreported: {result.stdout!r}"
         )
     for conforming_path in CONFORMING_TREE:
         assert conforming_path not in result.stdout, (

--- a/scripts/tests/test_prompt_lint.py
+++ b/scripts/tests/test_prompt_lint.py
@@ -8,12 +8,18 @@ invokes it — rather than reaching for an internal entry point.
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import sys
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Final
 
 SCRIPTS_DIR: Final[Path] = Path(__file__).resolve().parent.parent
+
+# A diagnostic names the offending file and the line it was found on, so an editor or a
+# CI annotation can jump straight there: `path:line: message`.
+DIAGNOSTIC_LINE: Final[re.Pattern[str]] = re.compile(r"^\S+?:\d+: .+$")
 
 # A tree that satisfies every convention the checker knows: the skill's name matches its
 # directory and its description opens with "Use when", the agent carries all four keys
@@ -47,11 +53,42 @@ CONFORMING_TREE: Final[dict[str, str]] = {
 }
 
 
-def _write_conforming_tree(*, root: Path) -> None:
-    for relative_path, content in CONFORMING_TREE.items():
+# One skill per way the skill frontmatter rules can break, so each skill carries exactly
+# one violation: no frontmatter at all (and so no name), no description, a name that
+# disagrees with its directory, and a description that does not open with "Use when".
+OFFENDING_SKILLS: Final[dict[str, str]] = {
+    "skills/no-frontmatter/SKILL.md": "# no-frontmatter\n\nA skill that never opens.\n",
+    "skills/no-description/SKILL.md": (
+        "---\nname: no-description\n---\n\n# no-description\n\nA skill with no blurb.\n"
+    ),
+    "skills/wrong-name/SKILL.md": (
+        "---\n"
+        "name: mismatched\n"
+        "description: Use when the name disagrees with the directory.\n"
+        "---\n"
+        "\n"
+        "# wrong-name\n"
+    ),
+    "skills/vague-description/SKILL.md": (
+        "---\n"
+        "name: vague-description\n"
+        "description: Lints prompt files, sometimes.\n"
+        "---\n"
+        "\n"
+        "# vague-description\n"
+    ),
+}
+
+
+def _write_prompts(*, root: Path, prompts: Mapping[str, str]) -> None:
+    for relative_path, content in prompts.items():
         prompt: Path = root / relative_path
         prompt.parent.mkdir(parents=True, exist_ok=True)
         prompt.write_text(content)
+
+
+def _write_conforming_tree(*, root: Path) -> None:
+    _write_prompts(root=root, prompts=CONFORMING_TREE)
 
 
 def _run_prompt_lint(*, root: Path) -> subprocess.CompletedProcess[str]:
@@ -74,3 +111,28 @@ def test_conforming_tree_exits_zero_with_no_output(tmp_path: Path) -> None:
 
     assert result.returncode == 0, f"prompt_lint failed: {result.stderr}"
     assert result.stdout == ""
+
+
+def test_offending_skill_frontmatter_is_reported_with_path_and_line(
+    tmp_path: Path,
+) -> None:
+    _write_conforming_tree(root=tmp_path)
+    _write_prompts(root=tmp_path, prompts=OFFENDING_SKILLS)
+
+    result: subprocess.CompletedProcess[str] = _run_prompt_lint(root=tmp_path)
+
+    assert result.returncode == 1, f"expected a failing lint, got: {result.stderr}"
+    reported_lines: list[str] = result.stdout.splitlines()
+    assert reported_lines, f"expected a diagnostic per violation: {result.stderr}"
+    for reported_line in reported_lines:
+        assert DIAGNOSTIC_LINE.match(reported_line) is not None, (
+            f"not a `path:line: message` diagnostic: {reported_line!r}"
+        )
+    for offending_path in OFFENDING_SKILLS:
+        assert any(offending_path in line for line in reported_lines), (
+            f"{offending_path} broke a skill rule unreported: {result.stdout!r}"
+        )
+    for conforming_path in CONFORMING_TREE:
+        assert conforming_path not in result.stdout, (
+            f"{conforming_path} conforms but was reported: {result.stdout!r}"
+        )

--- a/skills/pr-babysit/SKILL.md
+++ b/skills/pr-babysit/SKILL.md
@@ -167,8 +167,6 @@ Skip on subsequent iterations — the existing gate run in step 1f (after commen
 Kick off all data fetches in parallel at the start of each iteration:
 
 ```bash
-# All four in parallel:
-
 # 1. Review comments (inline code comments on specific lines)
 COMMENTS=$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" \
   --paginate \


### PR DESCRIPTION
PR 1 of the prompt-review plan: a deterministic checker for the repo's prompt files, with CI wiring to follow in PR 4.

## What lands

`scripts/prompt_lint/` (mirrors the `pr_size`/`dispatch` layout) with a CLI runnable from the repo root:

```
PYTHONPATH=scripts uv run python -m prompt_lint   # walks the tree, prints failures, exit 1 on any
```

Checks, driven by a `REQUIRED_KEYS` glob→keys table so later PRs add rows/checks without reshaping the package:

- **skills/*/SKILL.md** — frontmatter has `name` + `description`; `name` == directory name; `description` starts with `Use when`; file ≤ 500 lines (violation message carries the actual count)
- **agents/*.md** — frontmatter has `name`, `description`, `tools`, `model`; `name` == file stem
- **rules/*.md** — frontmatter has a `paths:` key

One `path:line: message` diagnostic per violation, exit 1; silent exit 0 on a conforming tree. Frontmatter parsing is hand-rolled line scanning — no new dependencies.

Also: `skills/pr-babysit/SKILL.md` drops two dead lines (a `# All four in parallel:` comment restating the instruction above it, plus its spacer blank), 501 → 499, so the real tree passes the ceiling on merge.

## How it was built

Strict TDD, five RED→GREEN vertical slices through the CLI (each RED witnessed failing for the right reason) + one logged non-behavioral edit. Gates on the final tree: ruff format ✓, ruff check ✓, mypy --strict ✓, pytest -W error 41 passed. Reviewer: score 76, no critical findings. Critic: achieved (88). Production diff is 79 added lines against the owner-approved 80-line cap for this PR (raised from 60 mid-run: the fixed cost of the mandated style scaffolding made the original cap infeasible for the full scope — decision logged in the run JSONL).

Advisory (non-blocking) findings logged for follow-up: frontmatter tests assert offending paths but not message text; `_frontmatter` accepts an unterminated `---` fence (whole doc read as frontmatter); tests repeat a 15-line assertion block; `prompt_lint` not yet in the coverage `addopts` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mg7PpxEm95rrNBU7pqN49

<!-- pr-explain:begin -->
### What & why
Add `prompt_lint`: a command that walks the repo's prompt files and fails on any that break the house conventions. Until now nothing checked skills, agents, or rules — a typo'd key shipped silently. First of six PRs; PR 4 adds the CI wiring.

**Goals**
- `python -m prompt_lint` exits 0 on today's tree — run below
- a broken prompt prints `path:line: message` and exits 1
- a skill past 500 lines fails with its line count; `pr-babysit` cut to 499

**[Read the explainer](https://claude.ai/code/artifact/3f068f8c-8a26-437d-ba14-c1cff9a462bb)** · 6 files touched
<!-- pr-explain:end -->
