### PR TITLE
feat(scripts): prompt_lint cross-checks the prompt tree against installer/catalog.toml

### DIFF
--- a/scripts/prompt_lint/__main__.py
+++ b/scripts/prompt_lint/__main__.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from .catalog import cross_check_catalog
 from .checks import lint_tree
 
 
 def main() -> int:
     """Reports how the prompt tree at the current directory breaks its conventions."""
-    violations: list[str] = list(lint_tree(root=Path.cwd()))
+    root: Path = Path.cwd()
+    violations: list[str] = [*lint_tree(root=root), *cross_check_catalog(root=root)]
     for violation in violations:
         print(violation)
     return 1 if violations else 0

--- a/scripts/prompt_lint/catalog.py
+++ b/scripts/prompt_lint/catalog.py
@@ -1,0 +1,37 @@
+"""The prompts on disk, checked against the inventory the installer places them from."""
+
+from __future__ import annotations
+
+import tomllib
+from collections.abc import Iterator
+from pathlib import Path
+
+from .constants import CATALOG_PATH, MISSING_ROW, UNIT_PATHS, UNITS_TABLE
+
+
+def _registered_units(*, catalog: Path) -> frozenset[str]:
+    """The path every [[units]] row stands for, so parsed rows go no further."""
+    rows: list[dict[str, str]] = tomllib.loads(catalog.read_text()).get(UNITS_TABLE, [])
+    return frozenset(
+        path_template.format(name=row["name"])
+        for row in rows
+        # A row of a kind that lives outside the prompt tree registers no prompt.
+        if (path_template := UNIT_PATHS.get(row["kind"])) is not None
+    )
+
+
+def cross_check_catalog(*, root: Path) -> Iterator[str]:
+    """Every prompt under root the installer has no [[units]] row to place, one each.
+
+    A tree with no catalog is not a tree that lost its rows, so it reports nothing.
+    The diagnostic carries no line number — the missing row has no line to point at.
+    """
+    catalog: Path = root / CATALOG_PATH
+    if not catalog.is_file():
+        return
+    registered: frozenset[str] = _registered_units(catalog=catalog)
+    for path_template in UNIT_PATHS.values():
+        for unit in sorted(root.glob(path_template.format(name="*"))):
+            where: str = str(unit.relative_to(root))
+            if where not in registered:
+                yield f"{where}: {MISSING_ROW}"

--- a/scripts/prompt_lint/catalog.py
+++ b/scripts/prompt_lint/catalog.py
@@ -4,34 +4,49 @@ from __future__ import annotations
 
 import tomllib
 from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
 
-from .constants import CATALOG_PATH, MISSING_ROW, UNIT_PATHS, UNITS_TABLE
+from .constants import CATALOG_PATH, MISSING_ROW, STALE_ROW, UNIT_PATHS, UNITS_TABLE
 
 
-def _registered_units(*, catalog: Path) -> frozenset[str]:
-    """The path every [[units]] row stands for, so parsed rows go no further."""
+@dataclass(frozen=True, kw_only=True)
+class _RegisteredUnit:
+    """A [[units]] row, carrying the path in the prompt tree that it stands for."""
+
+    kind: str
+    name: str
+    path: str
+
+
+def _registered_units(*, catalog: Path) -> tuple[_RegisteredUnit, ...]:
+    """Every [[units]] row that stands for a prompt, so parsed rows go no further."""
     rows: list[dict[str, str]] = tomllib.loads(catalog.read_text()).get(UNITS_TABLE, [])
