### PR TITLE
feat(rules): one English rule for every output, adapted from ASD-STE100

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ that plan honest as PRs land.
 
 ## Language Rules
 
-Opinionated coding standards that load automatically when editing matching files — per-language conventions plus two cross-cutting rules (design and TDD).
+Opinionated coding standards that load automatically when editing matching files — per-language conventions plus three cross-cutting rules (design, TDD, and English).
 
 | Language | File | Target | Highlights |
 |----------|------|--------|------------|
@@ -136,12 +136,13 @@ Opinionated coding standards that load automatically when editing matching files
 
 ### Cross-cutting rules
 
-Two language-agnostic rules install alongside the language rules and load on broader globs:
+Three language-agnostic rules install alongside the language rules and load on broader globs:
 
 | Rule | File | Loads on | Covers |
 |------|------|----------|--------|
 | Design principles | `rules/design-principles.md` | any source file | deep modules, information hiding, naming, complexity (Ousterhout) |
 | TDD | `rules/tdd.md` | test files | red→green→refactor, vertical slices, public-interface tests |
+| English | `rules/english.md` | every file | one word one meaning, simple tenses, 20/25-word sentences, banned words, when a picture earns its place (ASD-STE100) |
 
 ### Installation
 

--- a/installer/catalog.toml
+++ b/installer/catalog.toml
@@ -110,6 +110,10 @@ name = "design-principles"
 
 [[units]]
 kind = "rule"
+name = "english"
+
+[[units]]
+kind = "rule"
 name = "python"
 
 [[units]]
@@ -133,6 +137,8 @@ name = "ruff-format"
 # extras = source-relative paths (files or dirs) to the runtime support files a
 # skill reads — schemas, gates, helper scripts — staged with the units so an
 # install is self-contained.
