### PR TITLE
ci: run the prompt checker on prompt-path PRs (PR 4)

### DIFF
--- a/.github/workflows/prompt-lint.yml
+++ b/.github/workflows/prompt-lint.yml
@@ -1,0 +1,60 @@
+name: prompt-lint
+
+# CI for the prompt tree — skills/, agents/, rules/, and the CLAUDE.md template — which no
+# workflow watched before. `Lint the prompt tree` runs scripts/prompt_lint from the repo root
+# exactly as the package documents it (the checker reads the tree at the cwd), and
+# `Checker tests` runs the scripts/ suite so a change to the checker itself cannot regress it
+# silently. installer.yml is the sibling workflow for installer/; keep the checkout and uv
+# setup steps in sync with it.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - "agents/**"
+      - "rules/**"
+      - "templates/CLAUDE.md.template"
+      # The inputs the checks read, and the checker itself: catalog.toml drives the
+      # unit/extras cross-check, schemas/ the agent-example drift check, and scripts/ holds
+      # both prompt_lint and the suite the second step runs.
+      - "installer/catalog.toml"
+      - "schemas/**"
+      - "scripts/**"
+      - ".github/workflows/prompt-lint.yml"
+  pull_request:
+    paths:
+      - "skills/**"
+      - "agents/**"
+      - "rules/**"
+      - "templates/CLAUDE.md.template"
+      - "installer/catalog.toml"
+      - "schemas/**"
+      - "scripts/**"
+      - ".github/workflows/prompt-lint.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: scripts/uv.lock
+      - name: Sync dependencies
+        run: uv sync --frozen --project scripts
+      - name: Lint the prompt tree
+        run: PYTHONPATH=scripts uv run --project scripts python -m prompt_lint
+      - name: Checker tests
+        working-directory: scripts
+        run: uv run pytest


