### PR TITLE
fix(size): a line git cannot decode is still a line

### DIFF
--- a/scripts/pr_size/cli.py
+++ b/scripts/pr_size/cli.py
@@ -30,9 +30,20 @@ from .types import CommandRunner, SizeError, SizeReport
 
 
 def _subprocess_runner(*, argv: tuple[str, ...]) -> str:
-    """The real boundary: run a command, returning stdout, SizeError on failure."""
+    """The real boundary: run a command, returning stdout, SizeError on failure.
+
+    Git speaks UTF-8 whatever the caller's locale is, and a byte that is not is
+    replaced rather than raised: a line the policy counts is not made uncountable by
+    how it is spelled, and a decode error the caller reads as a verdict is worse than
+    one U+FFFD in a path.
+    """
     result: subprocess.CompletedProcess[str] = subprocess.run(
-        argv, capture_output=True, text=True, check=False
+        argv,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
     )
     if result.returncode != 0:
         detail: str = result.stderr.strip() or result.stdout.strip()
@@ -80,7 +91,7 @@ def run_cli(
             repo=repo,
             run=run if run is not None else _subprocess_runner,
         )
-    except (SizeError, OSError) as error:
+    except (SizeError, OSError, UnicodeError) as error:
         print(f"error: {error}", file=sys.stderr)
         return EXIT_ERROR
     payload: dict[str, Any] = {

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -8,6 +8,7 @@ and the shell through an injected fake runner — never a real git.
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import Final
 
@@ -308,6 +309,20 @@ def test_an_unmeasurable_change_exits_non_zero_without_a_verdict(
     assert capsys.readouterr().out == ""
 
 
+def test_a_path_the_locale_cannot_encode_exits_without_a_verdict(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An ASCII locale cannot put a non-ASCII path in git's argv — not a verdict."""
+
+    def explode(*, argv: tuple[str, ...]) -> str:
+        raise UnicodeEncodeError("ascii", argv[-1], 0, 1, "ordinal not in range(128)")
+
+    exit_code: int = run_cli(base="HEAD~1", head="HEAD", repo=".", run=explode)
+
+    assert exit_code not in {0, 1, 2}
+    assert capsys.readouterr().out == ""
+
+
 def test_an_added_line_that_looks_like_a_header_is_still_counted() -> None:
     """git renders an added line `++ x` as `+++ x`; only a paired header ends a file."""
     diff_text: str = (
@@ -511,3 +526,32 @@ def test_click_command_requires_a_base() -> None:
 
     assert result.exit_code == 2
     assert "--base" in result.output
+
+
+def test_a_line_git_cannot_decode_still_counts(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A latin-1 line is still a line — decoding must not cost the gate its verdict."""
+    repo: Path = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "--allow-empty", "-m", "base"], cwd=repo, check=True
+    )
+    (repo / "latin1.txt").write_bytes(b"caf\xe9 not utf-8\n")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add latin-1"], cwd=repo, check=True)
+
+    code: int = run_cli(base="HEAD~1", head="HEAD", repo=str(repo))
+
+    assert code == 0
+    payload: dict[str, object] = json.loads(capsys.readouterr().out)
+    assert payload["code"] == {
+        "files": 1,
+        "lines": 1,
+        "target": 35,
+        "cap": 100,
+        "band": "target",
+        "verdict": "pass",
+    }


### PR DESCRIPTION
Fourteenth slice of the PR-size gate (#147, split).

The gate shells out to `git diff` with `text=True`, which decodes as strict
UTF-8. One latin-1 byte anywhere in the diff — an accented name in a comment, a
smart quote pasted from a doc — raised `UnicodeDecodeError` out of
`subprocess.run`. `run_cli` catches `SizeError` and `OSError`, not that, so the
gate printed a traceback, no JSON, and **exit 1** — the same code as a `review`
verdict. A caller routing on the exit code would have read an unmeasured change
as one merely awaiting a judge.

Decoding with `errors="replace"` counts the line instead of losing it: the byte
is not what the policy measures, so this is one less error to handle rather
than one more. The gate's own contract — "exit codes are the verdict … an
unmeasured change never reads as a passing one" — is intact because there is
now nothing unmeasured.

Found by the review cycle's contract lens, which reproduced it on a synthetic
repo rather than reading the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqEKDtKAb2BVTJVNZt1Z1U