### PR TITLE
fix(size): read the path git actually printed

### DIFF
--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -3,11 +3,29 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Final
 
 # The unified diff we ask git for: the post-image path marker, and the hunk header we
 # read new-file line numbers from.
-NEW_PATH_MARKER: Final[str] = "+++ b/"
+POST_IMAGE_MARKER: Final[str] = "+++ "
+NEW_PATH_PREFIX: Final[str] = "b/"
+QUOTED_PATH_MARKER: Final[str] = '"'
+ESCAPE_MARKER: Final[str] = "\\"
+C_ESCAPES: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "a": "\a",
+        "b": "\b",
+        "f": "\f",
+        "n": "\n",
+        "r": "\r",
+        "t": "\t",
+        "v": "\v",
+        '"': '"',
+        "\\": "\\",
+    }
+)
 PRE_IMAGE_MARKER: Final[str] = "--- "
 FILE_BLOCK_MARKER: Final[str] = "diff --git "
 DELETED_POST_IMAGE: Final[str] = "+++ /dev/null"
@@ -81,8 +99,9 @@ PROSE_CAP_LINES: Final[int] = 150
 
 # How the shell talks to git. `--unified=0` keeps the parse honest (no context line can
 # be mistaken for an addition); `core.quotePath=false` keeps non-ASCII paths readable
