### PR TITLE
fix(installer): register to-dd in the catalog

### DIFF
--- a/installer/catalog.toml
+++ b/installer/catalog.toml
@@ -72,6 +72,10 @@ name = "shipped"
 
 [[units]]
 kind = "skill"
+name = "to-dd"
+
+[[units]]
+kind = "skill"
 name = "to-issues"
 
 [[units]]
@@ -178,6 +182,7 @@ name = "breakdown"
 units = [
   "skill/breakdown",
   "skill/to-prd",
+  "skill/to-dd",
   "skill/to-issues",
   "skill/pr-breakdown",
   "skill/course-correct",
@@ -193,6 +198,15 @@ units = [
 name = "pr-breakdown"
 units = ["skill/pr-breakdown", "rule/english"]
 extras = ["templates/pr-breakdown-map.html"]
+
+# to-dd fills a design-doc page from the conversation; its skeleton ships as a package
+# extra so an install is self-contained. A dedicated single-skill package carries the
+# extra (like pr-breakdown and pr-explain) so the multi-skill breakdown package above
+# stays extra-free; the skill falls back to the repo copy when installed without it.
+[[packages]]
+name = "to-dd"
+units = ["skill/to-dd", "rule/english"]
+extras = ["templates/design-doc.html"]
 
 [[packages]]
 name = "pr-ops"
@@ -231,4 +245,4 @@ packages = ["architect-pr", "lite-pr"]
 
 [[bundles]]
 name = "planning"
-packages = ["breakdown", "pr-breakdown"]
+packages = ["breakdown", "to-dd", "pr-breakdown"]


### PR DESCRIPTION
`skills/to-dd` landed with #173 but never got a `[[units]]` row, so it was not
installable and — since the prompt-lint gate arrived — `main` has been red and
every PR opened against it inherits the failure.

It follows the shape its two siblings already use: the unit row, membership in
the `breakdown` package beside `to-prd`/`to-issues`, and a dedicated single-skill
package carrying `templates/design-doc.html` as an extra so the multi-skill
package stays extra-free (the pattern `pr-breakdown` and `pr-explain` set). The
`planning` bundle pulls it in so the flagship path ships it.

`main` is currently red on `prompt-lint` (`skills/to-dd: no [[units]] row in installer/catalog.toml`) — the last two runs on main failed, and PR #193 inherits it. This unblocks both.

Verified: `prompt_lint` exits 0, `./validate.sh` and `at validate` report catalog OK — 31 units, 9 packages, 2 bundles, installer 182 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqEKDtKAb2BVTJVNZt1Z1U