### PR DESCRIPTION
PR 4 of the prompt-review plan. PRs 1–3 (#176, #177, #179) built `scripts/prompt_lint`; nothing ran it. Editing `skills/**`, `agents/**`, or `rules/**` triggered zero CI — the repo's only workflow, `installer.yml`, watches `installer/**` and the root shims.

## What lands

One new file, `.github/workflows/prompt-lint.yml` (+60 lines). Nothing else changes — no `scripts/`, no prompts.

```yaml
- name: Sync dependencies
  run: uv sync --frozen --project scripts
- name: Lint the prompt tree
  run: PYTHONPATH=scripts uv run --project scripts python -m prompt_lint
- name: Checker tests
  working-directory: scripts
  run: uv run pytest
```

- **Triggers** (`pull_request` + push to `main`): `skills/**`, `agents/**`, `rules/**`, `templates/CLAUDE.md.template`, the inputs the checks read (`installer/catalog.toml`, `schemas/**`), `scripts/**`, and this workflow file. This PR is therefore checked by the workflow it adds.
- **Lint the prompt tree** runs the checker from the repo root — `__main__.py` lints `Path.cwd()`, so cwd must be the tree — with `--project scripts` resolving the uv env, since there is no repo-root `pyproject.toml`. Non-zero exit fails the job.
- **Checker tests** runs `scripts/tests/` (47 tests), which ran in no workflow until now, so a change to the checker can't regress it silently.
- Checkout and uv setup mirror `installer.yml`: `actions/checkout@v4`, `astral-sh/setup-uv@v5` with `enable-cache` and a `cache-dependency-glob` on the lockfile, same `permissions`/`concurrency` blocks, same lowercase job name.

## Proof

All three of the workflow's steps, run locally on this commit from the repo root:

```
$ uv sync --frozen --project scripts
Checked 21 packages in 0.27ms                                        (exit 0)

$ PYTHONPATH=scripts uv run --project scripts python -m prompt_lint
                                                                     (no output, exit 0)

$ cd scripts && uv run pytest
47 passed in 1.16s                                                   (exit 0)
```

**A broken prompt fails the job.** Rather than pushing a broken branch, the tree at this commit was copied out with `git archive` (the repo untouched), one skill's frontmatter broken in the copy — `name: explain` → `expalin`, and a `description` that no longer opens with "Use when" — and the job's own steps replayed there:

```
$ PYTHONPATH=scripts uv run --project scripts python -m prompt_lint
skills/explain/SKILL.md:1: name must be 'explain'
skills/explain/SKILL.md:1: description must open with 'Use when'
                                                                     (exit 1)
```

That run doubles as proof the invocation resolves the tree from the cwd — the paths reported are the copy's, not the repo's. The critic independently re-seeded a different violation (dropping `model:` from `agents/coder-lite.md`) and got `agents/coder-lite.md:1: frontmatter is missing 'model'`, exit 1.

The workflow also parses to the intended shape (`yaml.safe_load`): job `checks`, steps `checkout` → `Install uv` → the three above.

## Deviation from the spec, deliberate

The spec named `scripts/prompt_lint/**` as the checker-code trigger; this uses **`scripts/**`**. Three reasons: `prompt_lint/drift.py` imports `scripts/check_prompt_schemas.py`; the second step runs the *whole* `scripts/tests/` suite, not just the prompt_lint tests; and `scripts/pyproject.toml` + `scripts/uv.lock` drive the setup step. `scripts/prompt_lint/**` would let an edit to any of those go untested. The critic judged the widening a superset that serves the spec.

Size: 60 lines against the spec's "~40 lines of YAML". 26 of them are the `push`/`pull_request` path lists, duplicated because GitHub Actions does not honor YAML anchors — `installer.yml` duplicates its list the same way — and 8 are comments.

## How it was built

Non-behavioral (pure CI config): TDD skipped and logged with a reason per `tdd.md`, since a workflow's triggers and steps have no public interface in this repo to assert against — GitHub is the only executor. Verification is the command reproduction and seeded-violation demonstration above.

Reviewer: **82**, no CRITICAL, highest finding 55 — below the 70 blocking bar, so no blockers. Critic: **achieved (90)**.

## Advisory, disclosed, not fixed

Below the blocking bar and shipped knowingly, each a judgement call worth an owner's eye:

- **(MAJOR, 55) `scripts/` is now watched by CI but still not lint- or type-gated.** This workflow is the only CI covering `scripts/`, and it runs pytest alone; `installer.yml`'s sibling job also runs `ruff format --check`, `ruff check`, and `mypy --strict`. So the repo's second uv project can merge unformatted, unlinted, untyped Python while the first cannot. The reviewer verified all three commands are green on this tree today (`24 files already formatted`, `All checks passed!`, `Success: no issues found in 24 source files`), so adding them is three cheap steps — but the spec for this PR asked for the checker and its tests, nothing about linting `scripts/`, so it stayed out of scope. **Worth a follow-up.**
- **(MINOR, 35) a stale `scripts/uv.lock` still passes.** `uv sync --frozen` installs the lock as-is without checking it against `pyproject.toml`, and the bare `uv run` steps after it will quietly relock. `--locked` would catch the drift. `installer.yml` has the identical exposure, so fixing only this one would break the parallel the spec asked for.
- **(MINOR, 30) `templates/CLAUDE.md.template` is a trigger no check reads.** The spec mandates it, but `prompt_lint`'s inputs are `skills/*/SKILL.md`, `agents/*.md`, `rules/*.md`, `installer/catalog.toml` and `schemas/`; a PR touching only the template burns a run whose result can't depend on the change. Kept because it is spec'd and because a future template check is the obvious place for it — but the header comment reads as though the template is checked today.

Residual, resolving on its own: no GitHub run of this workflow exists yet, so the runner-side steps (setup-uv caching, `uv sync --frozen` on a clean runner) are unexercised until this PR's own checks appear — which they will, since the workflow is in its own trigger list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMHS3VXM38MZvMgw6EUZBt


<!-- pr-explain:begin -->
### What & why
Run the prompt checker in CI on every pull request that touches a prompt file.

Three earlier PRs built the checker: it reads every skill, agent, and rule file and fails on a broken one. Nothing ran it — the repo's one workflow watches `installer/` — so bad prompts merged.

**Goals**
- editing a skill, agent, or rule starts a CI run
- a broken prompt fails the build instead of merging
- the checker's own 47 tests run here too

**[Read the explainer](https://claude.ai/code/artifact/196ad9ec-5fec-44d9-9862-8cf1a3fe017a)** · 1 file touched
<!-- pr-explain:end -->
