### PR TITLE
fix(skills): pr-explain verifies its diffs are editor-coloured before publishing

### DIFF
--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -289,6 +289,17 @@ The draft leaves Phase 4 only after both gates. Run them in order:
 - **The test list**: `.testlist` with a `.tfile` row per file and a `.trow` per test.
 - Screenshots and e2e output embed as `data:` URIs via `img.evidence`, each followed by
   its one-line `.evidence-cap` caption.
+- **Colour check, on the built file, before Phase 6.** An installed template that lags the
+  repo drops the syntax tokens silently, and every hunk renders as flat red and green — the
+  page still validates, so only these greps catch it:
+  - `grep -c -- --syn-kw <page>` → `0` means the template is stale. Rebuild from the repo's
+    `templates/pr-explain-page.html`; never hand-patch the built page.
+  - `grep -c tok- <page>` → every `.diff` block holding code carries at least one token span.
+    A block quoting prose (a Markdown file, a plain-text log) is the only allowed zero.
+  - `grep -n '\.diff \.\(add\|del\) {' <page>` → neither rule sets `color:`. Red and green
+    live in the line background and the `.sign` gutter, never on the code text.
+
+  Any one failing → fix it here. Publishing a flat diff is a failed run.
 
 ## Phase 6 — Publish
 
@@ -336,5 +347,6 @@ vs marked not-run; the proof verdict (sources used, or the ⚠ no-proof flag); s
 embedded, or the visual surface that shipped unseen and why (⚠); chapters
 emitted vs dropped (with the tiny-PR shrink reason if used); the PR whose teaser you
 updated; the mechanical gate result (coverage greps, Vale alerts fixed, or "vale
-unavailable — wc + grep only"); and the critic score — naming any dimension left under the
-bar when the page shipped flagged.
+unavailable — wc + grep only"); the colour check (tokens present, or the stale template you
+rebuilt from); and the critic score — naming any dimension left under the bar when the page
+shipped flagged.


### PR DESCRIPTION
### What & why

A published explainer is supposed to render its diff hunks like an editor: every token
in its own syntax colour, with the red and green carried by the line background and the
`+`/`−` gutter sign. Roughly 30 published pages were not doing that — the hunks were flat
red and green text, with no syntax highlighting at all.

The cause was not the template. `templates/pr-explain-page.html` has been correct since
da2c782; the *installed* copy under `~/.claude/at/` still had the pre-fix version, and the
skill built against that. Nothing noticed, because a page without syntax tokens is still
structurally valid — it passes every check the skill runs today.

Phase 5 already tells the builder to use `tok-kw` / `tok-fn` / `tok-str` / … spans. This
adds the step that confirms it actually happened, before Phase 6 publishes.

**Goals**

- catch a stale installed template at the point it does damage, not 30 pages later
- fail the run on a flat diff rather than publishing one
- keep the check mechanical — three greps, no judgement call

### The change

One file, `skills/pr-explain/SKILL.md` (+12 −3). A colour check at the end of Phase 5:

| Grep | Catches |
| --- | --- |
| `grep -c -- --syn-kw <page>` → `0` | the installed template lags the repo — rebuild from `templates/pr-explain-page.html`, never hand-patch the page |
| `grep -c tok- <page>` → `0` | the hunks are flat; a block quoting prose is the only allowed zero |
| `grep -n '\.diff \.\(add\|del\) {' <page>` sets `color:` | red/green landed on the code text instead of the line background and `.sign` |

The Report line now carries the colour-check result next to the other gate results.

### Proof

The greps were run against a real page from the bug and its repaired copy, so each one is
known to discriminate rather than merely to run:

```
=== FLAT page (the bug)
  --syn-kw: 0
  tok-:     0
  .diff .del { color: var(--red);   background: var(--red-soft);   … }
  .diff .add { color: var(--green); background: var(--green-soft); … }

=== FIXED page
  --syn-kw: 5
  tok-:     16
  .diff .del { background: var(--red-soft);   … }
  .diff .add { background: var(--green-soft); … }
```

The canonical template passes all three (`--syn-kw` ×5, neither rule sets `color:`).

Repo gates, run on this branch:

| Gate | Result |
| --- | --- |
| `./validate.sh` | 29 units, 8 packages, 2 bundles |
| `prompt_lint` | clean — SKILL.md 352 lines against the 500 cap |
| `scripts` suite | 41 passed |
| `installer` suite | 182 passed |

No screenshot: this changes a prompt, not a rendered surface. The rendering it protects is
evidenced by the grep output above.

### Not in this PR

The underlying reason the installed copy went stale — `~/.claude/at/` lagging the repo
until someone reinstalls — is a recurring problem that bit this skill and has bitten
make-pr before. This PR only makes the symptom loud at the point of use; detecting the
staleness itself belongs in the installer and wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSbBctmgeJhnLc4giXNPK2
