### PR TITLE
feat(size): register the gate everywhere the pipeline describes itself

### DIFF
--- a/agents/coder-lite.md
+++ b/agents/coder-lite.md
@@ -23,7 +23,10 @@ The skill's dispatch gives you:
 - in `fix` mode, the **specific blockers** to resolve (reviewer findings and/or critic gaps),
   verbatim;
 - the **base** ref, **target_cwd**, whether **dependencies are allowed** (and any named
-  dependency/version), and the absolute paths of the **rule files** to read.
+  dependency/version), and the absolute paths of the **rule files** to read;
+- the **size budget** — the counted-line target and caps this PR must land inside. Plan
+  slices to fit it; if the work genuinely cannot, return `blocked` rather than trim a
+  counted file to duck the gate.
 
 Run every repository command in `target_cwd`. Read **every** rule path the dispatch passed, in
 full, before writing code. If a rule path you need is missing from the dispatch, return `blocked`

--- a/docs/v1-workflow.md
+++ b/docs/v1-workflow.md
@@ -20,19 +20,22 @@ architect (the /make-pr skill, the driver)
   │                    reason)
   │
   ├─ gates      — uv run ruff/mypy/pytest · pnpm exec biome/tsc/vitest · cargo fmt/clippy/check/test  (hard fail, run first)
+  ├─ size gate  — python -m pr_size, counted lines        (hard fail over the cap)
+  ├─ size-judge — only in the grey zone                   (did it have to be this big?)
   ├─ reviewer   — quality + bugs + security on the diff   (is the code good?)
   └─ critic     — goal-fit on the task spec               (did it achieve the task?)
 
   → objective gates run before the judges; one batched fix round, then re-verify in proportion
     to the change (gates always; scoped re-review; critic only on behavioral change)
