### PR TITLE
feat(pr-explain): score the proof on a ladder instead of a flat chip row

### DIFF
--- a/schemas/evidence.schema.json
+++ b/schemas/evidence.schema.json
@@ -66,9 +66,37 @@
         }
       }
     },
-    "runtime": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+    "runtime": {
+      "$comment": "Evidence that the built artifact itself was watched working — pr-explain scores these rows into its proof chapter, where tests and gates together are worth 7 of 100 and can never clear the bar alone.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/runtime_evidence" }
+    }
   },
   "$defs": {
+    "runtime_evidence": {
+      "$comment": "One captured run of the built artifact, classified by what makes it strong. Either a file copied into runtime/ (a screenshot) or the verbatim output, or both.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "what", "cmd"],
+      "anyOf": [{ "required": ["path"] }, { "required": ["key_output"] }],
+      "properties": {
+        "kind": {
+          "$comment": "before_after: one command on the base and on the head. screenshot: a picture of the surface running. replay: one deterministic command a reader reruns to reproduce it. run_output: the built artifact driven end to end. load_bearing: the change reverted, and the break it caused. measurement: a number for a claim the PR makes.",
+          "enum": [
+            "before_after",
+            "screenshot",
+            "replay",
+            "run_output",
+            "load_bearing",
+            "measurement"
+          ]
+        },
+        "what": { "type": "string", "minLength": 1 },
+        "cmd": { "type": "string", "minLength": 1 },
+        "path": { "type": "string", "minLength": 1 },
+        "key_output": { "type": "string", "minLength": 1 }
+      }
+    },
     "witness": {
       "$comment": "One witnessed command run, quoted verbatim from the run that produced it.",
       "type": "object",

--- a/skills/make-pr-lite/SKILL.md
+++ b/skills/make-pr-lite/SKILL.md
@@ -142,8 +142,8 @@ gate output, and the reviewers' findings. Each reviewer finding carries a 1–10
    working — the branch is built right now, so for a behavioral run drive the built artifact
    end to end (`kind: "run_output"`, real data seeded) and screenshot anything a person looks
    at that now comes out different; each entry carries `kind`, `what`, the `cmd`, and either
-   verbatim `key_output` or a `path` copied into `.../runtime/`. `/pr-explain` scores these,
-   and its proof chapter values tests plus gates at 7 of 100. `[]` only when the slice is
+   verbatim `key_output` or a `path` copied into `.../runtime/`. `/pr-explain` scores these on
+   its proof ladder, where a green suite is worth a fraction of one real run. `[]` only when the slice is
    non-behavioral or nothing can be launched here — say which in the summary.
    Validate it:
    `uv run --no-project --with jsonschema python ~/.claude/at/scripts/validate_return.py ~/.claude/at/schemas/evidence.schema.json <that file>`

--- a/skills/make-pr-lite/SKILL.md
+++ b/skills/make-pr-lite/SKILL.md
@@ -138,7 +138,13 @@ gate output, and the reviewers' findings. Each reviewer finding carries a 1–10
    slice's non-test files>`, or `null` for every slice sharing a production file with another
    slice (a shared file makes per-slice counts non-derivable; never double-count) — plus one
    `gates[]` entry per gate in the final green pass with its
-   real `key_output` numbers, and `runtime: []` unless you copied artifacts into `.../runtime/`.
+   real `key_output` numbers, and one `runtime[]` entry per capture of the change actually
+   working — the branch is built right now, so for a behavioral run drive the built artifact
+   end to end (`kind: "run_output"`, real data seeded) and screenshot anything a person looks
+   at that now comes out different; each entry carries `kind`, `what`, the `cmd`, and either
+   verbatim `key_output` or a `path` copied into `.../runtime/`. `/pr-explain` scores these,
+   and its proof chapter values tests plus gates at 7 of 100. `[]` only when the slice is
+   non-behavioral or nothing can be launched here — say which in the summary.
    Validate it:
    `uv run --no-project --with jsonschema python ~/.claude/at/scripts/validate_return.py ~/.claude/at/schemas/evidence.schema.json <that file>`
    — a failing file blocks the push. Then ship it

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -235,8 +235,8 @@ in your JSONL log and the agents' returns, never new claims:
 - one `gates[]` entry per gate in the final green pass, `key_output` carrying the real
   numbers ("18 passed in 0.42s"), never a summary.
 - `runtime`: the branch is hot and built right now — this is the cheapest moment in the whole
-  pipeline to watch the change actually work, and `/pr-explain` scores these rows into the
-  proof chapter where tests and gates together are worth 7 of 100. For a behavioral run,
+  pipeline to watch the change actually work, and `/pr-explain` scores these rows on its proof
+  ladder, where a green suite is worth a fraction of one real run. For a behavioral run,
   capture at least one: **drive the built artifact** end to end (`run_output` — boot the
   server, run the installed CLI, put a real request through it with real data seeded) and,
   when anything a person looks at comes out different, a **screenshot** of it running. One

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -234,8 +234,16 @@ in your JSONL log and the agents' returns, never new claims:
   (schema-enforced).
 - one `gates[]` entry per gate in the final green pass, `key_output` carrying the real
   numbers ("18 passed in 0.42s"), never a summary.
-- `runtime`: paths relative to the evidence dir of any runtime evidence (screenshots, e2e
-  transcripts) you copy into `<run_root>/evidence/<branch-slug>/runtime/`; `[]` when none.
+- `runtime`: the branch is hot and built right now — this is the cheapest moment in the whole
+  pipeline to watch the change actually work, and `/pr-explain` scores these rows into the
+  proof chapter where tests and gates together are worth 7 of 100. For a behavioral run,
+  capture at least one: **drive the built artifact** end to end (`run_output` — boot the
+  server, run the installed CLI, put a real request through it with real data seeded) and,
+  when anything a person looks at comes out different, a **screenshot** of it running. One
+  entry per capture — `kind`, `what` (one line naming what the reader sees), the `cmd` behind
+  it, and either `key_output` verbatim or a `path` to a file you copied into
+  `<run_root>/evidence/<branch-slug>/runtime/`. `[]` only when the run is non-behavioral or
+  nothing can be launched here — and say which in the summary.
 
 Validate it with the same validator command as agent returns, against
 `~/.claude/at/schemas/evidence.schema.json` — a failing file blocks the push: fix the file,

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -73,8 +73,10 @@ forced tests or proof; log the shrink and its reason in the report.
 
 ## The proof ladder
 
-Chapter 4 scores what actually ran against this change, out of 100. Take the strongest
-instance of each row, score each row at most once, and add them up.
+Chapter 4 scores what actually ran against this change, out of 100. Add up the rows you earned,
+each at most once — two screenshots are still 20. One capture may earn several rows when it
+proves each independently: a before/after pair of screenshots proves both that the change
+happened (25) and that the surface renders (20). The rows are claims, not artifacts.
 
 | Pts | The proof | What earns it |
 |----:|-----------|---------------|
@@ -358,17 +360,21 @@ The draft leaves Phase 4 only after both gates. Run them in order:
   `.ba-label`, the replay and the run output as one `.cmd` block each.
 - Screenshots and e2e output embed as `data:` URIs via `img.evidence`, each followed by
   its one-line `.evidence-cap` caption.
-- **Colour check, on the built file, before Phase 6.** An installed template that lags the
-  repo drops the syntax tokens silently, and every hunk renders as flat red and green — the
-  page still validates, so only these greps catch it:
-  - `grep -c -- --syn-kw <page>` → `0` means the template is stale. Rebuild from the repo's
-    `templates/pr-explain-page.html`; never hand-patch the built page.
+- **Staleness check, on the built file, before Phase 6.** An installed template that lags the
+  repo drops whole rule sets silently — the page still validates, and only these greps catch it.
+  A stale template is never hand-patched: rebuild from the repo's
+  `templates/pr-explain-page.html`.
+  - `grep -c -- --syn-kw <page>` → `0` is a template older than the syntax tokens, and every
+    hunk renders as flat red and green.
+  - `grep -c '\.rung' <page>` → `0` is a template older than the ladder, and Chapter 4 renders
+    as unstyled text. Each generation of the template needs its own grep here: add one whenever
+    a chapter gains a class the last generation lacked.
   - `grep -c tok- <page>` → every `.diff` block holding code carries at least one token span.
     A block quoting prose (a Markdown file, a plain-text log) is the only allowed zero.
   - `grep -n '\.diff \.\(add\|del\) {' <page>` → neither rule sets `color:`. Red and green
     live in the line background and the `.sign` gutter, never on the code text.
 
-  Any one failing → fix it here. Publishing a flat diff is a failed run.
+  Any one failing → fix it here. Publishing a flat diff or a bare ladder is a failed run.
 
 ## Phase 6 — Publish
 
@@ -418,6 +424,6 @@ with what it would have taken** (plus the ⚠ flag when under the bar or nothing
 screenshots embedded, or the visible surface that shipped unseen and why (⚠); chapters
 emitted vs dropped (with the tiny-PR shrink reason if used); the PR whose teaser you
 updated; the mechanical gate result (coverage greps, Vale alerts fixed, or "vale
-unavailable — wc + grep only"); the colour check (tokens present, or the stale template you
-rebuilt from); and the critic score — naming any dimension left under the bar when the page
-shipped flagged.
+unavailable — wc + grep only"); the staleness check (tokens and ladder present, or the stale
+template you rebuilt from); and the critic score — naming any dimension left under the bar when
+the page shipped flagged.

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-explain
-description: Use when the user invokes /pr-explain or wants a reader-facing explainer page for a pull request — a plain-words page with five chapters (what & why, a walkthrough of the whole diff, every test enumerated, the proof, and confirm commands run with their real output), published as a private claude.ai artifact with a teaser in the PR body.
-argument-hint: "[#N | PR URL | blank = current branch's PR]"
+description: Use when the user invokes /pr-explain or wants a reader-facing explainer page for a pull request — a plain-words page with five chapters (what & why, a walkthrough of the whole diff, every test enumerated, a scored proof, and confirm commands run with their real output), published as a private claude.ai artifact with a teaser in the PR body.
+argument-hint: "[#N | PR URL | blank = current branch's PR] [--confirmed \"<what you saw>\"]"
 ---
 
 # PR Explain
@@ -20,10 +20,10 @@ Three rules run through the whole page:
 - **The whole diff.** Every change in the PR is either shown and explained or named in a
   roll-up line. A reader who finishes the walkthrough has seen the change — never two
   excerpts from a hundred-line diff.
-- **Nothing unrun.** Output on the page is output you captured. Proof is something that
-  actually executed. A change a person looks at is proven by a picture of it running —
-  never by text output about it. If no proof can be written for a behavior change, the
-  page says so — that is a finding about the PR, not a gap to pad over.
+- **Proof is scored, not asserted.** Output on the page is output you captured, and every
+  piece of it sits on the ladder below carrying its points — so a reader sees at a glance
+  whether this change was watched working or merely compiled. Tests and gates together are
+  worth 7 of 100: "all tests passed" is the weakest sentence on the page, never the proof.
 
 ## Arguments
 
@@ -32,6 +32,7 @@ Three rules run through the whole page:
 | *(blank)* | The open PR for the current branch |
 | `#N` or `N` | PR number in the target repo |
 | a PR URL | That PR |
+| `--confirmed "<what you saw>"` | Fills the ladder's top row — you ran this change yourself. Quoted verbatim, dated today. Combines with any form above |
 
 ## Runtime resolution
 
@@ -60,7 +61,7 @@ an empty chapter, never pad it.
 | 1 | What & why | What does this PR do, why now, and what is true after it merges? | ≤ 80 words |
 | 2 | The walkthrough | What did we change, where is it, and why — across the whole diff | ≤ 40-word note per hunk |
 | 3 | The tests | Which tests pin this, one by one, and how they went RED then GREEN | one ≤ 14-word line per test |
-| 4 | The proof | What actually ran against this change, with real numbers | 40–70 words + evidence |
+| 4 | The proof | What actually ran against this change, scored on the ladder | 40–70 words + the ladder + evidence |
 | 5 | See for yourself | What can you paste to confirm it — with the output we got | ≤ 40 words + run blocks |
 
 Prose scales with the diff: chapters 1, 4, and 5 keep fixed budgets; the walkthrough grows
@@ -69,6 +70,28 @@ captured output, and test names never count as prose. Each diff or command block
 12 lines — trim to the lines that carry the decision. A tiny PR with no behavior (docs, a
 version bump, one-line config) shrinks to Chapter 1, a one-line tree, and Chapter 5 — no
 forced tests or proof; log the shrink and its reason in the report.
+
+## The proof ladder
+
+Chapter 4 scores what actually ran against this change, out of 100. Take the strongest
+instance of each row, score each row at most once, and add them up.
+
+| Pts | The proof | What earns it |
+|----:|-----------|---------------|
+| 50 | **The owner ran it** | A human outside this run drove the change and said what they saw. Arrives only through `--confirmed` — never write this row yourself, on any evidence |
+| 25 | **Before and after on the real thing** | One command, one seeded state, run on the base and on the head, both outputs shown. The only row that proves the *change* rather than that something ran |
+| 20 | **A picture of it running** | A screenshot of the built thing doing its job with real data seeded. Text about a surface is not the surface |
+| 15 | **A replay the reader can run** | One deterministic command — a `docker run` on a pinned image, a script in the repo — that reproduces your captured output on their machine |
+| 10 | **Real output from the built artifact** | The compiled binary, the booted server, the installed CLI driven end to end here, output verbatim |
+| 10 | **Proof it is load-bearing** | The change reverted and the resulting failure captured. The difference between "the new code runs" and "the new code is what does it" |
+| 10 | **A number for the claim** | The PR says faster, smaller, fewer — measured on the base and on the head, same input. Only when it claims one |
+| 5 | **The tests pass** | RED → GREEN witnesses and a green suite. They assert what we told them to assert. Capped: 800 passing is still 5 |
+| 2 | **The gates** | Lint, typecheck, format, build, CI green — all of them together, once. They say it compiles and is tidy |
+| 0 | **An assertion** | "Verified", "works as expected", a number claimed only in the PR body. Named on the page as unproven; never a scored row |
+
+**The bar is 30** for a PR with behavior. Tests plus gates come to 7, so the bar cannot be
+cleared by the suite alone — that is the point of the number. Phase 3 climbs, Phase 4 scores,
+under 30 ships flagged.
 
 ## Phase 1 — Gather
 
@@ -93,9 +116,12 @@ may not be the one you were asked about. `--json files` gives every touched path
 - **Evidence (Chapters 3-4)**: slug the head branch (`/` and whitespace → `_`) and read
   `<target_repo>/.v1-runs/evidence/<slug>/evidence.json` — the make-pr / make-pr-lite handoff.
   It carries `behaviors[]` (each with a RED and a GREEN witness), `gates[]` (real gate numbers
-  from the run), and `runtime` (artifact paths relative to that dir). Chapters 3 and 4 quote it
-  verbatim: the RED witness carries the failure reason, the GREEN witness what made it pass plus
-  `+<lines_added>`, one gate chip per `gates[]` row. **Never invent evidence.**
+  from the run), and `runtime[]` — the ladder rows the pipeline already captured, each with its
+  `kind`, the `cmd` behind it, and a `path` into that dir or verbatim `key_output`. Chapters 3
+  and 4 quote it verbatim: the RED witness carries the failure reason, the GREEN witness what
+  made it pass plus `+<lines_added>`, the gates collapse into the ladder's one 2-point row, and
+  each `runtime[]` entry scores its own row. **Never invent evidence.** Rows the handoff does
+  not carry are rows Phase 3 climbs itself, or leaves unlit.
 
 ## Phase 2 — Understand (before writing a word)
 
@@ -125,34 +151,54 @@ may not be the one you were asked about. `--json files` gives every touched path
    (`git ls-tree -d --name-only HEAD`), byte-sorted, equal-width cells; light the ones that
    contain a touched file. Same strip, same order, every PR — it orients the reader in the
    whole repo without printing it.
-8. **Spot the visual surface.** Does the diff touch anything a person looks at — an HTML
-   page or template, frontend components, CSS, a TUI or formatted terminal output, a chart,
-   an email body? If yes, Chapter 4 owes a screenshot of it running on this branch; plan
-   now how Phase 3 will launch and capture it.
+8. **Spot what a person sees.** Not "does the diff touch a template" — *after this merges,
+   does anything a human looks at come out different?* A page, a TUI, a chart, an email body,
+   the shape of a CLI's output, or a rendered view of data this PR changes even when the
+   rendering file is untouched: a board that now lists 3 rows where it listed 48 has changed
+   visibly, and "the page is untouched" is no excuse. Yes → Chapter 4 owes a screenshot of it
+   running on this branch, and the before/after pair is there for the taking. Plan now how
+   Phase 3 captures both.
 
-## Phase 3 — Run (capture real output)
+## Phase 3 — Run (climb the ladder)
 
 Before writing, run the change. Everything here executes in the target repo, on the PR's
-head; capture output verbatim for Chapters 4 and 5.
+head; capture output verbatim for Chapters 4 and 5. Work the ladder from the bottom up and
+stop once the score clears 30 — but never skip a row that is cheap to reach here.
 
-- **Rerun the PR's tests** with the narrowest selector that covers the diff's test files
-  (`pytest tests/catalog/ -q`, `cargo test -p <crate>`, `vitest run <dir>`). A fresh green
-  run is first-class proof: chip it as `run here — <n> passed`.
-- **Screenshot every visual change.** Phase 2 spotted a visual surface → launch it on this
-  branch (start the server, open the page — the `run` skill knows the launch patterns) and
-  capture what a person sees: a headless-browser screenshot for a web page, the rendered
-  terminal for a TUI. Seed enough real data first that the surface shows its job, not an
-  empty frame. Status codes, byte counts, and greps prove the server answered — only a
-  screenshot proves the page renders. Genuinely cannot launch it here → that is a proof
-  gap Chapter 4 must declare, never a step to skip.
+- **Drive the built artifact end to end** (10). Build it, boot it, and put a real request
+  through it: the compiled binary, the server on a local port, the installed CLI. Seed real
+  data first so the answer is interesting. A test harness exercising the same code is not
+  this row — the artifact a user gets is.
+- **Capture the before and after** (25). `git worktree add <scratch>/base <base>`, build there,
+  run the same command against the same seeded state, keep that output; then run it on the
+  head. One command, two outputs, the difference visible. The cheapest large points on the
+  ladder and the pair a reader actually believes. Remove the worktree when done.
+- **Screenshot what a person sees** (20). Phase 2 spotted a visible surface → launch it on
+  this branch (the `run` skill knows the launch patterns) and capture the frame: a
+  headless-browser shot for a page, the rendered terminal for a TUI. Seed enough real data
+  that the surface shows its job, not an empty frame. Status codes, byte counts, and greps
+  prove the server answered; only a picture proves a person sees it. Genuinely cannot launch
+  it here → a gap Chapter 4 declares, never a step to skip.
+- **Write the replay** (15). Fold the end-to-end run into one command anyone can paste — a
+  `docker run` on a pinned image, or a script committed in the repo — and run it once from
+  clean to confirm it reproduces. Deterministic or it does not score: pin the image, seed
+  fixed data, and keep clocks, ports, and paths out of the compared output.
+- **Break it on purpose** (10). `git checkout <base> -- <the production file>`, re-run the one
+  command or test the PR makes pass, capture the failure, then
+  `git checkout HEAD -- <that file>` to restore. Confirm the tree is clean again before
+  writing anything else.
+- **Measure the claim** (10). The PR says faster, smaller, fewer → time it or count it on the
+  base worktree and on the head, same input, and keep both numbers.
+- **Rerun the tests** (5) with the narrowest selector covering the diff's test files
+  (`pytest tests/catalog/ -q`, `cargo test -p <crate>`, `vitest run <dir>`).
 - **Run every Chapter 5 command yourself first.** Only ship a command you ran; paste its
   real output next to it. A command the reader needs but you cannot run here (missing
   credentials, no device) ships marked `not run here — needs <thing>`, never with imagined
   output.
 - **Safe commands only**: test runners, linters, builds, read-only CLI and `curl` against a
   server you started locally from the repo. Never migrations against shared databases,
-  deploys, publishes, or network writes. No documented way to run it → say so and fall back
-  to the evidence file and CI.
+  deploys, publishes, or network writes. A row you cannot reach safely stays unlit and the
+  page says why — never one you assert.
 
 ## Phase 4 — Write
 
@@ -214,24 +260,37 @@ the witnesses are absent.
 
 ### Chapter 4 — The proof
 
-Proof is what actually executed, strongest first: your Phase 3 runs, then the evidence
-file's gates, then CI checks (`gh pr checks`). Chip each with its real number. Numbers
-claimed only in the PR body appear attributed ("PR body reports: pytest 161 passed"), never
-as a verified chip.
+Score the ladder, then show the evidence — **the evidence itself, in this chapter**. Chapter 5
+is what the *reader* can paste; Chapter 4 is what *ran*, and a sentence reporting that a run
+happened is not that run. So the strong rows carry their artifact here: the screenshot embeds,
+the before/after prints as two labelled blocks, the replay prints as its one command with the
+output it produced.
 
-**The proof gate is hard.** For a PR with behavior, this chapter can neither be dropped nor
-padded. If all three sources come up empty — nothing was ever run against this change — the
-chapter is the `.no-proof` verdict, verbatim: *"No proof exists: nothing was run to show
-this change works. A PR whose proof cannot be written had nothing to prove — that is a
-finding about the PR, not this page."* Carry a ⚠ into the teaser and the report. Never
-invent a chip to avoid the verdict.
+Open with the score (`the proof — 62 / 100`). Then one `.rung` per ladder row, in ladder
+order, each earned row carrying its real number and the command behind it. **Rows you did not
+earn stay on the page, unlit, with their points** — an unlit "before and after · 25" tells the
+reader what was not done, which is the whole reason the ladder is visible. The gates collapse
+into their single 2-point row, chips and all; a red CI check chips `fail`. Numbers claimed
+only in the PR body appear attributed in prose ("PR body reports: pytest 161 passed"), never
+as a scored row.
 
-**A visual change needs visual proof.** Phase 2 spotted a visual surface → at least one
-Phase 3 screenshot of it running embeds here (`img.evidence`, `data:` URI), each with a
-one-line `.evidence-cap` caption naming what the reader is looking at. Chips about the
-surface — curl status, byte counts, grep hits — do not substitute. No screenshot → the
-chapter says which surface shipped unseen and why, and a ⚠ carries into the teaser and
-the report exactly like the no-proof verdict.
+**The bar is hard.** Under 30 on a PR with behavior → the chapter opens with the
+`.short-proof` banner naming the score and the cheapest unlit row, and a ⚠ carries into the
+teaser and the report. Nothing ran at all → the `.no-proof` verdict instead, verbatim: *"No
+proof exists: nothing was run to show this change works. A PR whose proof cannot be written
+had nothing to prove — that is a finding about the PR, not this page."* Never light a row you
+did not earn: a page that scores 7 honestly is worth more than one that lies to clear 30.
+
+**The top row is yours alone.** The owner row renders on every page — unlit and explicit ("you
+have not run this yourself yet") unless this run was given `--confirmed`, in which case it
+carries the quoted words and today's date. Never fill it from a PR comment, a review approval,
+or something said in chat.
+
+**A visible change needs a picture.** Phase 2 spotted a visible surface → at least one Phase 3
+screenshot of it running embeds here (`img.evidence`, `data:` URI), each with a one-line
+`.evidence-cap` caption naming what the reader is looking at. Rows about the surface — curl
+status, byte counts, grep hits — do not substitute. No screenshot → the chapter says which
+surface shipped unseen and why, and the same ⚠ carries into the teaser and the report.
 
 ### Chapter 5 — See for yourself
 
@@ -246,8 +305,13 @@ The draft leaves Phase 4 only after both gates. Run them in order:
 - **Mechanical gate (always).**
   - *Coverage*: count hunks (`gh pr diff <N> | grep -c '^@@'`) and check every one is a
     walkthrough entry or inside a named roll-up line. Grep each test name from the inventory
-    against the draft; every one appears. Phase 2 spotted a visual surface → grep the page
+    against the draft; every one appears. Phase 2 spotted a visible surface → grep the page
     for `img.evidence`; zero hits fails the gate unless Chapter 4 carries the declared ⚠.
+  - *Proof*: add the points of the lit `.rung` rows and check the total matches the printed
+    score. Every ladder row appears, lit or unlit — `grep -c 'class="rung' <page>` equals the
+    ladder's row count. Under 30 on a behavior PR → `.short-proof` is present and the ⚠ is in
+    the teaser. A lit row with no captured command or artifact behind it fails the gate: unlight
+    it and re-score.
   - *Prose*: `wc -w` each budgeted unit and cut anything over. `grep` the draft for every
     banned word above and rewrite each hit. Then, **if `vale` is on PATH**, write the draft
     to a scratch `.md` and run `vale --config ~/.claude/at/templates/pr-explain.vale.ini
@@ -262,8 +326,8 @@ The draft leaves Phase 4 only after both gates. Run them in order:
   - **Whole diff walked** — every hunk shown or named; each shown hunk's note answers what,
     why, and where; the walkthrough reads in call-path order like a narration.
   - **Enumerated & real** — every test in the diff is on the list with a plain line; every
-    output and chip on the page was actually run or quoted from evidence/CI; the no-proof
-    verdict, if present, is honest.
+    output and lit rung was actually run or quoted from evidence/CI; the score is what the lit
+    rows add up to; the ⚠ banner or no-proof verdict, if present, is honest.
   - **Sharp & short** — clean statements; ≤ 25-word sentences; every unit within budget;
     Chapter 1 is the three moves and nothing more.
 
@@ -287,6 +351,11 @@ The draft leaves Phase 4 only after both gates. Run them in order:
   deleted lines open with a `.sign` `+`/`−`, and the red/green lives in the line background
   and sign — never in the code text.
 - **The test list**: `.testlist` with a `.tfile` row per file and a `.trow` per test.
+- **The ladder**: `.score` with the total and its `.bar`, then one `.rung` per row — earned
+  rows carry `.pts`, `.what`, and a `.how` naming the command; unearned rows carry the same
+  three with `class="rung unlit"`. Evidence hangs under the row it scores: the screenshot as
+  `img.evidence` + `.evidence-cap`, the before/after as two `.cmd` blocks each opened by a
+  `.ba-label`, the replay and the run output as one `.cmd` block each.
 - Screenshots and e2e output embed as `data:` URIs via `img.evidence`, each followed by
   its one-line `.evidence-cap` caption.
 - **Colour check, on the built file, before Phase 6.** An installed template that lags the
@@ -322,13 +391,14 @@ Maintain exactly one marker-delimited block in the PR description:
 **Goals**
 <the Chapter 1 goal bullets, verbatim>
 
-**[Read the explainer](<artifact-url>)** · <n> files touched
+**[Read the explainer](<artifact-url>)** · <n> files touched · proof <score>/100
 <!-- pr-explain:end -->
 ```
 
-Chapter 1 doubles as the PR description the big repos would ask for — that is by design.
-If the page carries the no-proof verdict, append `· ⚠ no proof — see the explainer` to the
-link line.
+Chapter 1 doubles as the PR description the big repos would ask for — that is by design. The
+score rides the link line so the number is visible without opening the page. Under the bar,
+append `· ⚠ proof under the bar` to that line; nothing run at all, `· ⚠ no proof — see the
+explainer`.
 
 - Re-read the body with `gh pr view <N> --json body` — it may have changed since Phase 1.
   Replace the block between the markers in place (append if the markers are absent); write the
@@ -343,8 +413,9 @@ link line.
 ## Report
 
 End with: the artifact URL; hunks shown / rolled up / total; tests enumerated; commands run
-vs marked not-run; the proof verdict (sources used, or the ⚠ no-proof flag); screenshots
-embedded, or the visual surface that shipped unseen and why (⚠); chapters
+vs marked not-run; **the proof score out of 100, the rows you lit, and the cheapest unlit row
+with what it would have taken** (plus the ⚠ flag when under the bar or nothing ran);
+screenshots embedded, or the visible surface that shipped unseen and why (⚠); chapters
 emitted vs dropped (with the tiny-PR shrink reason if used); the PR whose teaser you
 updated; the mechanical gate result (coverage greps, Vale alerts fixed, or "vale
 unavailable — wc + grep only"); the colour check (tokens present, or the stale template you

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -22,8 +22,8 @@ Three rules run through the whole page:
   excerpts from a hundred-line diff.
 - **Proof is scored, not asserted.** Output on the page is output you captured, and every
   piece of it sits on the ladder below carrying its points — so a reader sees at a glance
-  whether this change was watched working or merely compiled. Tests and gates together are
-  worth 7 of 100: "all tests passed" is the weakest sentence on the page, never the proof.
+  whether this change was watched working or merely compiled. "All tests passed" is the
+  weakest sentence on the page, never the proof.
 
 ## Arguments
 
@@ -164,8 +164,9 @@ may not be the one you were asked about. `--json files` gives every touched path
 ## Phase 3 — Run (climb the ladder)
 
 Before writing, run the change. Everything here executes in the target repo, on the PR's
-head; capture output verbatim for Chapters 4 and 5. Work the ladder from the bottom up and
-stop once the score clears 30 — but never skip a row that is cheap to reach here.
+head; capture output verbatim for Chapters 4 and 5. Get the artifact running first — four of
+the rows below reuse that one instance — then work down them until the score clears 30, and
+take every row still cheap to reach after that.
 
 - **Drive the built artifact end to end** (10). Build it, boot it, and put a real request
   through it: the compiled binary, the server on a local port, the installed CLI. Seed real
@@ -311,8 +312,8 @@ The draft leaves Phase 4 only after both gates. Run them in order:
     for `img.evidence`; zero hits fails the gate unless Chapter 4 carries the declared ⚠.
   - *Proof*: add the points of the lit `.rung` rows and check the total matches the printed
     score. Every scorable row appears, lit or unlit — `grep -c 'class="rung' <page>` is 9; the
-    0-point assertion row is prose, never a rung. Under 30 on a behavior PR → `.short-proof` is present and the ⚠ is in
-    the teaser. A lit row with no captured command or artifact behind it fails the gate: unlight
+    0-point assertion row is prose, never a rung. Under 30 on a behavior PR → `.short-proof` is
+    present and the ⚠ is in the teaser. A lit row with no command or artifact behind it: unlight
     it and re-score.
   - *Prose*: `wc -w` each budgeted unit and cut anything over. `grep` the draft for every
     banned word above and rewrite each hit. Then, **if `vale` is on PATH**, write the draft

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -37,8 +37,9 @@ Three rules run through the whole page:
 ## Runtime resolution
 
 - **Template**: `~/.claude/at/templates/pr-explain-page.html` — design tokens plus the
-  `.bottomline`, `.goals`, `.tree`, `.hunk-head`, `.testlist`, `.wit`, `.gate-chip`,
-  `.no-proof`, and `.cmd` classes the chapters use. Missing? Still ship: build a
+  `.bottomline`, `.goals`, `.tree`, `.hunk-head`, `.testlist`, `.wit`, `.score`, `.rung`,
+  `.short-proof`, `.gate-chip`, `.no-proof`, `.ba-label`, and `.cmd` classes the chapters
+  use. Missing? Still ship: build a
   single-file HTML page with inline CSS that follows the chapter contract. Visual polish
   degrades; the contract does not.
 - **Vale config**: `~/.claude/at/templates/pr-explain.vale.ini`, staged with the template. It
@@ -100,9 +101,9 @@ under 30 ships flagged.
 ```bash
 branch="$(git branch --show-current)"           # blank arg; empty output → detached HEAD: stop, ask for #N
 gh pr list --head "$branch" --json number,url    # [] → no open PR: stop, ask for #N
-gh pr view <N> --json number,title,body,url,headRefName,additions,deletions,createdAt,files
-gh pr diff <N>
-gh pr checks <N> || true
+gh pr view "<N>" --json number,title,body,url,headRefName,additions,deletions,createdAt,files
+gh pr diff "<N>"
+gh pr checks "<N>" || true                       # <N> is the PR number you substitute
 ```
 
 Always pass the explicit `<N>` — a bare `gh pr view` targets the current branch's PR, which
@@ -266,8 +267,8 @@ the witnesses are absent.
 Score the ladder, then show the evidence — **the evidence itself, in this chapter**. Chapter 5
 is what the *reader* can paste; Chapter 4 is what *ran*, and a sentence reporting that a run
 happened is not that run. So the strong rows carry their artifact here: the screenshot embeds,
-the before/after prints as two labelled blocks, the replay prints as its one command with the
-output it produced.
+the before/after prints as two labelled blocks, and the replay prints as the one command with
+the output it produced here — Chapter 5 then points back at it rather than printing it twice.
 
 Open with the score (`the proof — 62 / 100`). Then one `.rung` per ladder row, in ladder
 order, each earned row carrying its real number and the command behind it. **Rows you did not
@@ -298,8 +299,9 @@ surface shipped unseen and why, and the same ⚠ carries into the teaser and the
 ### Chapter 5 — See for yourself
 
 One or two command blocks the reader can paste to confirm *this* change, each followed by
-the output you captured in Phase 3. Commands you could not run here carry the
-`not run here — needs <thing>` mark instead of output.
+the output you captured in Phase 3. A replay already printed in Chapter 4 is named here, not
+reprinted. Commands you could not run here carry the `not run here — needs <thing>` mark
+instead of output.
 
 ### The bar
 
@@ -335,8 +337,8 @@ The draft leaves Phase 4 only after both gates. Run them in order:
     Chapter 1 is the three moves and nothing more.
 
   Below **90** → apply the specific misses as one rewrite pass, then re-score once. After the
-  rewrite, re-run the coverage greps and per-unit `wc` — those are hard and must still hold
-  at publish.
+  rewrite, re-run the coverage greps, the proof arithmetic, and per-unit `wc` — those are hard
+  and must still hold at publish.
 - **Ship-flag.** Still < 90 after the rewrite → publish anyway and record the final score and
   the unmet dimensions in the report. Never block the publish or loop a third time.
 

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -308,8 +308,8 @@ The draft leaves Phase 4 only after both gates. Run them in order:
     against the draft; every one appears. Phase 2 spotted a visible surface → grep the page
     for `img.evidence`; zero hits fails the gate unless Chapter 4 carries the declared ⚠.
   - *Proof*: add the points of the lit `.rung` rows and check the total matches the printed
-    score. Every ladder row appears, lit or unlit — `grep -c 'class="rung' <page>` equals the
-    ladder's row count. Under 30 on a behavior PR → `.short-proof` is present and the ⚠ is in
+    score. Every scorable row appears, lit or unlit — `grep -c 'class="rung' <page>` is 9; the
+    0-point assertion row is prose, never a rung. Under 30 on a behavior PR → `.short-proof` is present and the ⚠ is in
     the teaser. A lit row with no captured command or artifact behind it fails the gate: unlight
     it and re-score.
   - *Prose*: `wc -w` each budgeted unit and cut anything over. `grep` the draft for every
@@ -326,7 +326,7 @@ The draft leaves Phase 4 only after both gates. Run them in order:
   - **Whole diff walked** — every hunk shown or named; each shown hunk's note answers what,
     why, and where; the walkthrough reads in call-path order like a narration.
   - **Enumerated & real** — every test in the diff is on the list with a plain line; every
-    output and lit rung was actually run or quoted from evidence/CI; the score is what the lit
+    output and lit row was actually run or quoted from evidence/CI; the score is what the lit
     rows add up to; the ⚠ banner or no-proof verdict, if present, is honest.
   - **Sharp & short** — clean statements; ≤ 25-word sentences; every unit within budget;
     Chapter 1 is the three moves and nothing more.

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -209,8 +209,8 @@ take every row still cheap to reach after that.
 Draft the prose in a scratch buffer under these rules:
 
 1. **One PR, one thing.** Chapter 1 leads with it. Secondary changes get one line, never an arc.
-2. **Every claim points at something the page shows** — a walkthrough hunk, a test line, a
-   gate chip, captured output. "Faster", "safer", "fixed" each arrive with a number or output.
+2. **Every claim points at something the page shows** — a walkthrough hunk, a test line, a lit
+   ladder row, captured output. "Faster", "safer", "fixed" each arrive with a number or output.
 3. **Concrete before abstract.** The failing command, the error, or the real line comes before
    any statement about it. Examples are trimmed from the actual diff, never invented.
 4. **Plain words, ≤ 25-word sentences, one idea per sentence, data over adjectives.**
@@ -361,8 +361,6 @@ The draft leaves Phase 4 only after both gates. Run them in order:
   three with `class="rung unlit"`. Evidence hangs under the row it scores: the screenshot as
   `img.evidence` + `.evidence-cap`, the before/after as two `.cmd` blocks each opened by a
   `.ba-label`, the replay and the run output as one `.cmd` block each.
-- Screenshots and e2e output embed as `data:` URIs via `img.evidence`, each followed by
-  its one-line `.evidence-cap` caption.
 - **Staleness check, on the built file, before Phase 6.** An installed template that lags the
   repo drops whole rule sets silently — the page still validates, and only these greps catch it.
   A stale template is never hand-patched: rebuild from the repo's

--- a/templates/pr-explain-page.html
+++ b/templates/pr-explain-page.html
@@ -123,7 +123,30 @@
   .tag.red { color: var(--red); background: var(--red-soft); }
   .tag.green { color: var(--green); background: var(--green-soft); }
 
-  /* Chapter 4 — the proof: gate chips + runtime evidence. */
+  /* Chapter 4 — the proof: the scored ladder, then the evidence itself.
+     A rung is lit only when something ran; unlit rungs stay on the page with their
+     points, so the reader sees what was NOT done. */
+  .score { font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em;
+    text-transform: uppercase; color: var(--ink-3); margin-top: 14px; }
+  .score .n { font-size: 15px; color: var(--ink); font-weight: 700; letter-spacing: 0; }
+  .score .bar { display: block; height: 5px; border-radius: 3px; background: var(--line);
+    margin-top: 6px; overflow: hidden; }
+  .score .bar i { display: block; height: 100%; background: var(--accent); }
+  .score.short .bar i { background: var(--amber); }
+  .ladder { margin-top: 14px; border-top: 1px solid var(--line); }
+  .rung { display: flex; gap: 12px; align-items: baseline; padding: 8px 0;
+    border-bottom: 1px solid var(--line); font-size: 15.5px; }
+  .rung .pts { font-family: var(--mono); font-size: 12px; font-weight: 700;
+    color: var(--accent); min-width: 2.6em; text-align: right; flex: none; }
+  .rung .what { color: var(--ink); }
+  .rung .how { font-family: var(--mono); font-size: 11.5px; color: var(--ink-3); }
+  .rung.unlit { opacity: 0.5; }
+  .rung.unlit .pts { color: var(--ink-3); }
+  .rung-eq { padding: 10px 0 2px; }
+  .short-proof { border: 1px solid var(--amber); background: var(--amber-soft);
+    border-radius: 8px; padding: 14px 18px; margin-top: 10px; font-size: 15.5px; }
+  .short-proof .tag { font-family: var(--mono); font-size: 10.5px; font-weight: 700;
+    color: var(--amber); letter-spacing: 0.08em; display: block; margin-bottom: 4px; }
   .gate-row { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 10px; }
   .gate-chip { font-family: var(--mono); font-size: 11.5px; padding: 3px 9px;
     border-radius: 999px; background: var(--green-soft); color: var(--green); }
@@ -132,6 +155,8 @@
     padding: 14px 18px; margin-top: 10px; font-size: 15.5px; }
   .no-proof .tag { font-family: var(--mono); font-size: 10.5px; font-weight: 700;
     color: var(--red); letter-spacing: 0.08em; display: block; margin-bottom: 4px; }
+  .ba-label { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em;
+    text-transform: uppercase; color: var(--ink-3); margin: 12px 0 -6px; }
   img.evidence { max-width: 100%; border: 1px solid var(--line-strong); border-radius: 6px; margin-top: 12px; }
   .evidence-cap { font-family: var(--mono); font-size: 11.5px; color: var(--ink-3); margin: 4px 0 0; }
 
@@ -203,20 +228,40 @@
 
   <div class="chapter">
     <div class="clabel">The proof</div>
-    <!-- SLOT: 40-70 words + evidence — only what actually ran, strongest first:
-         fresh runs from this session, then evidence-file gates, then CI. Chips carry real numbers:
-         <div class="gate-row"><span class="gate-chip">run here — pytest 161 passed</span><span class="gate-chip">mypy strict</span></div>
-         A visual surface in the diff (page, TUI, chart) REQUIRES a screenshot of it running,
-         embedded as <img class="evidence" src="data:…"> with a
-         <p class="evidence-cap">one-line caption of what the reader sees</p> — text output
-         about the surface never substitutes; no screenshot → declare the gap + ⚠.
-         Other runtime evidence (e2e output) embeds the same way.
-         CI check results as chips (class "fail" for red ones);
-         PR-body claims appear only attributed in prose ("PR body reports: …"), never as chips.
-         A behavior PR with NOTHING run → this verdict, verbatim, instead (never drop, never pad):
-         <div class="no-proof"><span class="tag">NO PROOF</span>No proof exists: nothing was run to
+    <!-- SLOT: 40-70 words, then the ladder, then the evidence itself — NOT a sentence saying
+         a run happened. Score = the lit rungs added up; bar is 30 for a PR with behavior.
+         The score, its bar filled to score%:
+      <div class="score">the proof — <span class="n">62 / 100</span>
+        <span class="bar"><i style="width:62%"></i></span></div>
+         Then EVERY ladder row in ladder order — earned ones lit, the rest unlit but present,
+         because an unlit "before and after · 25" tells the reader what was not done:
+      <div class="ladder">
+        <div class="rung unlit"><span class="pts">50</span><span class="what">The owner ran it
+          — <span class="how">you have not run this yourself yet</span></span></div>
+        <div class="rung"><span class="pts">25</span><span class="what">Before and after on the
+          real thing — <span class="how">curl /agents on main: 48 rows · on this branch: 3</span></span></div>
+        <div class="rung"><span class="pts">5</span><span class="what">The tests pass —
+          <span class="how">cargo test · 82 passed, 0 failed</span></span></div>
+        <div class="rung"><span class="pts">2</span><span class="what">The gates —
+          <span class="how">fmt, clippy -D warnings, CI</span></span></div>
+      </div>
+         The gates rung may carry its chips (class "fail" for red CI):
+      <div class="gate-row"><span class="gate-chip">CI check — pass 31s</span></div>
+         Evidence hangs UNDER the rung it scores. Screenshot (required when Phase 2 spotted
+         something a person sees — curl output never substitutes; none → say which surface
+         shipped unseen + ⚠):
+      <img class="evidence" src="data:…"><p class="evidence-cap">what the reader is looking at</p>
+         Before/after — two labelled blocks, same command, base then head:
+      <p class="ba-label">on main</p><div class="cmd">…</div>
+      <p class="ba-label">on this branch</p><div class="cmd">…</div>
+         Under the bar → open the chapter with this, and ⚠ the teaser:
+      <div class="short-proof"><span class="tag">PROOF UNDER THE BAR</span>17 of 100. Nothing but
+         the suite and the gates ran against this change. The cheapest thing missing: <what>.</div>
+         NOTHING ran at all → this verdict instead, verbatim (never drop, never pad):
+      <div class="no-proof"><span class="tag">NO PROOF</span>No proof exists: nothing was run to
          show this change works. A PR whose proof cannot be written had nothing to prove — that is
-         a finding about the PR, not this page.</div> -->
+         a finding about the PR, not this page.</div>
+         PR-body claims appear only attributed in prose ("PR body reports: …"), never as a rung. -->
   </div>
 
   <div class="chapter">


### PR DESCRIPTION
### What & why

Score the proof chapter on a 100-point ladder, so a reader can tell at a glance whether a change was *watched working* or merely compiled.

Every explainer ended the same way: one row of identical green pills where `cargo fmt, no diff` carried the same visual weight as the built binary answering a real request. On a typical page five of the seven chips said only that the code compiles and the tests we wrote pass — the weakest claim available, presented as the proof.

**Goals**
- the owner running it themselves scores 50; before/after on the real thing 25; a picture of it running 20; a reader-runnable replay 15 — tests are 5 and all the gates together are 2
- "all tests passed" tops out at 7 and can never clear the bar of 30 on its own
- rows nobody earned stay on the page, unlit, with their points, so the reader sees what was *not* done
- the agent can never write the top row — it arrives only through the new `--confirmed` argument

### The ladder, rendered

[Three states of PR #46's proof chapter](https://claude.ai/code/artifact/9d389756-1d65-49fb-864f-f8ff8dcb48a6) — as it shipped, the same evidence honestly scored at 17/100 with the under-bar banner, and what climbing gets you at 72/100. Specimen CSS is copied verbatim from the template.

### What changed

| File | Change |
|------|--------|
| `skills/pr-explain/SKILL.md` | the ladder and its bar; Phase 3 climbs it; Chapter 4 scores it and carries the evidence itself; `--confirmed` fills the top row |
| `templates/pr-explain-page.html` | `.score`, `.rung`, `.short-proof`, `.ba-label`; the flat chip row collapses into one 2-point rung |
| `schemas/evidence.schema.json` | `runtime[]` stops being bare path strings and becomes typed rows the ladder can score |
| `skills/make-pr/SKILL.md`, `skills/make-pr-lite/SKILL.md` | capture a run of the built artifact while the branch is still hot and built, instead of handing over only tests and gates |

Two rules changed shape rather than tightening:

- **Phase 3 is a climb, not a capture.** Drive the built artifact end to end, take before/after from a base worktree, screenshot what a person sees, write a deterministic replay, break it on purpose, measure the claim.
- **The visible-surface test stopped asking "does the diff touch a template."** It asks whether anything a person looks at comes out different. PR #46 excused its missing screenshot with "the page that renders it is untouched" while the board went from 48 rows to 3.

### The proof

- `PYTHONPATH=scripts uv run --project scripts python -m prompt_lint` → exit 0
- `uv run --project scripts pytest scripts/tests -q` → 47 passed
- `uv run --project installer pytest installer/tests -m "not e2e"` → 161 passed
- `./validate.sh` → catalog OK — 30 units, 8 packages, 2 bundles
- the tightened `runtime[]` contract, driven through the repo's own validator: a six-kind evidence file **validates**, and four weak shapes are **rejected** — the old bare-path array, a row claiming evidence with neither `path` nor `key_output` attached, an unknown `kind`, and a smuggled-in `points` field
- the ladder arithmetic gate this PR adds, run against the rendered artifact: printed 17 = lit rows 17, printed 72 = lit rows 72 (it caught a real mismatch — the climbed panel was labelled 62 while its rows added to 72)

Scored on its own ladder, this PR is **47 / 100** — under the bar's spirit if not its letter, and the rows it misses are the honest ones.

| | Row | |
|---|---|---|
| **20** | a picture of it running | the artifact is the changed template's CSS rendering the new markup |
| **10** | real output from the built artifact | the schema driven through the repo's own validator |
| **10** | proof it is load-bearing | four weak shapes perturbed and rejected, not just the good one accepted |
| **5** | the tests pass | 47 + 161 |
| **2** | the gates | prompt_lint, validate.sh |
| — | *the owner ran it* (50) | *unlit — you have not run this yourself* |
| — | *before and after on the real thing* (25) | *unlit — the artifact rescores a past page, it does not run this change on base vs head* |
| — | *a replay the reader can run* (15) | *unlit — no pinned one-liner* |
| — | *a number for the claim* (10) | *unlit — "tests + gates = 7" is a definition, not a measurement* |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpWujSPcoQkRwd1bc5ykxJ

