### PR TITLE
fix(size): the diff is git's, not a user's diff driver

### DIFF
--- a/scripts/pr_size/constants.py
+++ b/scripts/pr_size/constants.py
@@ -98,10 +98,15 @@ PROSE_TARGET_LINES: Final[int] = 100
 PROSE_CAP_LINES: Final[int] = 150
 
 # How the shell talks to git. `--unified=0` keeps the parse honest (no context line can
-# be mistaken for an addition); `core.quotePath=false` keeps non-ASCII paths readable
+# be mistaken for an addition); the `diff.external`/`--no-ext-diff`/`--no-textconv`
+# settings refuse a user's diff driver, which would otherwise hand us its output — or
+# nothing — in place of the diff (a `.gitattributes` `-diff` path is the one dodge left:
+# git renders it as binary and the gate counts nothing, which review has to catch);
+# `core.quotePath=false` keeps non-ASCII paths readable
 # rather than octal-escaped, though a path holding a quote, a backslash or a control
 # character is C-quoted whatever it says; the two prefix settings override a user config
-# that would drop or rename the `a/`+`b/` prefixes the header parse keys on.
+# that would drop or rename the `a/`+`b/` prefixes the header parse keys on, including
+# the `diff.srcPrefix`/`diff.dstPrefix` pair git 2.45 added.
 GIT_DIFF_FLAGS: Final[tuple[str, ...]] = (
     "-c",
     "core.quotePath=false",
@@ -109,9 +114,17 @@ GIT_DIFF_FLAGS: Final[tuple[str, ...]] = (
     "diff.noprefix=false",
     "-c",
     "diff.mnemonicPrefix=false",
+    "-c",
+    "diff.srcPrefix=a/",
+    "-c",
+    "diff.dstPrefix=b/",
+    "-c",
+    "diff.external=",
     "diff",
     "--unified=0",
     "--no-color",
+    "--no-textconv",
+    "--no-ext-diff",
     "--find-renames",
 )
 

--- a/scripts/tests/test_pr_size.py
+++ b/scripts/tests/test_pr_size.py
@@ -26,6 +26,7 @@ from pr_size import (
     measure,
 )
 from pr_size.cli import cli, report_for, run_cli
+from pr_size.constants import GIT_DIFF_FLAGS
 from pr_size.policy import code_budget
 from pr_size.sizing import classify
 from validate_return import errors_against
@@ -631,3 +632,17 @@ def test_a_quoted_path_keeps_characters_latin_1_cannot_hold() -> None:
     files: tuple[ChangedFile, ...] = changed_files(diff_text=diff_text)
 
     assert [file.path for file in files] == ['中"文.py']
+
+
+def test_the_gate_asks_git_for_a_diff_no_local_config_can_reshape() -> None:
+    """Each pin closed a silent under-count; a dropped one reopens it, not a test."""
+    assert set(GIT_DIFF_FLAGS) >= {
+        "core.quotePath=false",
+        "diff.noprefix=false",
+        "diff.mnemonicPrefix=false",
+        "diff.srcPrefix=a/",
+        "diff.dstPrefix=b/",
+        "diff.external=",
+        "--no-textconv",
+        "--no-ext-diff",
+    }


### PR DESCRIPTION
Sixteenth slice of the PR-size gate (#147, split).

Three ways a local git config made the gate report a size the change did not
have — all of them silent, all exit 0.

**`diff.external` and `GIT_EXTERNAL_DIFF`** hand the diff to a user's own
program, whose output the parse does not recognize. A twelve-line change read
as `"files": [], "lines": 0, "verdict": "pass"`.

**A `.gitattributes` `textconv`** counts the converted text rather than the
file: a forty-line addition behind `textconv = head -3` measured as seven
lines.

**`diff.srcPrefix`/`diff.dstPrefix`** (git 2.45) rename the `a/`+`b/` prefixes
the header parse keys on. The two prefix settings already pinned are the older
pair, so `dstPrefix=w/` made every post-image header unreadable — again 0
files, again `pass`.

`--no-ext-diff`, `--no-textconv`, `diff.external=` and the two prefix pins
close all three, and a test asserts the set so a future edit cannot quietly
drop one. A gate that under-counts is worse than one that fails, because a PR
lands on the strength of it.

One dodge is left and is named where the flags are: a path marked `-diff` in
`.gitattributes` is rendered as binary, so the gate counts nothing for it. That
takes a visible edit to a counted file, which is review's to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqEKDtKAb2BVTJVNZt1Z1U