+# rule/english rides in every package on purpose. It governs the words every skill
+# emits, so a user who installs one package still gets the voice.
 [[packages]]
 name = "architect-pr"
 units = [
@@ -142,6 +148,7 @@ units = [
   "agent/reviewer",
   "agent/critic",
   "rule/design-principles",
+  "rule/english",
   "rule/tdd",
 ]
 extras = ["schemas", "gates", "scripts/validate_return.py", "rules"]
@@ -154,6 +161,7 @@ units = [
   "agent/reviewer",
   "agent/critic",
   "rule/design-principles",
+  "rule/english",
   "rule/tdd",
 ]
 extras = ["schemas", "gates", "scripts/validate_return.py", "rules"]
@@ -162,7 +170,7 @@ extras = ["schemas", "gates", "scripts/validate_return.py", "rules"]
 # rule, composed in via the rules extra rather than a bundled in-skill copy.
 [[packages]]
 name = "improve-architecture"
-units = ["skill/improve-architecture", "rule/design-principles"]
+units = ["skill/improve-architecture", "rule/design-principles", "rule/english"]
 extras = ["rules"]
 
 [[packages]]
@@ -173,6 +181,7 @@ units = [
   "skill/to-issues",
   "skill/pr-breakdown",
   "skill/course-correct",
+  "rule/english",
 ]
 
 # pr-breakdown publishes a PR-map artifact from the issue's PR table; its page skeleton
@@ -182,7 +191,7 @@ units = [
 # installed without it. The planning bundle pulls this in so the flagship path ships it.
 [[packages]]
 name = "pr-breakdown"
-units = ["skill/pr-breakdown"]
+units = ["skill/pr-breakdown", "rule/english"]
 extras = ["templates/pr-breakdown-map.html"]
 
 [[packages]]
@@ -194,6 +203,7 @@ units = [
   "skill/pr-make-till-merge",
   "skill/latest-rebase",
   "skill/shipped",
+  "rule/english",
 ]
 
 # pr-explain publishes a per-PR explainer page; its page skeleton ships as a package
@@ -202,7 +212,7 @@ units = [
 # the page skeleton; both degrade gracefully when absent.
 [[packages]]
 name = "pr-explain"
-units = ["skill/pr-explain"]
+units = ["skill/pr-explain", "rule/english"]
 extras = ["templates/pr-explain-page.html", "templates/pr-explain.vale.ini"]
 
 # dispatch fans a plan's ready PRs out into parallel tmux windows; the mechanics live in
@@ -211,7 +221,7 @@ extras = ["templates/pr-explain-page.html", "templates/pr-explain.vale.ini"]
 # that reads it.
 [[packages]]
 name = "dispatch"
-units = ["skill/dispatch"]
+units = ["skill/dispatch", "rule/english"]
 extras = ["scripts/dispatch"]
 
 # --- bundles (provisional) ---

--- a/rules/english.md
+++ b/rules/english.md
@@ -1,14 +1,13 @@
 ---
-paths: "**/*"
+paths: "**/*", "*"
 ---
 
 # English Rules
 
 Every word we emit: chat replies, artifact pages, PR bodies, issue text, commit messages,
 code comments, agent briefs, error strings. Adapted from ASD-STE100 Simplified Technical
-English (Issue 9), the controlled language the aerospace industry wrote so a technician
-cannot misread a maintenance instruction. Our reader sits in the same seat — no
-back-channel, no follow-up question. Write for one reading.
+English (Issue 9), the aerospace standard for instructions a technician cannot misread.
+Our reader has no back-channel either. Write for one reading.
 
 Two faults break one reading: a word with more than one meaning, and a sentence with more
 than one possible structure. Every rule below removes one of them.
@@ -16,7 +15,9 @@ than one possible structure. Every rule below removes one of them.
 ## Words
 
 - **One word, one meaning.** Give a concept one word and use that word everywhere. Never
-  use one word for two concepts. A `gate` is the CI check, and it is nothing else.
+  use one word for two concepts. A `slice` is the vertical unit of work, and nothing else.
+- **Concrete nouns.** Name the real thing. `functionality`, `capability`, and `solution`
+  name nothing.
 - **The commonest word wins.** `use`, not `utilize`. `about`, not `regarding`. `start`, not
   `initiate`. Take the short common word before the formal one.
 - **Approved terms are the names already in the tree** — `slice`, `unit`, `package`,
@@ -52,7 +53,8 @@ STE restricts verb forms, because a compound tense hides who acts and when.
 
 ## Sentences
 
-- **20 words** is the cap for an instruction. **25 words** is the cap for description.
+- **20 words** is the cap for an instruction — a sentence that tells someone to act.
+  **25 words** is the cap for every other sentence.
 - **One instruction per sentence.** Two actions are two sentences.
 - **Three words is the cap for a noun cluster.** "prompt lint check" reads. "prompt lint
   check failure report" is not a phrase, it is a puzzle.
@@ -83,8 +85,8 @@ A picture earns its place when it shows what prose must spell out slowly.
 | numbers carry the argument | |
 
 A picture shows the real mechanism, with the real names from the tree. A decorative
-diagram costs a read and returns nothing, so it is worse than no diagram. The
-`artifact-diagramming` and `dataviz` skills own how to draw one.
+diagram costs a read and returns nothing, so it is worse than no diagram. When the
+`artifact-diagramming` or `dataviz` skills are available, they own how to draw one.
 
 ## Where these rules stop
 

--- a/rules/english.md
+++ b/rules/english.md
@@ -1,0 +1,97 @@
+---
+paths: "**/*"
+---
+
+# English Rules
+
+Every word we emit: chat replies, artifact pages, PR bodies, issue text, commit messages,
+code comments, agent briefs, error strings. Adapted from ASD-STE100 Simplified Technical
+English (Issue 9), the controlled language the aerospace industry wrote so a technician
+cannot misread a maintenance instruction. Our reader sits in the same seat — no
+back-channel, no follow-up question. Write for one reading.
+
+Two faults break one reading: a word with more than one meaning, and a sentence with more
+than one possible structure. Every rule below removes one of them.
+
+## Words
+
+- **One word, one meaning.** Give a concept one word and use that word everywhere. Never
+  use one word for two concepts. A `gate` is the CI check, and it is nothing else.
+- **The commonest word wins.** `use`, not `utilize`. `about`, not `regarding`. `start`, not
+  `initiate`. Take the short common word before the formal one.
+- **Approved terms are the names already in the tree** — `slice`, `unit`, `package`,
+  `extra`, `hook`, `gate`, `artifact`. Use the tree's spelling. A new term earns its place
+  once, in plain words, then stays fixed.
+- **No synonym for variety.** Repeat the noun. A fresh word makes the reader ask whether
+  you mean a fresh thing.
+
+**Banned words:** leverage, robust, seamless, comprehensive, powerful, streamline, utilize,
+facilitate, ensure, delve, furthermore, moreover, "in order to", "it's worth noting",
+"game-changer", "not only… but also".
+
+**Banned moves:** the rhetorical question. The wind-up before the point. The summary that
+repeats what the reader just read. The apology. The adjective that carries no data — write
+"2× faster", not "significantly faster".
+
+## Grammar
+
+STE restricts verb forms, because a compound tense hides who acts and when.
+
+| Use | Do not use |
+|-----|-----------|
+| infinitive, imperative | present perfect — "we have added" |
+| simple present, simple past, simple future | past perfect, future perfect |
+| past participle **as an adjective** — "the staged copy" | continuous forms as verbs — "we are adding" |
+
+- **An `-ing` word is a noun or it is gone.** "the sizing rule" holds. "we are staging the
+  unit" does not — write "we stage the unit".
+- **Active voice in every instruction.** "The gate reads the diff", not "the diff is read".
+  Take passive voice only in description, and only when the actor is unknown.
+- **Drop no words.** Keep the article, the subject, the verb. STE says plainly that a cut
+  word buys length and pays in ambiguity.
+
+## Sentences
+
+- **20 words** is the cap for an instruction. **25 words** is the cap for description.
+- **One instruction per sentence.** Two actions are two sentences.
+- **Three words is the cap for a noun cluster.** "prompt lint check" reads. "prompt lint
+  check failure report" is not a phrase, it is a puzzle.
+- **The condition comes first:** "If the file is absent, skip the step."
+
+## Paragraphs, lists, and emphasis
+
+- **One topic per paragraph, six sentences at most.**
+- **A list carries a sequence, a set of conditions, or three or more parallel items.**
+  Nothing else. Two items are a sentence.
+- **Prose is the default.** An answer built only from bullets is an outline, not an
+  explanation, and the reader must rebuild every connection you dropped. Put bullets under
+  a sentence that says what they are.
+- **Emphasis is rare by definition.** Bold the term the reader will search for. Bold every
+  line and you emphasize nothing.
+- One em-dash aside per paragraph at most. No emoji in prose.
+
+## Pictures
+
+A picture earns its place when it shows what prose must spell out slowly.
+
+| Draw it | Write it |
+|---------|----------|
+| the thing has a shape — tree, graph, layout | it is one fact |
+| steps flow into each other | it is one comparison |
+| three or more things differ on two or more axes | the picture would restate the sentence |
+| before against after | you fill space |
+| numbers carry the argument | |
+
+A picture shows the real mechanism, with the real names from the tree. A decorative
+diagram costs a read and returns nothing, so it is worse than no diagram. The
+`artifact-diagramming` and `dataviz` skills own how to draw one.
+
+## Where these rules stop
+
+Quoted material, command output, code, test names, existing API and file names, and anyone
+else's words stay verbatim. Never rewrite a quote into STE.
+
+## Self-check
+
+Read the draft once against this file before you publish a page, a PR body, or an issue.
+Fix what it catches, then name the fixes in your report: which rule, which sentence.

--- a/skills/explain/SKILL.md
+++ b/skills/explain/SKILL.md
@@ -66,17 +66,14 @@ If the source is too thin for a real "why", say so and ask for one sentence of i
 
 ### The voice
 
-- Commonest words. If a code word is the only fit (symlink, hash, CI), say what it
-  does in plain words right after — once.
-- Short sentences. One idea each.
-- Active voice. "It checks the files," not "the files are checked."
-- Talk to the reader: "you", "your".
-- Concrete nouns. Name the real thing — not "functionality."
-- No wind-up. Start with the point.
+The `english` rule governs every word — it loads each session, so you already have it.
+Two additions this skill owns:
 
-**Banned words:** leverage, robust, seamless, comprehensive, powerful, streamline,
-utilize, facilitate, ensure, delve, furthermore, moreover, "in order to", "it's
-worth noting", "game-changer", "not only… but also".
+- If a code word is the only fit (symlink, hash, CI), say what it does in plain words
+  right after — once.
+- Talk to the reader: "you", "your".
+
+Read the draft against the rule before you print it, and fix what it catches.
 
 Under ~150 words. Plain paragraphs — no bullets or emoji. Print it in chat; post it
 to the PR or issue only if they ask.

--- a/skills/explain/SKILL.md
+++ b/skills/explain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: explain
-description: Use when the user wants a dead-simple, plain-words explanation of a slice or a PR — why we need it, what it is, what changes — or invokes /explain.
+description: Use when the user wants a dead-simple, plain-words explanation of a slice or a PR. It answers why we need it, what it is, and what changes. Also use when the user invokes /explain.
 ---
 
 # Explain
@@ -28,8 +28,8 @@ Resolve `<id>` in this order:
    `gh pr view --json title,body`).
 2. **`#92` or `PR 92`** → a GitHub PR. `gh pr view 92 --json title,body,files`;
    take the "why" from its body (no such PR → ask). Go to Phase 3.
-3. **A bare or dotted number** → open the plan issue (`gh issue view <N> --json body`)
-   and match the id *whole* against both tables; the table it sits in decides — **PR
+3. **A bare or dotted number** → open the plan issue (`gh issue view <N> --json body`).
+   Match the id *whole* against both tables. The table it sits in decides: **PR
    breakdown** → PR row, **slice** table → slice (including a hand-inserted `4.5`).
    Whole-cell, so `4.2` ≠ `14.2`.
 4. **No single match** → a whole number may be a GitHub PR; confirm "Did you mean PR

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -213,7 +213,7 @@ Draft the prose in a scratch buffer under these rules:
    ladder row, captured output. "Faster", "safer", "fixed" each arrive with a number or output.
 3. **Concrete before abstract.** The failing command, the error, or the real line comes before
    any statement about it. Examples are trimmed from the actual diff, never invented.
-4. **The `english` rule holds on every line** — its word caps, its banned list, its
+4. **The `english` rule governs every line** — its word caps, its banned list, its
    anti-overuse clauses. Data over adjectives.
 5. **One name per concept — the name from the code.** Present tense for the new behavior; past
    tense only for what it replaced.
@@ -317,7 +317,7 @@ The draft leaves Phase 4 only after both gates. Run them in order:
     present and the ⚠ is in the teaser. A lit row with no command or artifact behind it: unlight
     it and re-score.
   - *Prose*: `wc -w` each budgeted unit and cut anything over. `grep` the draft for every
-    banned word — the `english` rule's list plus the five above — and rewrite each hit. Then
+    banned word — the `english` rule's list plus the six above — and rewrite each hit. Then
     read the draft once against the rule and fix what it catches. **If `vale` is on PATH**, write the draft
     to a scratch `.md` and run `vale --config ~/.claude/at/templates/pr-explain.vale.ini
     <draft>.md` (run `vale --config … sync` once first if `StylesPath` is empty), rewriting

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-explain
-description: Use when the user invokes /pr-explain or wants a reader-facing explainer page for a pull request — a plain-words page with five chapters (what & why, a walkthrough of the whole diff, every test enumerated, a scored proof, and confirm commands run with their real output), published as a private claude.ai artifact with a teaser in the PR body.
+description: Use when the user invokes /pr-explain or wants a reader-facing explainer page for a pull request. It is a plain-words page with five chapters. They are: what & why, a walkthrough of the whole diff, every test enumerated, a scored proof, and confirm commands run with their real output. It is published as a private claude.ai artifact with a teaser in the PR body.
 argument-hint: "[#N | PR URL | blank = current branch's PR] [--confirmed \"<what you saw>\"]"
 ---
 
@@ -20,8 +20,8 @@ Three rules run through the whole page:
 - **The whole diff.** Every change in the PR is either shown and explained or named in a
   roll-up line. A reader who finishes the walkthrough has seen the change — never two
   excerpts from a hundred-line diff.
-- **Proof is scored, not asserted.** Output on the page is output you captured, and every
-  piece of it sits on the ladder below carrying its points — so a reader sees at a glance
+- **Proof is scored, not asserted.** Output on the page is output you captured. Every
+  piece of it sits on the ladder below, carrying its points. A reader sees at a glance
   whether this change was watched working or merely compiled. "All tests passed" is the
   weakest sentence on the page, never the proof.
 
@@ -51,11 +51,11 @@ Three rules run through the whole page:
 
 ## The page — five chapters
 
-The shape follows what the big open-source repos converged on for PR descriptions —
-Kubernetes ("what this PR does / why we need it"), Google's CL guide (a standalone
-imperative first line), React ("the exact commands you ran and their output") — retold in
-plain words. Each chapter answers one question. A budget is a ceiling, not a target; drop
-an empty chapter, never pad it.
+The shape follows what the big open-source repos converged on for PR descriptions,
+retold in plain words. Kubernetes gives "what this PR does / why we need it", Google's
+CL guide a standalone imperative first line, React "the exact commands you ran and
+their output". Each chapter answers one question. A budget is a ceiling, not a target;
+drop an empty chapter, never pad it.
 
 | # | Chapter | The question it answers | Budget |
 |---|---------|-------------------------|--------|
@@ -69,8 +69,8 @@ Prose scales with the diff: chapters 1, 4, and 5 keep fixed budgets; the walkthr
 one note per hunk and the test list one line per test. Code, diffs, trees, command blocks,
 captured output, and test names never count as prose. Each diff or command block caps at
 12 lines — trim to the lines that carry the decision. A tiny PR with no behavior (docs, a
-version bump, one-line config) shrinks to Chapter 1, a one-line tree, and Chapter 5 — no
-forced tests or proof; log the shrink and its reason in the report.
+version bump, one-line config) shrinks to Chapter 1, a one-line tree, and Chapter 5.
+Force no tests or proof there; log the shrink and its reason in the report.
 
 ## The proof ladder
 