-  → done only when: all behaviors green, gates green, no CRITICAL, no unwaived review finding ≥70, critic=achieved
+  → done only when: all behaviors green, gates green, size gate pass (or judge acceptable),
+    no CRITICAL, no unwaived review finding ≥70, critic=achieved
 ```
 
 `architect` is a **skill** (now invoked as `/make-pr`) called explicitly in the main loop
 (`disable-model-invocation: true`, so it never auto-triggers), which lets it orchestrate,
 collect results, and loop.
-`worker-coder` (the GREEN/REFACTOR/non-behavioral coder), `tdd-runner`, `reviewer`, `critic`
-are **agents** (isolated, scope-locked workers it dispatches via the Agent tool).
+`worker-coder` (the GREEN/REFACTOR/non-behavioral coder), `tdd-runner`, `reviewer`, `critic`,
+`size-judge` are **agents** (isolated, scope-locked workers it dispatches via the Agent tool).
 
 ## Task contract
 
@@ -74,19 +77,22 @@ dependencies_allowed: false
 The workflow's pieces now live at the repo root (no longer under a `v1/` directory):
 
 - `skills/make-pr/SKILL.md` — the driver (this skill): orchestration loop, JSONL logging contract, decision rules
-- `agents/` — `worker-coder.md` (GREEN/REFACTOR/non-behavioral), `tdd-runner.md` (RED), `reviewer.md`, `critic.md`
-- `schemas/` — authoritative return-shape contracts the architect validates against (`_defs` + one per role)
-- `scripts/` — `validate_return.py`, `check_prompt_schemas.py`, plus pyproject/tests; run via `uv`
+- `agents/` — `worker-coder.md` (GREEN/REFACTOR/non-behavioral), `tdd-runner.md` (RED), `reviewer.md`, `critic.md`, `size-judge.md`
+- `schemas/` — authoritative shape contracts the architect validates against (`_defs` + one per role, plus the tool-output `size-report`)
+- `scripts/` — `validate_return.py`, `check_prompt_schemas.py`, `pr_size/` (the size gate), plus pyproject/tests; run via `uv`
 - `gates/` — declarative hard gates: `python.json`, `typescript.json`, `rust.json`
 - `rules/` — `design-principles.md`, `tdd.md`, `python.md`, `typescript.md`, `rust.md`; resolved by the architect via `rules_root` and shipped into each project's `.claude/rules/` by the installer
 - `runs/` — gitignored placeholder; real run logs go to `<target_cwd>/.v1-runs` (`run_root`)
 
-## How quality is enforced (two layers)
+## How quality is enforced (three layers)
 
 1. **Hard tooling gates** (`gates/*.json`) — objective, non-negotiable: format, lint,
    typecheck, tests. The architect runs these and will not declare done on a red gate.
-2. **Rules the agents read** (repo-root `rules/*.md`) — judgment the tools can't enforce: design
-   (deep modules, information hiding), readability (naming, comments), and test quality
+2. **The size gate** — the one hard gate that is not a `gates/*.json` profile:
+   `python -m pr_size` counts a change the way the policy counts it and answers
+   `pass` / `review` / `block`. Only `review` reaches the `size-judge` agent.
+3. **Rules the agents read** (repo-root `rules/*.md`) — judgment the tools can't enforce:
+   design (deep modules, information hiding), readability (naming, comments), and test quality
    (behavior through public interfaces). The reviewer holds the line on these.
 
 ## Return contracts
@@ -99,6 +105,9 @@ treats a failure as a malformed return. The ` ```json ` block shown in each agen
 same shape for the model to read; `scripts/check_prompt_schemas.py` (run via `uv run --no-project
 --with jsonschema python scripts/check_prompt_schemas.py`) validates each example against its
 schema and flags any omitted field, so a prompt edit can't silently add, rename, or drop a field.
+The size gate's own output has no prompt behind it, like `evidence.schema.json`:
+`schemas/size-report.schema.json` is guarded instead by a pytest that validates a real
+printed report against it.
 
 ## Gate contract
 

--- a/installer/catalog.toml
+++ b/installer/catalog.toml
@@ -89,6 +89,10 @@ name = "reviewer"
 
 [[units]]
 kind = "agent"
+name = "size-judge"
+
+[[units]]
+kind = "agent"
 name = "tdd-runner"
 
 [[units]]
@@ -135,24 +139,26 @@ units = [
   "skill/make-pr",
   "agent/tdd-runner",
   "agent/worker-coder",
+  "agent/size-judge",
   "agent/reviewer",
   "agent/critic",
   "rule/design-principles",
   "rule/tdd",
 ]
-extras = ["schemas", "gates", "scripts/validate_return.py", "rules"]
+extras = ["schemas", "gates", "scripts/validate_return.py", "scripts/pr_size", "rules"]
 
 [[packages]]
 name = "lite-pr"
 units = [
   "skill/make-pr-lite",
   "agent/coder-lite",
+  "agent/size-judge",
   "agent/reviewer",
   "agent/critic",
   "rule/design-principles",
   "rule/tdd",
 ]
-extras = ["schemas", "gates", "scripts/validate_return.py", "rules"]
+extras = ["schemas", "gates", "scripts/validate_return.py", "scripts/pr_size", "rules"]
 
 # improve-architecture audits a subsystem; its rubric is the canonical design-principles
 # rule, composed in via the rules extra rather than a bundled in-skill copy.

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -79,7 +79,9 @@ Resolve before the first dispatch:
   handoff (always under `<target_cwd>/.v1-runs/` — the path `/pr-explain` reads — even if
   run_root is overridden). Never write runtime state into `skill_root`.
 - **Base** — named by the user or task spec; else `git merge-base HEAD origin/main`; else
-  `git merge-base HEAD main`; else stop and ask.
+  `git merge-base HEAD main`; else stop and ask. Every gate diffs `base...HEAD`, so a
+  branch still carrying commits already squash-merged to main measures them again: at
+  intake, cherry-pick onto the target ref and re-resolve `base` against it.
 - **Run id** — the branch name or task id, `/` and whitespace → `_`.
 - **Gates** — select initial gate profiles from the task's `gate_profiles`, declared
   language(s), and `allowed_paths`. After workers change files, re-select from
@@ -87,16 +89,23 @@ Resolve before the first dispatch:
   of that profile's `triggers` globs in `~/.claude/at/gates/*.json` (the lists cover both
   root-level and nested forms). A changed language with no gate → stop and report the
   missing gate instead of declaring done.
+- **Size budget** — the PR may add **35 counted lines of code**; past that it must argue,
+  and past the caps in step 5's `block` row it cannot land; past 75 on 1–2 files it must name
+  the piece a split would break. Counted lines exclude tests, lockfiles, and generated or
+  vendored output; prose (`.md` and friends) has its own 100-line target. The tool at
+  `~/.claude/at/scripts/pr_size` — not your own count — decides. The budget is yours:
+  workers are scoped to one behavior and never see it.
 
 ## Tool boundaries
 
 - `Write`/`Edit` only for files under `<run_root>/` (contents per Runtime resolution).
   Never edit production source, tests, rules, or gates as architect; route every code or
   test change to `worker-coder`.
-- `Bash` only for: `git`, `date`, JSONL validation, the schema validator, re-running a
-  worker's reported verification (e.g. the named GREEN test), the task-provided baseline
-  command, and the selected gate `setup`/`run` commands — all in `target_cwd`. Never run
-  gate `fix` commands directly; route fixes to `worker-coder`.
+- `Bash` only for: `git`, `date`, JSONL validation, the schema validator, the size gate
+  command in step 5, re-running a worker's reported verification (e.g. the named GREEN
+  test), the task-provided baseline command, and the selected gate `setup`/`run` commands —
+  all in `target_cwd`. Never run gate `fix` commands directly; route fixes to
+  `worker-coder`.
 - `Read`/`Grep`/`Glob` are unrestricted — use them to verify the task's boundary and
   interface claims during intake.
 - Before **Done**, validate that the JSONL parses and its rows match the subagent calls,
@@ -117,10 +126,11 @@ Resolve before the first dispatch:
    failure.
 3. **Plan behaviors.** Per `tdd.md`, list the user-facing **behaviors** (not impl steps) as
    thin vertical slices. Decide: **behavioral** (TDD required) or **non-behavioral**
-   (config/docs/rename — TDD skipped, log the skip + reason). Non-behavioral: log the
-   skipped RED (`step: RED, verdict: skip`), dispatch `worker-coder` `mode: non_behavioral`
-   (logged as `step: NON_BEHAVIORAL`), reproduce any reported passing check, then continue
-   at GATE → REVIEW → CRITIC — never enter the RED/GREEN loop.
+   (config/docs/rename — TDD skipped, log the skip + reason). **Size the plan here**: stop
+   for re-scope now if the behaviors together head past a cap (step 5's `block` row).
+   Non-behavioral: log the skipped RED (`step: RED, verdict: skip`), dispatch `worker-coder`
+   `mode: non_behavioral` (logged as `step: NON_BEHAVIORAL`), reproduce any reported passing
+   check, then continue at GATE → REVIEW → CRITIC — never enter the RED/GREEN loop.
 4. **Per behavior, in order:**
    a. **RED** → dispatch `tdd-runner`. Require `"status":"red"` and `"right_reason":true`;
       else re-dispatch with feedback — max 3 RED dispatches per behavior (each a fresh
@@ -185,10 +195,11 @@ Resolve before the first dispatch:
      always blocks), unless the human explicitly waived it in the run log (logged
      `step: REVIEW, verdict: skip, note: "waived by human: <finding>"`);
    - any critic verdict of `not_achieved` or `partial`, with its gaps.
-   **Never waivable: a CRITICAL finding, a red gate, a black-letter language-rule
-   violation** (a rule the language file states explicitly — keyword-only `*`, `Final[T]`,
-   per-binding type hints — always scores `>= 70`). Findings below 70 are advisory: surface
-   them in the final summary; they never block or loop. No blockers → **Done**.
+   **Never waivable: a CRITICAL finding, a red gate, a size-gate `block` or judge `split`,
+   a black-letter language-rule violation** (a rule the language file states explicitly —
+   keyword-only `*`, `Final[T]`, per-binding type hints — always scores `>= 70`). Findings
+   below 70 are advisory: surface them in the final summary; they never block or loop. No
+   blockers → **Done**.
 7. **Fix once, re-verify in proportion.** Capture `git rev-parse HEAD` as `<pre_fix>`, then
    route all blockers back as **one batched fix round** (never finding-by-finding):
    - a **behavioral** gap (missing behavior; a wrong RED test — bad assertion,
@@ -197,19 +208,21 @@ Resolve before the first dispatch:
    - a **mechanical or design** fix goes to `worker-coder` directly
      (`mode: non_behavioral` for format/lint/type/rename; `mode: refactor` for a
      behavior-preserving restructure).
-   Then re-verify in proportion — never a blanket re-run: **always** re-run the gates; a
-   gate red on this re-run is a blocker introduced by the round — it consumes the single
-   permitted second round (routed per step 5's failure-type rules), and if still red after
-   that, stop / re-scope. Re-review **only** `git diff <pre_fix>...HEAD` with `reviewer` — a
-   scoped re-review cannot re-litigate approved code. Re-run `critic` **only if** the fix
-   changed behavior or coverage. One fix round; a second only if round 1 introduced a new
-   blocker. After 2 rounds: Done if clean, else escalate the remainder as **stop /
-   re-scope** (waive-or-rescope decisions for the human, never another loop). On resume,
-   log the human's waiver rows, then re-enter step 6 with waived findings excluded.
-8. **Done** → only when: all behaviors green, all gates green, no unwaived blocker per step
-   6's waivability rule, critic `achieved`, and any step-7 fix re-verified per the
-   proportional rule. Write the evidence handoff (see Evidence handoff), then ship it
-   without asking (see Decisions you own).
+   Then re-verify in proportion — never a blanket re-run: **always** re-run the gates,
+   **including the size gate**, run with the run's `base` and routed through step 5's table
+   — an earlier `acceptable` does not carry to a changed diff. A language gate red on this
+   re-run is a blocker introduced by the round — it consumes the single permitted second
+   round (routed per step 5's failure-type rules), and if still red after that, stop /
+   re-scope. Re-review **only** `git diff <pre_fix>...HEAD` with `reviewer` — a scoped
+   re-review cannot re-litigate approved code. Re-run `critic` **only if** the fix changed
+   behavior or coverage. One fix round; a second only if round 1 introduced a new blocker.
+   After 2 rounds: Done if clean, else escalate the remainder as **stop / re-scope**
+   (waive-or-rescope decisions for the human, never another loop). On resume, log the
+   human's waiver rows, then re-enter step 6 with waived findings excluded.
+8. **Done** → only when: all behaviors green, all gates green, the size gate `pass` or its
+   judge `acceptable`, no unwaived blocker per step 6's waivability rule, critic `achieved`,
+   and any step-7 fix re-verified per the proportional rule. Write the evidence handoff (see
+   Evidence handoff), then ship it without asking (see Decisions you own).
 
 ## JSONL logging contract (mandatory)
 
@@ -218,8 +231,8 @@ Append **one line per subagent call, TDD skip, gate run, and human waiver** to `
 create nested paths. Schema:
 
 ```json
-{"ts":"<ISO8601>","run":"<run-id>","step":"RED|GREEN|REFACTOR|NON_BEHAVIORAL|GATE|REVIEW|CRITIC",
- "role":"tdd-runner|coder|reviewer|critic|architect","prompt":"<full prompt you sent>",
+{"ts":"<ISO8601>","run":"<run-id>","step":"RED|GREEN|REFACTOR|NON_BEHAVIORAL|GATE|SIZE|REVIEW|CRITIC",
+ "role":"tdd-runner|coder|size-judge|reviewer|critic|architect","prompt":"<full prompt you sent>",
  "result":"<full agent return>","verdict":"pass|fail|skip","files":["<changed paths>"],
  "note":"<e.g. TDD skip reason, retry #, decision made>"}
 ```
@@ -229,7 +242,9 @@ pretty-printing; JSON-escape prompts and results — never hand-build strings co
 newlines or quotes. A skipped TDD step:
 `"step":"RED","verdict":"skip","note":"non-behavioral: <reason>"`. `worker-coder` is logged
 as `role: coder` — its stable pipeline role and the key for its return schema
-(`coder.schema.json`).
+(`coder.schema.json`). A size `pass`, or a `review` the judge called `acceptable`, logs as
+`pass`; `block`, `split`, `unmeasured`, and a run the gate could not measure log as
+`fail`, with the gate's own word in `note`.
 
 Example rows — a GREEN dispatch and a non-behavioral skip:
 
@@ -255,7 +270,9 @@ in your JSONL log and the agents' returns, never new claims:
   derivable). Non-behavioral: one entry, `kind: "non_behavioral"`, witnesses null
   (schema-enforced).
 - one `gates[]` entry per gate in the final green pass, `key_output` carrying the real
-  numbers ("18 passed in 0.42s"), never a summary.
+  numbers ("18 passed in 0.42s"), never a summary — including the size gate as
+  `name: "size"` with its `cmd`, the tool's own `exit_code` (0, or 1 when the judge
+  returned `acceptable`), and the report's `summary` line.
 - `runtime`: paths relative to the evidence dir of any runtime evidence (screenshots, e2e
   transcripts) you copy into `<run_root>/evidence/<branch-slug>/runtime/`; `[]` when none.
 


### PR DESCRIPTION
The gate and its judge exist; this is the rest of the system agreeing that they do.

- **`installer/catalog.toml`** registers `size-judge` as a unit and stages `scripts/pr_size` as an extra of both PR packages, so an install carries the gate it is told to run.
- **`docs/v1-workflow.md`** adds both to the pipeline diagram and the agent/script rosters, and names the size gate as the one hard enforcement layer that is *not* a `gates/*.json` profile — its report schema guarded by a pytest rather than the prompt-example check.
- **`agents/coder-lite.md`** declares the size budget as an input, since make-pr-lite's build dispatch now passes it.
- **make-pr's loop** is made to respect the gate throughout: budget and base notes at intake, the tool in the `Bash` allowlist, plan-time sizing at step 3, a `block` or judge `split` on the never-waivable list, the gate re-run in the fix round, the Done predicate, the `SIZE` JSONL rows and their verdict mapping, and the size run in the evidence handoff.

`gate: PASS — code 8 lines / 1 file; prose 71 (target 100)`