-# rather than octal-escaped; the two prefix settings override a user config that would
-# drop or rename the `a/`+`b/` prefixes the header parse keys on.
+# rather than octal-escaped, though a path holding a quote, a backslash or a control
+# character is C-quoted whatever it says; the two prefix settings override a user config
+# that would drop or rename the `a/`+`b/` prefixes the header parse keys on.
 GIT_DIFF_FLAGS: Final[tuple[str, ...]] = (
     "-c",
     "core.quotePath=false",

--- a/scripts/pr_size/sizing.py
+++ b/scripts/pr_size/sizing.py
@@ -9,16 +9,20 @@ from pathlib import PurePosixPath
 
 from .constants import (
     ADDED_LINE_MARKER,
+    C_ESCAPES,
     CONTEXT_LINE_MARKER,
     DELETED_POST_IMAGE,
+    ESCAPE_MARKER,
     FILE_BLOCK_MARKER,
     GENERATED_BASENAME,
     GENERATED_DIR_SEGMENTS,
     HUNK_HEADER,
     INLINE_TEST_SUFFIXES,
-    NEW_PATH_MARKER,
+    NEW_PATH_PREFIX,
+    POST_IMAGE_MARKER,
     PRE_IMAGE_MARKER,
     PROSE_SUFFIXES,
+    QUOTED_PATH_MARKER,
     RUST_ITEM_START,
     RUST_LITERAL_OR_COMMENT,
     RUST_TEST_ATTRIBUTE,
@@ -33,8 +37,8 @@ def changed_files(
 ) -> tuple[ChangedFile, ...]:
     """Every path the diff adds to, classified, with the lines it gained.
 
-    A modified file that only lost lines is here with zero; a deletion, a pure rename
-    and a binary are absent — none of them is anything to read.
+    A modified file that only lost lines is here with zero; a deletion, a pure rename,
+    a mode-only change and a binary are absent — none of them is anything to read.
 
     `sources` carries the post-image content of files whose tests live inside them
     (Rust); a file absent from it is charged entirely by its path, which can only
@@ -138,6 +142,45 @@ def classify(*, path: str) -> FileKind:
     return FileKind.CODE
 
 
+def _unquote(*, quoted: str) -> str:
+    """A C-quoted path's real characters — its escapes stand for bytes, not text.
+
+    git escapes `"`, `\\` and the control characters by name, and any other byte it
+    chooses to hide as three octal digits. Both denote bytes of a UTF-8 sequence, so
+    they are rebuilt as bytes and decoded once, not mapped character by character.
+    """
+    raw: bytearray = bytearray()
+    index: int = 0
+    while index < len(quoted):
+        if quoted[index] != ESCAPE_MARKER:
+            raw += quoted[index].encode("utf-8")
+            index += 1
+        elif quoted[index + 1 : index + 2] in C_ESCAPES:
+            raw += C_ESCAPES[quoted[index + 1]].encode("utf-8")
+            index += 2
+        else:
+            raw.append(int(quoted[index + 1 : index + 4], 8))
+            index += 4
+    return raw.decode("utf-8", "replace")
+
+
+def _post_image_path(*, line: str) -> str | None:
+    """The path a `+++` header names, however git spelled it, or None.
+
+    Two spellings compose: git pads a path holding a space with a trailing TAB, and
+    C-quotes the whole `b/<path>` when it holds a quote, a backslash or a control
+    character — neither of which `core.quotePath=false` turns off. Read as-is, the pad
+    misfiles the path by its suffix and the quotes stop the line being read as a header
+    at all, so the block's lines are charged to the file before it.
+    """
+    rest: str = line.removeprefix(POST_IMAGE_MARKER).removesuffix("\t")
+    if rest.startswith(QUOTED_PATH_MARKER) and rest.endswith(QUOTED_PATH_MARKER):
+        rest = _unquote(quoted=rest[1:-1])
+    return (
+        rest.removeprefix(NEW_PATH_PREFIX) if rest.startswith(NEW_PATH_PREFIX) else None
+    )
+
+
 def added_line_numbers(*, diff_text: str) -> dict[str, tuple[int, ...]]:
     """Which post-image line numbers each changed path gained, keyed by that path.
 
@@ -158,15 +201,18 @@ def added_line_numbers(*, diff_text: str) -> dict[str, tuple[int, ...]]:
         # `diff --git` line with no header seen since.
         if line.startswith(FILE_BLOCK_MARKER):
             awaiting_header = True
+        named: str | None = (
+            _post_image_path(line=line) if line.startswith(POST_IMAGE_MARKER) else None
+        )
         is_header: bool = (
             awaiting_header
             and previous.startswith(PRE_IMAGE_MARKER)
-            and (line.startswith(NEW_PATH_MARKER) or line == DELETED_POST_IMAGE)
+            and (named is not None or line == DELETED_POST_IMAGE)
         )
         awaiting_header = awaiting_header and not is_header
         previous = line
-        if is_header and line.startswith(NEW_PATH_MARKER):
-            path = line.removeprefix(NEW_PATH_MARKER)
+        if is_header and named is not None:
+            path = named
             added.setdefault(path, [])
         elif is_header:
             # A post-image we cannot attribute — `+++ /dev/null`, a deletion. Charge

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -555,3 +555,79 @@ def test_a_line_git_cannot_decode_still_counts(
         "band": "target",
         "verdict": "pass",
     }
+
+
+def test_a_path_with_a_space_keeps_its_own_suffix() -> None:
+    """git pads such a post-image with a TAB; the suffix decides the budget class."""
+    diff_text: str = (
+        "diff --git a/my docs/read me.md b/my docs/read me.md\n"
+        "--- /dev/null\n"
+        "+++ b/my docs/read me.md\t\n"
+        "@@ -0,0 +1 @@\n"
+        "+one\n"
+    )
+
+    files: tuple[ChangedFile, ...] = changed_files(diff_text=diff_text)
+
+    assert files == (
+        ChangedFile(
+            path="my docs/read me.md", kind=FileKind.PROSE, lines=1, test_lines=0
+        ),
+    )
+
+
+def test_a_quoted_path_is_its_own_file() -> None:
+    """git C-quotes a path holding `"`; unread, its lines fall to the file before it."""
+    diff_text: str = (
+        "diff --git a/plain.py b/plain.py\n"
+        "--- /dev/null\n"
+        "+++ b/plain.py\n"
+        "@@ -0,0 +1 @@\n"
+        "+a = 1\n"
+        'diff --git "a/has\\"quote.py" "b/has\\"quote.py"\n'
+        "--- /dev/null\n"
+        '+++ "b/has\\"quote.py"\n'
+        "@@ -0,0 +1 @@\n"
+        "+b = 2\n"
+    )
+
+    files: tuple[ChangedFile, ...] = changed_files(diff_text=diff_text)
+
+    assert [(file.path, file.lines) for file in files] == [
+        ("plain.py", 1),
+        ('has"quote.py', 1),
+    ]
+
+
+def test_a_quoted_path_can_also_be_tab_padded() -> None:
+    """git quotes AND pads when a path holds both a quote and a space."""
+    diff_text: str = (
+        'diff --git "a/guide for \\"v2\\".md" "b/guide for \\"v2\\".md"\n'
+        "--- /dev/null\n"
+        '+++ "b/guide for \\"v2\\".md"\t\n'
+        "@@ -0,0 +1 @@\n"
+        "+one\n"
+    )
+
+    files: tuple[ChangedFile, ...] = changed_files(diff_text=diff_text)
+
+    assert files == (
+        ChangedFile(
+            path='guide for "v2".md', kind=FileKind.PROSE, lines=1, test_lines=0
+        ),
+    )
+
+
+def test_a_quoted_path_keeps_characters_latin_1_cannot_hold() -> None:
+    """The escapes are ASCII; the bytes around them are UTF-8 and must survive."""
+    diff_text: str = (
+        'diff --git "a/中\\"文.py" "b/中\\"文.py"\n'
+        "--- /dev/null\n"
+        '+++ "b/中\\"文.py"\n'
+        "@@ -0,0 +1 @@\n"
+        "+x = 1\n"
+    )
+
+    files: tuple[ChangedFile, ...] = changed_files(diff_text=diff_text)
+
+    assert [file.path for file in files] == ['中"文.py']


### PR DESCRIPTION
Fifteenth slice of the PR-size gate (#147, split).

Two spellings of a post-image path the header parse did not know, both found by
the review cycle's contract lens on synthetic repos.

**A space in the path.** git pads such a header with a trailing TAB —
`+++ b/my docs/read me.md\t` — and the parser kept it. `read me.md\t` has the
suffix `.md\t`, so a docs change was charged to the **code** budget against a
cap of 50 rather than prose against 150; a `-lock.json` or `_test.py` under a
directory with a space stopped being excluded for the same reason.

**A quote in the path.** git C-quotes the whole `b/<path>` when it holds a
quote, a backslash or a control character, whatever `core.quotePath=false`
says: `+++ "b/has\"quote.py"`. That does not start with `+++ b/`, so it was not
a header at all — the block's lines were charged to the file before it, and the
file itself never appeared. Three one-line files measured as two. Losing a file
from the count is the dangerous half: at three files the cap is 50, at two it
is 100.

`_post_image_path` now reads both spellings, so the two markers it replaces are
`POST_IMAGE_MARKER` + `NEW_PATH_PREFIX` rather than one fused `"+++ b/"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqEKDtKAb2BVTJVNZt1Z1U