@@ -111,19 +111,20 @@ may not be the one you were asked about. `--json files` gives every touched path
 `additions`/`deletions`; that list builds the Chapter 2 tree.
 
 - **The why (Chapter 1)**: read the issue or PRD the PR body references (`Closes #N` /
-  `Refs #N`; prefer `Closes`, first match) with `gh issue view <N> --json title,body` (this
-  repo needs `--json`, a bare `gh issue view` errors on classic project cards). The reason
+  `Refs #N`; prefer `Closes`, first match). Use `gh issue view <N> --json title,body` —
+  this repo needs `--json`, and a bare `gh issue view` errors on classic project cards. The reason
   comes from there — the slice/PR row the body names, else the issue's headline problem — not
   from the diff. Nothing referenced → derive it from the PR body and diff, and say so on the
   page.
 - **Evidence (Chapters 3-4)**: slug the head branch (`/` and whitespace → `_`) and read
   `<target_repo>/.v1-runs/evidence/<slug>/evidence.json` — the make-pr / make-pr-lite handoff.
-  It carries `behaviors[]` (each with a RED and a GREEN witness), `gates[]` (real gate numbers
-  from the run), and `runtime[]` — the ladder rows the pipeline already captured, each with its
-  `kind`, the `cmd` behind it, and a `path` into that dir or verbatim `key_output`. Chapters 3
-  and 4 quote it verbatim: the RED witness carries the failure reason, the GREEN witness what
-  made it pass plus `+<lines_added>`, the gates collapse into the ladder's one 2-point row, and
-  each `runtime[]` entry scores its own row. **Never invent evidence.** Rows the handoff does
+  It carries `behaviors[]` (each with a RED and a GREEN witness) and `gates[]` (real gate
+  numbers from the run). It also carries `runtime[]`, the ladder rows the pipeline
+  already captured. Each one has its `kind`, the `cmd` behind it, and a `path` into that
+  dir or verbatim `key_output`. Chapters 3 and 4 quote it verbatim. The RED witness carries the
+  failure reason, the GREEN witness what made it pass plus `+<lines_added>`. The gates
+  collapse into the ladder's one 2-point row, and each `runtime[]` entry scores its own
+  row. **Never invent evidence.** Rows the handoff does
   not carry are rows Phase 3 climbs itself, or leaves unlit.
 
 ## Phase 2 — Understand (before writing a word)