-    return frozenset(
-        path_template.format(name=row["name"])
+    return tuple(
+        _RegisteredUnit(
+            kind=row["kind"], name=row["name"], path=template.format(name=row["name"])
+        )
         for row in rows
         # A row of a kind that lives outside the prompt tree registers no prompt.
-        if (path_template := UNIT_PATHS.get(row["kind"])) is not None
+        if (template := UNIT_PATHS.get(row["kind"])) is not None
     )
 
 
 def cross_check_catalog(*, root: Path) -> Iterator[str]:
-    """Every prompt under root the installer has no [[units]] row to place, one each.
+    """Every prompt the catalog has no row for, and every row with no prompt on disk.
 
-    A tree with no catalog is not a tree that lost its rows, so it reports nothing.
-    The diagnostic carries no line number — the missing row has no line to point at.
+    A tree with no catalog is not a tree that lost its rows, so it reports nothing, and
+    neither diagnostic carries a line number — neither finding sits on a line.
     """
     catalog: Path = root / CATALOG_PATH
     if not catalog.is_file():
         return
-    registered: frozenset[str] = _registered_units(catalog=catalog)
+    registered: tuple[_RegisteredUnit, ...] = _registered_units(catalog=catalog)
+    known: frozenset[str] = frozenset(unit.path for unit in registered)
     for path_template in UNIT_PATHS.values():
-        for unit in sorted(root.glob(path_template.format(name="*"))):
-            where: str = str(unit.relative_to(root))
-            if where not in registered:
+        for prompt in sorted(root.glob(path_template.format(name="*"))):
+            if (where := str(prompt.relative_to(root))) not in known:
                 yield f"{where}: {MISSING_ROW}"
+    for unit in registered:
+        if not (root / unit.path).exists():
+            yield STALE_ROW.format(unit=f"{unit.kind}/{unit.name}", path=unit.path)

--- a/scripts/prompt_lint/catalog.py
+++ b/scripts/prompt_lint/catalog.py
@@ -4,26 +4,17 @@ from __future__ import annotations
 
 import tomllib
 from collections.abc import Iterator
-from dataclasses import dataclass
 from pathlib import Path
 
 from .constants import CATALOG_PATH, MISSING_ROW, STALE_ROW, UNIT_PATHS, UNITS_TABLE
+from .types import RegisteredUnit
 
 
-@dataclass(frozen=True, kw_only=True)
-class _RegisteredUnit:
-    """A [[units]] row, carrying the path in the prompt tree that it stands for."""
-
-    kind: str
-    name: str
-    path: str
-
-
-def _registered_units(*, catalog: Path) -> tuple[_RegisteredUnit, ...]:
+def _registered_units(*, catalog: Path) -> tuple[RegisteredUnit, ...]:
     """Every [[units]] row that stands for a prompt, so parsed rows go no further."""
     rows: list[dict[str, str]] = tomllib.loads(catalog.read_text()).get(UNITS_TABLE, [])
     return tuple(
-        _RegisteredUnit(
+        RegisteredUnit(
             kind=row["kind"], name=row["name"], path=template.format(name=row["name"])
         )
         for row in rows
@@ -41,7 +32,7 @@ def cross_check_catalog(*, root: Path) -> Iterator[str]:
     catalog: Path = root / CATALOG_PATH
     if not catalog.is_file():
         return
-    registered: tuple[_RegisteredUnit, ...] = _registered_units(catalog=catalog)
+    registered: tuple[RegisteredUnit, ...] = _registered_units(catalog=catalog)
     known: frozenset[str] = frozenset(unit.path for unit in registered)
     for path_template in UNIT_PATHS.values():
         for prompt in sorted(root.glob(path_template.format(name="*"))):

--- a/scripts/prompt_lint/constants.py
+++ b/scripts/prompt_lint/constants.py
@@ -20,6 +20,7 @@ REQUIRED_KEYS: Final[dict[str, tuple[str, ...]]] = {
 CATALOG_PATH: Final[str] = "installer/catalog.toml"
 UNITS_TABLE: Final[str] = "units"
 MISSING_ROW: Final[str] = f"no [[{UNITS_TABLE}]] row in {CATALOG_PATH}"
+STALE_ROW: Final[str] = f"{CATALOG_PATH}: unit {{unit}} has no prompt at {{path}}"
 
 # Where a unit of each kind sits in the tree — one row per kind, so a new kind is a row
 # here rather than another branch. Filled with a name it is the path a [[units]] row

--- a/scripts/prompt_lint/constants.py
+++ b/scripts/prompt_lint/constants.py
@@ -16,3 +16,16 @@ REQUIRED_KEYS: Final[dict[str, tuple[str, ...]]] = {
     "agents/*.md": ("name", "description", "tools", "model"),
     "rules/*.md": ("paths",),
 }
+
+CATALOG_PATH: Final[str] = "installer/catalog.toml"
+UNITS_TABLE: Final[str] = "units"
+MISSING_ROW: Final[str] = f"no [[{UNITS_TABLE}]] row in {CATALOG_PATH}"
+
+# Where a unit of each kind sits in the tree — one row per kind, so a new kind is a row
+# here rather than another branch. Filled with a name it is the path a [[units]] row
+# stands for; filled with '*' it is the glob that finds every unit of that kind.
+UNIT_PATHS: Final[dict[str, str]] = {
+    "skill": "skills/{name}",
+    "agent": "agents/{name}.md",
+    "rule": "rules/{name}.md",
+}

--- a/scripts/prompt_lint/types.py
+++ b/scripts/prompt_lint/types.py
@@ -1,0 +1,14 @@
+"""The vocabulary the checks speak: a catalog row resolved to the path it stands for."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, kw_only=True)
+class RegisteredUnit:
+    """A [[units]] row, carrying the path in the prompt tree that it stands for."""
+
+    kind: str
+    name: str
+    path: str

--- a/scripts/tests/test_prompt_lint.py
+++ b/scripts/tests/test_prompt_lint.py
@@ -284,3 +284,123 @@ def test_overlong_skill_is_reported_with_its_line_count(tmp_path: Path) -> None:
         assert conforming_path not in result.stdout, (
             f"{conforming_path} conforms but was reported: {result.stdout!r}"
         )
+
+
+# Where the installer keeps the inventory of units it can place; a catalog diagnostic
+# names it, since that is the file the reader has to edit to fix the finding.
+CATALOG: Final[str] = "installer/catalog.toml"
+
+# A skill is registered under the directory that names it, so the path a catalog row
+# stands for is the directory rather than the SKILL.md inside it.
+SKILL_FILE: Final[str] = "SKILL.md"
+
+# One prompt per kind that the catalog below does carry a row for. Every fixture in
+# this pair conforms to the frontmatter conventions, so the only finding either can
+# provoke is a catalog one.
+REGISTERED_PROMPTS: Final[dict[str, str]] = {
+    "skills/registered/SKILL.md": (
+        "---\n"
+        "name: registered\n"
+        "description: Use when the catalog already carries a row for a skill.\n"
+        "---\n"
+        "\n"
+        "# registered\n"
+        "\n"
+        "A skill the installer can place.\n"
+    ),
+    "agents/registered.md": (
+        "---\n"
+        "name: registered\n"
+        "description: Runs errands for a test fixture the catalog knows about.\n"
+        "tools: Read\n"
+        "model: opus\n"
+        "---\n"
+        "\n"
+        "# registered\n"
+    ),
+    "rules/registered.md": (
+        '---\npaths: "**/*.py"\n---\n\n# registered\n\nA rule with a row.\n'
+    ),
+}
+
+
+# The same three kinds with no row in the catalog — a skill directory, an agent file
+# and a rule file. All three reach the catalog by the same path, so one fixture spanning
+# the kinds pins the behaviour without a test per kind.
+UNREGISTERED_PROMPTS: Final[dict[str, str]] = {
+    "skills/orphan/SKILL.md": (
+        "---\n"
+        "name: orphan\n"
+        "description: Use when a skill exists on disk but nowhere in the catalog.\n"
+        "---\n"
+        "\n"
+        "# orphan\n"
+        "\n"
+        "A skill the installer cannot place.\n"
+    ),
+    "agents/orphan.md": (
+        "---\n"
+        "name: orphan\n"
+        "description: Answers to a name the installer's inventory never lists.\n"
+        "tools: Read\n"
+        "model: opus\n"
+        "---\n"
+        "\n"
+        "# orphan\n"
+    ),
+    "rules/orphan.md": (
+        '---\npaths: "**/*.md"\n---\n\n# orphan\n\nA rule the installer cannot place.\n'
+    ),
+}
+
+
+# A catalog whose [[units]] rows cover REGISTERED_PROMPTS and stop there, so the tree
+# holds both halves of the cross-check: three prompts with a row, three without.
+PARTIAL_CATALOG: Final[dict[str, str]] = {
+    CATALOG: (
+        "[[units]]\n"
+        'kind = "skill"\n'
+        'name = "registered"\n'
+        "\n"
+        "[[units]]\n"
+        'kind = "agent"\n'
+        'name = "registered"\n'
+        "\n"
+        "[[units]]\n"
+        'kind = "rule"\n'
+        'name = "registered"\n'
+    ),
+}
+
+
+def _unit_paths(*, prompts: Mapping[str, str]) -> list[str]:
+    """The path each prompt is registered under, which for a skill is its directory."""
+    return [
+        str(Path(prompt_path).parent)
+        if Path(prompt_path).name == SKILL_FILE
+        else prompt_path
+        for prompt_path in prompts
+    ]
+
+
+def test_prompt_without_a_units_row_is_reported_with_the_catalog(
+    tmp_path: Path,
+) -> None:
+    _write_prompts(root=tmp_path, prompts=REGISTERED_PROMPTS)
+    _write_prompts(root=tmp_path, prompts=UNREGISTERED_PROMPTS)
+    _write_prompts(root=tmp_path, prompts=PARTIAL_CATALOG)
+
+    result: subprocess.CompletedProcess[str] = _run_prompt_lint(root=tmp_path)
+
+    assert result.returncode == 1, (
+        f"expected a failing lint for the uncatalogued prompts: {result.stdout!r}"
+    )
+    reported_lines: list[str] = result.stdout.splitlines()
+    for unit_path in _unit_paths(prompts=UNREGISTERED_PROMPTS):
+        assert any(unit_path in line and CATALOG in line for line in reported_lines), (
+            f"{unit_path} has no [[units]] row unreported: {result.stdout!r}"
+        )
+    for unit_path in _unit_paths(prompts=REGISTERED_PROMPTS):
+        assert unit_path not in result.stdout, (
+            f"{unit_path} has a [[units]] row but was reported: {result.stdout!r}"
+        )

--- a/scripts/tests/test_prompt_lint.py
+++ b/scripts/tests/test_prompt_lint.py
@@ -12,6 +12,7 @@ import re
 import subprocess
 import sys
 from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
 
@@ -403,4 +404,73 @@ def test_prompt_without_a_units_row_is_reported_with_the_catalog(
     for unit_path in _unit_paths(prompts=REGISTERED_PROMPTS):
         assert unit_path not in result.stdout, (
             f"{unit_path} has a [[units]] row but was reported: {result.stdout!r}"
+        )
+
+
+@dataclass(frozen=True, kw_only=True)
+class _StaleRow:
+    """A [[units]] row and the path the installer would need on disk to place it."""
+
+    kind: str
+    name: str
+    missing_path: str
+
+
+# One row per prompt kind the tree holds no files for. The names share no prefix with
+# the registered ones, so a diagnostic naming a stale row cannot be read as naming a
+# row whose files are present.
+STALE_ROWS: Final[tuple[_StaleRow, ...]] = (
+    _StaleRow(kind="skill", name="vanished", missing_path="skills/vanished"),
+    _StaleRow(kind="agent", name="departed", missing_path="agents/departed.md"),
+    _StaleRow(kind="rule", name="retired", missing_path="rules/retired.md"),
+)
+
+# The installer also places hooks, and `hooks/` is no part of the prompt tree. A row of
+# that kind stands for no prompt path, so it can never go stale.
+HOOK_KIND: Final[str] = "hook"
+HOOK_NAME: Final[str] = "ruff-format"
+
+
+def _units_row(*, kind: str, name: str) -> str:
+    """The shape the catalog registers one unit in."""
+    return f'[[units]]\nkind = "{kind}"\nname = "{name}"\n'
+
+
+def _catalog_with_stale_rows() -> dict[str, str]:
+    """The rows for REGISTERED_PROMPTS, plus stale ones and one of a non-prompt kind."""
+    rows: list[str] = [
+        PARTIAL_CATALOG[CATALOG],
+        *(
+            _units_row(kind=stale_row.kind, name=stale_row.name)
+            for stale_row in STALE_ROWS
+        ),
+        _units_row(kind=HOOK_KIND, name=HOOK_NAME),
+    ]
+    return {CATALOG: "\n".join(rows)}
+
+
+def test_units_row_with_no_files_on_disk_is_reported_with_the_missing_path(
+    tmp_path: Path,
+) -> None:
+    _write_prompts(root=tmp_path, prompts=REGISTERED_PROMPTS)
+    _write_prompts(root=tmp_path, prompts=_catalog_with_stale_rows())
+
+    result: subprocess.CompletedProcess[str] = _run_prompt_lint(root=tmp_path)
+
+    assert result.returncode == 1, (
+        f"expected a failing lint for the stale [[units]] rows: {result.stdout!r}"
+    )
+    reported_lines: list[str] = result.stdout.splitlines()
+    for stale_row in STALE_ROWS:
+        unit: str = f"{stale_row.kind}/{stale_row.name}"
+        assert any(
+            CATALOG in line and unit in line and stale_row.missing_path in line
+            for line in reported_lines
+        ), f"the row for {unit} has no files unreported: {result.stdout!r}"
+    assert HOOK_NAME not in result.stdout, (
+        f"the {HOOK_KIND} row registers no prompt but was reported: {result.stdout!r}"
+    )
+    for unit_path in _unit_paths(prompts=REGISTERED_PROMPTS):
+        assert unit_path not in result.stdout, (
+            f"{unit_path} is on disk with a row but was reported: {result.stdout!r}"
         )


### PR DESCRIPTION
## What & why

A skill directory added to `skills/` without a `[[units]]` row in `installer/catalog.toml` is silently uninstallable — `./at validate` only checks that catalog refs resolve, never that the disk and the catalog agree, and nothing catches the reverse (a row whose files are gone).

This adds a **catalog cross-check in both directions** to `scripts/prompt_lint/`, run by the existing `python -m prompt_lint` entry point alongside PR 1's frontmatter checks (#176):

- every `skills/<name>/`, `agents/<name>.md`, `rules/<name>.md` has a `[[units]]` row of the matching kind;
- every `[[units]]` row of those kinds has its prompt on disk;
- rows of a kind outside the prompt tree (`hook`) are ignored, not errors.

```
skills/explain: no [[units]] row in installer/catalog.toml
installer/catalog.toml: unit skill/ghost has no prompt at skills/ghost
```

Additive by construction — a new `catalog.py` plus three lines of registration in `__main__.py`; `checks.py` is untouched, so PR 3 rebases cleanly.

## How it works

`constants.py` gains one row per kind (`UNIT_PATHS`), a path template that fills with a name for the catalog side and with `*` for the disk sweep — so a fourth prompt kind is a row, not a branch. `catalog.py` parses each `[[units]]` row into a frozen `_RegisteredUnit(kind, name, path)` at the boundary (stdlib `tomllib`; the installer package is never imported), then drives both directions off that one tuple. A tree with no `installer/catalog.toml` reports nothing.

## Tests

Both drive the real CLI as a subprocess over a fixture tree, the way a gate invokes it:

- `test_prompt_without_a_units_row_is_reported_with_the_catalog` — an unregistered skill dir, agent file and rule file are each named alongside the catalog; the registered ones are not.
- `test_units_row_with_no_files_on_disk_is_reported_with_the_missing_path` — a stale row per kind is named with its `<kind>/<name>` id and missing path; a `hook` row is not reported.

## Proof

```
$ cd scripts && uv run pytest -W error
43 passed in 0.46s
$ uv run ruff format --check . && uv run ruff check . && uv run mypy --strict .
22 files already formatted / All checks passed! / Success: no issues found in 22 source files

$ PYTHONPATH=scripts scripts/.venv/bin/python -m prompt_lint     # the real tree
$ echo $?
0
```

…and on a copy of the real tree with the `explain` row deleted and a ghost row added, exit 1 with exactly the two lines quoted above.

## Known trade-off

The production diff is **69 added lines against the spec's 60-line cap**. The remaining cuts were deleting the boundary-parse helper (leaking the raw TOML dict shape into the diagnostic function) or the frozen dataclass's docstring — both damage the rules the same spec makes binding, so this landed at the smallest honest size. Reviewer findings all scored below the blocking bar; the two worth a follow-up are the raw `KeyError` a malformed `[[units]]` row would raise, and the skill sweep globbing `skills/*` rather than `skills/*/SKILL.md`.

Part of the prompt-review plan; extends #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZ1fd6SJPCXnnVJgVTWfe9


<!-- pr-explain:begin -->
### What & why

Make `prompt_lint` compare the prompt tree with `installer/catalog.toml` in both directions. A skill dropped into `skills/` without a `[[units]]` row installs nowhere — and nothing caught it, because `at validate` only checks the rows it has.

**Goals**

- a prompt with no row fails the lint, naming the file to edit
- a row whose prompt is gone fails too, naming the missing path
- `hook` rows are ignored — the prompt tree holds no hooks
- the repo as it stands passes clean

**[Read the explainer](https://claude.ai/code/artifact/0c6bbef9-b3be-4ca6-aae7-57f1149d98b6)** · 5 files touched
<!-- pr-explain:end -->

