### PR TITLE
feat(skills): run /shipped on sonnet

### DIFF
--- a/skills/shipped/SKILL.md
+++ b/skills/shipped/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: shipped
 description: Use when PRs have merged and the plan records need catching up — ticks every merged-but-unrecorded PR row (✅ + PR link) in the central plan issue, its build-plan artifact, and any cross-referenced issue, or invokes /shipped.
+model: sonnet
 ---
 
 # Shipped


### PR DESCRIPTION
## What

One line of frontmatter: `model: sonnet` on `skills/shipped/SKILL.md`.

## Why

`/shipped` is bookkeeping only — tick a row, paste a PR link, pin the artifact marker. It authors no prose, merges nothing, and re-plans nothing (that is `/course-correct`). It does not need the session's model.

Claude Code skill frontmatter accepts a `model:` override (`haiku`, `sonnet`, `opus`, `fable`, a full ID, or `inherit`). The override is scoped to the turn the skill runs on, so this moves `/shipped` and nothing else in the caller's session.

## Proof

Throwaway probe skill against the installed CLI (2.1.222), session started with `--model opus`, reading `modelUsage` out of the result JSON:

| turn | frontmatter | model billed |
| --- | --- | --- |
| `/modelprobe` | `model: sonnet` | `claude-sonnet-5` |
| next turn, same live session | — | `claude-opus-5` |
| `/plainprobe` (control) | none | `claude-opus-5` |

So the override lands, and it reverts when the skill's turn ends.

`prompt_lint` exits 0 (it asserts required keys are present, and ignores extras) and `validate.sh` reports `catalog OK — 30 units, 8 packages, 2 bundles`. The installer stages `SKILL.md` verbatim, so no catalog change is needed.

## Caveats

- A `/shipped` run that spans more than one turn (you interject mid-run) continues on the session model from the second turn on.
- `claude --resume` on a session whose last turn was the skill starts back up on sonnet.
- `context: fork` + `model:` was the other option and is worse here — forked subagents do not carry the Artifact tool, and `/shipped` has to republish the build-plan artifact.

Worth watching the artifact diff on the next real run before treating the downgrade as settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012io8nCsUfYdCrx6eKnTtr6