@@ -134,8 +135,8 @@ may not be the one you were asked about. `--json files` gives every touched path
    `__tests__`, `.test.`, `.spec.`, or lives under `tests/`). Production files drive Chapter 2;
    test files drive Chapter 3.
 3. **Take the hunk inventory.** List every hunk in `gh pr diff` (each `@@` block). Classify
-   each: a **decision** hunk changes behavior, an interface, or logic — anything you would
-   pause on while pair-programming; a **mechanical** hunk is imports, re-exports, wiring,
+   each. A **decision** hunk changes behavior, an interface, or logic — anything you would
+   pause on while pair-programming. A **mechanical** hunk is imports, re-exports, wiring,
    formatting, renames, lockfiles. Every decision hunk becomes a walkthrough entry with its
    own diff lines and note. Mechanical hunks roll up into one named line per file ("plus the
    import and route registration"). Shown or named — those are the only two options; a hunk
@@ -146,7 +147,7 @@ may not be the one you were asked about. `--json files` gives every touched path
 5. **Take the test inventory.** For every test file in the diff, list each added or changed
    test by its name in the code. Each becomes one Chapter 3 line.
 6. **Build the tree** (Chapter 2): the touched subtree only. Group touched files under their
-   folders; show a touched file with a `●`, its name in bold, and `+adds −dels`; mark test
+   folders. Show a touched file with a `●`, its name in bold, and `+adds −dels`. Mark test
    files with a `test` tag and give them no callout. Add a couple of untouched siblings, dimmed
    with `·`, only when they help the reader place the change — do not print the whole folder.
    Cap the tree around 20 rows.
@@ -155,18 +156,18 @@ may not be the one you were asked about. `--json files` gives every touched path
    contain a touched file. Same strip, same order, every PR — it orients the reader in the
    whole repo without printing it.
 8. **Spot what a person sees.** Not "does the diff touch a template" — *after this merges,
-   does anything a human looks at come out different?* A page, a TUI, a chart, an email body,
-   the shape of a CLI's output, or a rendered view of data this PR changes even when the
-   rendering file is untouched: a board that now lists 3 rows where it listed 48 has changed
-   visibly, and "the page is untouched" is no excuse. Yes → Chapter 4 owes a screenshot of it
+   does anything a human looks at come out different?* Candidates: a page, a TUI, a chart,
+   an email body, the shape of a CLI's output, or a rendered view of data this PR changes.
+   That holds even when the rendering file is untouched. A board that now lists 3 rows where
+   it listed 48 has changed visibly, and "the page is untouched" is no excuse. Yes → Chapter 4 owes a screenshot of it
    running on this branch, and the before/after pair is there for the taking. Plan now how
    Phase 3 captures both.
 
 ## Phase 3 — Run (climb the ladder)
 
 Before writing, run the change. Everything here executes in the target repo, on the PR's
-head; capture output verbatim for Chapters 4 and 5. Get the artifact running first — four of
-the rows below reuse that one instance — then work down them until the score clears 30, and
+head; capture output verbatim for Chapters 4 and 5. Get the artifact running first, because
+four of the rows below reuse that one instance. Then work down them until the score clears 30, and
 take every row still cheap to reach after that.
 
 - **Drive the built artifact end to end** (10). Build it, boot it, and put a real request
@@ -184,7 +185,7 @@ take every row still cheap to reach after that.
   prove the server answered; only a picture proves a person sees it. Genuinely cannot launch
   it here → a gap Chapter 4 declares, never a step to skip.
 - **Write the replay** (15). Fold the end-to-end run into one command anyone can paste — a
-  `docker run` on a pinned image, or a script committed in the repo — and run it once from
+  `docker run` on a pinned image, or a script committed in the repo. Run it once from
   clean to confirm it reproduces. Deterministic or it does not score: pin the image, seed
   fixed data, and keep clocks, ports, and paths out of the compared output.
 - **Break it on purpose** (10). `git checkout <base> -- <the production file>`, re-run the one
@@ -229,7 +230,7 @@ Three moves, in order, nothing else:
   the PR by this line.
 - **One or two sentences of why** — what was missing or broken, and why now. From the issue
   or PRD, not the diff.
-- **Goals** — two to four short bullets, each an outcome that is true after merge and
+- **Goals** — two to four short bullets. Each is an outcome that is true after merge and
   checkable on this page (by a walkthrough hunk, a test line, or a run).
 
 Example shape (not words to copy):
@@ -256,7 +257,7 @@ per-file callouts stay — they are the index; the hunks are the walkthrough.
 ### Chapter 3 — The tests
 
 Enumerate, then witness. First the list: every test from the inventory, grouped under its
-file, one line each — the test's name from the code plus ≤ 14 plain words of what it checks.
+file, one line each. A line is the test's name from the code plus ≤ 14 plain words of what it checks.
 No test in the diff is left off the list. Then the RED → GREEN story from the witnesses,
 verbatim from the evidence file. No evidence file → the list stands alone and the page says
 the witnesses are absent.
@@ -265,32 +266,32 @@ the witnesses are absent.
 
 Score the ladder, then show the evidence — **the evidence itself, in this chapter**. Chapter 5
 is what the *reader* can paste; Chapter 4 is what *ran*, and a sentence reporting that a run
-happened is not that run. So the strong rows carry their artifact here: the screenshot embeds,
+happened is not that run. So the strong rows carry their artifact here. The screenshot embeds,
 the before/after prints as two labelled blocks, and the replay prints as the one command with
-the output it produced here — Chapter 5 then points back at it rather than printing it twice.
+the output it produced. Chapter 5 then points back at it rather than printing it twice.
 
 Open with the score (`the proof — 62 / 100`). Then one `.rung` per ladder row, in ladder
 order, each earned row carrying its real number and the command behind it. **Rows you did not
-earn stay on the page, unlit, with their points** — an unlit "before and after · 25" tells the
+earn stay on the page, unlit, with their points.** An unlit "before and after · 25" tells the
 reader what was not done, which is the whole reason the ladder is visible. The gates collapse
 into their single 2-point row, chips and all; a red CI check chips `fail`. Numbers claimed
 only in the PR body appear attributed in prose ("PR body reports: pytest 161 passed"), never
 as a scored row.
 
 **The bar is hard.** Under 30 on a PR with behavior → the chapter opens with the
-`.short-proof` banner naming the score and the cheapest unlit row, and a ⚠ carries into the
+`.short-proof` banner, naming the score and the cheapest unlit row. A ⚠ carries into the
 teaser and the report. Nothing ran at all → the `.no-proof` verdict instead, verbatim: *"No
 proof exists: nothing was run to show this change works. A PR whose proof cannot be written
 had nothing to prove — that is a finding about the PR, not this page."* Never light a row you
 did not earn: a page that scores 7 honestly is worth more than one that lies to clear 30.
 
-**The top row is yours alone.** The owner row renders on every page — unlit and explicit ("you
-have not run this yourself yet") unless this run was given `--confirmed`, in which case it
-carries the quoted words and today's date. Never fill it from a PR comment, a review approval,
+**The top row is yours alone.** The owner row renders on every page. It is unlit and explicit
+("you have not run this yourself yet") unless this run was given `--confirmed`. Given that
+flag, it carries the quoted words and today's date. Never fill it from a PR comment, a review approval,
 or something said in chat.
 
 **A visible change needs a picture.** Phase 2 spotted a visible surface → at least one Phase 3
-screenshot of it running embeds here (`img.evidence`, `data:` URI), each with a one-line
+screenshot of it running embeds here (`img.evidence`, `data:` URI). Each carries a one-line
 `.evidence-cap` caption naming what the reader is looking at. Rows about the surface — curl
 status, byte counts, grep hits — do not substitute. No screenshot → the chapter says which
 surface shipped unseen and why, and the same ⚠ carries into the teaser and the report.
@@ -351,16 +352,16 @@ The draft leaves Phase 4 only after both gates. Run them in order:
   `.note` classes exactly as the SLOT comment shows; indent rows with `l1`/`l2`/`l3`. A callout
   is a `.note` row directly under its file.
 - **The walkthrough**: one `.hunk-head` + `.diff` + `.diff-note` group per decision hunk;
-  roll-ups are a `.diff-note` alone. Diff lines read like an editor: every token wears its
-  syntax color (`tok-kw`, `tok-fn`, `tok-str`, `tok-num`, `tok-type`, `tok-com`), added and
+  roll-ups are a `.diff-note` alone. Diff lines read like an editor. Every token wears its
+  syntax color (`tok-kw`, `tok-fn`, `tok-str`, `tok-num`, `tok-type`, `tok-com`). Added and
   deleted lines open with a `.sign` `+`/`−`, and the red/green lives in the line background
   and sign — never in the code text.
 - **The test list**: `.testlist` with a `.tfile` row per file and a `.trow` per test.
-- **The ladder**: `.score` with the total and its `.bar`, then one `.rung` per row — earned
+- **The ladder**: `.score` with the total and its `.bar`, then one `.rung` per row. Earned
   rows carry `.pts`, `.what`, and a `.how` naming the command; unearned rows carry the same
-  three with `class="rung unlit"`. Evidence hangs under the row it scores: the screenshot as
-  `img.evidence` + `.evidence-cap`, the before/after as two `.cmd` blocks each opened by a
-  `.ba-label`, the replay and the run output as one `.cmd` block each.
+  three with `class="rung unlit"`. Evidence hangs under the row it scores. The screenshot goes
+  as `img.evidence` + `.evidence-cap`. The before/after goes as two `.cmd` blocks each opened
+  by a `.ba-label`. The replay and the run output go as one `.cmd` block each.
 - **Staleness check, on the built file, before Phase 6.** An installed template that lags the
   repo drops whole rule sets silently — the page still validates, and only these greps catch it.
   A stale template is never hand-patched: rebuild from the repo's
@@ -419,12 +420,17 @@ explainer`.
 
 ## Report
 
-End with: the artifact URL; hunks shown / rolled up / total; tests enumerated; commands run
-vs marked not-run; **the proof score out of 100, the rows you lit, and the cheapest unlit row
-with what it would have taken** (plus the ⚠ flag when under the bar or nothing ran);
-screenshots embedded, or the visible surface that shipped unseen and why (⚠); chapters
-emitted vs dropped (with the tiny-PR shrink reason if used); the PR whose teaser you
-updated; the mechanical gate result (coverage greps, Vale alerts fixed, or "vale
-unavailable — wc + grep only"); the staleness check (tokens and ladder present, or the stale
-template you rebuilt from); and the critic score — naming any dimension left under the bar when
-the page shipped flagged.
+End with one line each:
+
+- The artifact URL.
+- Hunks shown / rolled up / total, and tests enumerated.
+- Commands run vs marked not-run.
+- **The proof score out of 100, the rows you lit, and the cheapest unlit row with what it
+  would have taken.** Add the ⚠ flag when under the bar or nothing ran.
+- Screenshots embedded, or the visible surface that shipped unseen and why (⚠).
+- Chapters emitted vs dropped, with the tiny-PR shrink reason if used.
+- The PR whose teaser you updated.
+- The mechanical gate result: coverage greps, Vale alerts fixed, or "vale unavailable —
+  wc + grep only".
+- The staleness check: tokens and ladder present, or the stale template you rebuilt from.
+- The critic score, naming any dimension left under the bar when the page shipped flagged.

--- a/skills/pr-explain/SKILL.md
+++ b/skills/pr-explain/SKILL.md
@@ -13,10 +13,10 @@ does that. They want to *understand the whole change*, not a sampler of it.
 
 Three rules run through the whole page:
 
-- **Plain words.** Say it the way you would to a smart friend who has not seen the code.
-  If a code word is the only word that fits (`hash`, `symlink`, `CI`), say what it does in
-  plain words right after — once. Short sentences, one idea each. Active voice. Talk to the
-  reader: "you", "your". Start with the point; no wind-up.
+- **Plain words.** The `english` rule governs every word on the page — it loads each
+  session, so you already have it. Say it the way you would to a smart friend who has not
+  seen the code. If a code word is the only word that fits (`hash`, `symlink`, `CI`), say
+  what it does in plain words right after — once. Talk to the reader: "you", "your".
 - **The whole diff.** Every change in the PR is either shown and explained or named in a
   roll-up line. A reader who finishes the walkthrough has seen the change — never two
   excerpts from a hundred-line diff.
@@ -213,14 +213,13 @@ Draft the prose in a scratch buffer under these rules:
    ladder row, captured output. "Faster", "safer", "fixed" each arrive with a number or output.
 3. **Concrete before abstract.** The failing command, the error, or the real line comes before
    any statement about it. Examples are trimmed from the actual diff, never invented.
-4. **Plain words, ≤ 25-word sentences, one idea per sentence, data over adjectives.**
+4. **The `english` rule holds on every line** — its word caps, its banned list, its
+   anti-overuse clauses. Data over adjectives.
 5. **One name per concept — the name from the code.** Present tense for the new behavior; past
    tense only for what it replaced.
 
-Banned on sight: leverages, robust, seamless, comprehensive, delve, streamlined, powerful,
-simply, utilize, facilitate, ensures, significantly, various, clearly, essentially, furthermore,
-moreover, "in order to", "it's worth noting", "not only… but also", and "should" when you mean
-what the code *does*.
+Banned here on top of the rule's list: simply, significantly, various, clearly, essentially,
+and "should" when you mean what the code *does*.
 
 ### Chapter 1 — What & why
 
@@ -318,7 +317,8 @@ The draft leaves Phase 4 only after both gates. Run them in order:
     present and the ⚠ is in the teaser. A lit row with no command or artifact behind it: unlight
     it and re-score.
   - *Prose*: `wc -w` each budgeted unit and cut anything over. `grep` the draft for every
-    banned word above and rewrite each hit. Then, **if `vale` is on PATH**, write the draft
+    banned word — the `english` rule's list plus the five above — and rewrite each hit. Then
+    read the draft once against the rule and fix what it catches. **If `vale` is on PATH**, write the draft
     to a scratch `.md` and run `vale --config ~/.claude/at/templates/pr-explain.vale.ini
     <draft>.md` (run `vale --config … sync` once first if `StylesPath` is empty), rewriting
     every alert. `vale` absent or `sync` can't reach the registry → degrade to the `wc` +

--- a/skills/to-prd/SKILL.md
+++ b/skills/to-prd/SKILL.md
@@ -74,8 +74,8 @@ Show the draft in chat. Wait for an OK or edits. **Don't publish until approved.
 
 ## Phase 5 — Publish
 
-Write the approved body to a temp file (dodges shell-escaping), drop an unknown
-label so the create can't fail on it, then print one parseable line:
+Write the approved body to a temp file, which dodges shell-escaping. Drop an unknown
+label so the create can't fail on it. Then print one parseable line:
 
 ```bash
 TITLE="..."; LABEL="${LABEL-Plan}"; BODY=$(mktemp)

--- a/skills/to-prd/SKILL.md
+++ b/skills/to-prd/SKILL.md
@@ -41,7 +41,7 @@ a time, concrete options) — otherwise skip when context is rich.
 **Write it tight:**
 
 - One screen. Cut anything that doesn't change a decision.
-- The `english` rule holds on every line — it loads each session, so you already have it. Cut all hedging.
+- The `english` rule governs every line — it loads each session, so you already have it. Cut all hedging.
 - Tables and bullets over paragraphs. A PRD is scanned, not read: this is the one document where a list beats prose.
 - Only what was discussed or confirmed — invent nothing.
 - No file paths or code; they rot. Rare exception: a tiny snippet that nails a decision — a type, a schema.

--- a/skills/to-prd/SKILL.md
+++ b/skills/to-prd/SKILL.md
@@ -41,9 +41,8 @@ a time, concrete options) — otherwise skip when context is rich.
 **Write it tight:**
 
 - One screen. Cut anything that doesn't change a decision.
-- Plain English, no filler. Ban "robust", "seamless", "leverage", "comprehensive", "powerful" — and all hedging.
-- Short declarative sentences. Concrete nouns. Say the thing.
-- Tables and bullets over paragraphs.
+- The `english` rule holds on every line — it loads each session, so you already have it. Cut all hedging.
+- Tables and bullets over paragraphs. A PRD is scanned, not read: this is the one document where a list beats prose.
 - Only what was discussed or confirmed — invent nothing.
 - No file paths or code; they rot. Rare exception: a tiny snippet that nails a decision — a type, a schema.
 


### PR DESCRIPTION
## What this does

Adds `rules/english.md` — one canonical writing rule that loads every session and governs every word the skill box emits: chat replies, artifact pages, PR bodies, issue text, commit messages, code comments, agent briefs.

## Why

The voice guidance already existed, in three places at once. `skills/explain` and `skills/pr-explain` each carried a near-identical banned-word list and its own "short sentences, active voice" block, and `to-prd` carried a third variant. Every other skill carried nothing. One decision encoded three times, unenforced everywhere else — the information-leakage red flag from our own `design-principles.md`.

## The rule

Adapted from [ASD-STE100 Simplified Technical English](https://www.asd-ste100.org/) (Issue 9), the controlled language the aerospace industry wrote so a technician cannot misread a maintenance instruction. Full STE discipline:

| Section | Holds |
|---------|-------|
| Words | one word one meaning; concrete nouns; the commonest word wins; approved terms are the names already in the tree; banned words; banned moves |
| Grammar | simple tenses only — no present perfect, no past perfect; `-ing` as a noun or gone; active voice in every instruction; drop no words |
| Sentences | 20-word cap for instructions, 25 for everything else; one instruction per sentence; 3-word noun clusters; condition first |
| Paragraphs | one topic, six sentences at most; a list needs a sequence or 3+ parallel items; prose is the default; emphasis is rare |
| Pictures | an earns-its-place ladder — draw it when the thing has a shape, write it when the picture would restate the sentence |

It installs on `paths: "**/*", "*"`, which is what makes it reach *every* output rather than only the files a language rule matches.

## What changed in the skills

`explain`, `pr-explain`, and `to-prd` drop their duplicated voice blocks and point at the rule, keeping only what each adds on top — `explain` keeps "explain a code word once" and second-person address, `pr-explain` keeps its six extra banned words, `to-prd` keeps its documented exception that a PRD is scanned so lists beat prose there. Each also gains the self-check step: read the draft against the rule before publishing.

## The rule holds on the files that ship it

The first version of this PR was violated 34 times by the files it touched, which is how a rule gets ignored. Every one is now fixed — sentences split, never reworded for style:

| File | Over cap before | After |
|------|-----------------|-------|
| `rules/english.md` | 0 | 0 |
| `skills/pr-explain/SKILL.md` | 23 | 0 |
| `skills/explain/SKILL.md` | 2 | 0 |
| `skills/to-prd/SKILL.md` | 1 | 0 |

The 117-word semicolon run in pr-explain's Report section became the vertical list the rule asks for. Three skill descriptions split into two or three sentences, keeping every trigger word the matcher needs.

Verified prose-only two ways. Every code span, path, flag, and CSS class is byte-identical to before, checked by diffing the sorted multiset of backticked tokens per file. The only words that leave the tree are four verb-form changes where the concept stays: `marked`→`Mark`, `resumed`→`resume`, `forced`→`Force`, and "in which case"→"Given that flag".

## Catalog

`rule/english` rides in all eight packages on purpose. Installing any one package still gets the voice.

## Checks run

```
English check (caps + banned)   ALL PASS — 4 files, 0 over cap, 0 banned
./validate.sh                   catalog OK — 30 units, 8 packages, 2 bundles
python -m prompt_lint ..        exit 0
installer: pytest -q            182 passed
scripts:   pytest -q            47 passed
fenced bash blocks              all parse
```

## Follow-ups, not in this PR

- Promote the sentence-cap/banned-word checker from a throwaway script into a `prompt_lint` check, so CI holds the line and the other 13 prompt files get covered.
- A shared `templates/english.vale.ini` with custom STE styles, promoted from the pr-explain-only config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Aj4m5cGzjF8jBikJQ9v8r
